### PR TITLE
Shows days in duration strings; try out JS testing

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,6 +32,11 @@ jobs:
           cache-dependency-path: |
             poetry.lock
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       # Cache the project venv (created by Poetry in-project)
       - name: Cache .venv
         uses: actions/cache@v4

--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,15 @@ check-types: $(REQ)
 pytest: $(REQ)
 	make pylint
 	$(PYTHON) -m pytest . -v --cov=. --cov-report=xml --cov-report=html --log-cli-level=DEBUG --log-file-level=DEBUG
-	@echo covreage report in htmlcov/
-test: pytest
+	@echo coverage report in htmlcov/
+test-js:
+	@echo "Running JavaScript unit tests..."
+	node tests/test_time_utils.js
+test: $(REQ)
+	@python_exit=0; js_exit=0; \
+	make pytest || python_exit=$$?; \
+	make test-js || js_exit=$$?; \
+	exit $$(($$python_exit + $$js_exit))
 
 ################################################################
 ## Every minutes

--- a/app/static/time_utils.js
+++ b/app/static/time_utils.js
@@ -1,0 +1,28 @@
+// Time utility functions for formatting and displaying time-related values
+// [TODO] Move more time-related utility functions here soon (e.g., formatTimestamp, etc.)
+
+// Format time duration from seconds to human-readable string
+function formatDuration(seconds) {
+  if (seconds === null) return 'Active';
+
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  const parts = [];
+  if (days > 0) {
+    parts.push(days + 'd');
+  }
+  if (days > 0 || hours > 0) {
+    parts.push(hours + 'h');
+  }
+  parts.push(minutes + 'm');
+
+  return parts.join(' ');
+}
+
+// Export for Node.js testing if in Node environment
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { formatDuration };
+}
+

--- a/app/templates/alerts.html
+++ b/app/templates/alerts.html
@@ -3,6 +3,7 @@
 {% block head %}
 <link href="https://unpkg.com/tabulator-tables@5.5.2/dist/css/tabulator.min.css" rel="stylesheet">
 <script src="https://unpkg.com/tabulator-tables@5.5.2/dist/js/tabulator.min.js"></script>
+<script src="{{ url_for('static', filename='time_utils.js') }}"></script>
 {% endblock %}
 
 {% block body %}
@@ -89,19 +90,7 @@ document.getElementById('device-filter').addEventListener('change', function() {
   historyTable.setData('/api/v1/alerts/history' + (deviceId ? '?device_id=' + deviceId : ''));
 });
 
-// Format time duration
-function formatDuration(seconds) {
-  if (seconds === null) return 'Active';
-
-  const hours = Math.floor(seconds / 3600);
-  const minutes = Math.floor((seconds % 3600) / 60);
-
-  if (hours > 0) {
-    return hours + 'h ' + minutes + 'm';
-  } else {
-    return minutes + 'm';
-  }
-}
+// formatDuration is now loaded from time_utils.js (start of trying non-playwright testing)
 
 // Format timestamp
 function formatTimestamp(timestamp) {

--- a/tests/test_time_utils.js
+++ b/tests/test_time_utils.js
@@ -1,0 +1,49 @@
+/**
+ * Simple Node.js tests for time utility functions
+ * Run with: node tests/test_time_utils.js
+ */
+const { formatDuration } = require('../app/static/time_utils.js');
+
+// Test cases: [seconds, expected_format]
+const testCases = [
+    [null, "Active"],  // null should return "Active"
+    [0, "0m"],  // 0 seconds = 0 minutes
+    [30, "0m"],  // 30 seconds = 0 minutes (rounded down)
+    [60, "1m"],  // 1 minute
+    [90, "1m"],  // 1.5 minutes = 1 minute (rounded down)
+    [3599, "59m"],  // 59 minutes 59 seconds = 59 minutes
+    [3600, "1h 0m"],  // 1 hour = 1h 0m
+    [3660, "1h 1m"],  // 1 hour 1 minute = 1h 1m
+    [7200, "2h 0m"],  // 2 hours = 2h 0m
+    [9000, "2h 30m"],  // 2.5 hours = 2h 30m
+    [86400, "1d 0h 0m"],  // 1 day = 1d 0h 0m
+    [864480, "10d 0h 8m"],  // 10 days 8 minutes = 10d 0h 8m (user's example)
+    [90000, "1d 1h 0m"],  // 1 day 1 hour = 1d 1h 0m
+    [893280, "10d 8h 8m"],  // 10 days 8 hours 8 minutes (248h 8m in old format)
+    [172800, "2d 0h 0m"],  // 2 days = 2d 0h 0m
+    [259200, "3d 0h 0m"],  // 3 days = 3d 0h 0m
+    [604800, "7d 0h 0m"],  // 7 days = 7d 0h 0m
+    [691200, "8d 0h 0m"],  // 8 days = 8d 0h 0m
+    [259380, "3d 0h 3m"],  // 3 days 3 minutes = 3d 0h 3m
+    [43200, "12h 0m"],  // 12 hours = 12h 0m (no days)
+];
+
+let passed = 0;
+let failed = 0;
+
+console.log('Testing formatDuration function...\n');
+
+testCases.forEach(([seconds, expected]) => {
+    const result = formatDuration(seconds);
+    if (result === expected) {
+        passed++;
+        console.log(`✓ formatDuration(${seconds === null ? 'null' : seconds}) = "${result}"`);
+    } else {
+        failed++;
+        console.error(`✗ formatDuration(${seconds === null ? 'null' : seconds}) = "${result}", expected "${expected}"`);
+    }
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);
+


### PR DESCRIPTION
The original purpose of this commit was simply to show "10d 0h 5m" instead of "240h 5m".

But the first attempt at testing needed to use Playwright, so I added tooling to simplify JS testing, which will also have the nice side effect of separating HTML and JS code blocks.