### PR TITLE
Add AE-200 data to debug page and improve UX

### DIFF
--- a/app/routes_web.py
+++ b/app/routes_web.py
@@ -6,6 +6,7 @@ import logging
 import datetime
 import time
 import json
+import asyncio
 from typing import List
 from flask import render_template, request
 
@@ -13,6 +14,7 @@ from .constants import __version__
 from . import db
 from . import rules_engine
 from . import hubitat
+from . import ae200
 from . import room_config
 from .utils.request_utils import parse_device_ids
 from .utils.db_utils import with_db_connection
@@ -195,12 +197,59 @@ def create_web_routes(app):
             hubitat_names_json = json.dumps({"error": str(e)}, indent=2)
             hubitat_json = json.dumps({"error": str(e)}, indent=2)
 
+        # Fetch Mitsubishi AE-200 devices and details
+        ae200_names_json = None
+        ae200_json = None
+        ae200_device_info_json = None
+        try:
+            ae200_devices = ae200.get_devices()
+            # Extract just the names into a simple array
+            ae200_device_names = [dev.get("name", "Unknown") for dev in ae200_devices]
+            ae200_names_json = json.dumps(ae200_device_names, indent=2)
+            # Raw list from AE-200 (id + name)
+            ae200_json = json.dumps(ae200_devices, indent=2)
+
+            # Per-device status direct from AE-200, fetched concurrently
+            async def _fetch_ae200_details_async(devices):
+                ae200_details: dict[str, dict] = {}
+                tasks = []
+                ids: list[str] = []
+                for dev in devices:
+                    device_id = dev.get("id")
+                    if device_id is None:
+                        continue
+                    ids.append(str(device_id))
+                    tasks.append(ae200.get_device_info_async(device_id))
+                if not tasks:
+                    return ae200_details
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+                for key, result in zip(ids, results):
+                    if isinstance(result, Exception):
+                        ae200_details[key] = {"error": str(result)}
+                    else:
+                        ae200_details[key] = result
+                return ae200_details
+
+            ae200_details = ae200.runner.run_async_safely(
+                _fetch_ae200_details_async(ae200_devices)
+            )
+            ae200_device_info_json = json.dumps(ae200_details, indent=2, default=str)
+        except Exception as e:
+            logger.warning("Failed to fetch AE-200 devices: %s", e)
+            ae200_names_json = json.dumps({"error": str(e)}, indent=2)
+            ae200_json = json.dumps({"error": str(e)}, indent=2)
+            ae200_device_info_json = json.dumps({"error": str(e)}, indent=2)
+
         return render_template(
             "debug_all_devices.html",
             all_devices_names_json=all_devices_names_json,
             all_devices_json=all_devices_json,
             hubitat_names_json=hubitat_names_json,
             hubitat_json=hubitat_json,
+            ae200_names_json=ae200_names_json,
+            ae200_json=ae200_json,
+            ae200_device_info_json=ae200_device_info_json,
+            hide_nav=True,
         )
 
     @app.route("/kitchen")

--- a/app/templates/debug_all_devices.html
+++ b/app/templates/debug_all_devices.html
@@ -8,24 +8,63 @@
   </div>
 </div>
 
-<div class="pure-g">
-  <div class="pure-u-1">
-    <h2>All Devices (from Database - like Chart page)</h2>
-    <h3>Device Names</h3>
-    <pre class="debug-pre">{{ all_devices_names_json }}</pre>
-    <h3>Full Device Data</h3>
-    <pre class="debug-pre">{{ all_devices_json }}</pre>
+<section id="db-devices">
+  <div class="pure-g">
+    <div class="pure-u-1">
+      <h2>All Devices (from Database)</h2>
+      <h3>Device Names</h3>
+      <details open>
+        <summary>Show / hide database device names</summary>
+        <pre class="debug-pre">{{ all_devices_names_json }}</pre>
+      </details>
+      <h3>Full Device Data</h3>
+      <details>
+        <summary>Show / hide full database device data</summary>
+        <pre class="debug-pre">{{ all_devices_json }}</pre>
+      </details>
+    </div>
   </div>
-</div>
+</section>
 
-<div class="pure-g">
-  <div class="pure-u-1">
-    <h2>Hubitat Devices (Testing)</h2>
-    <h3>Device Names</h3>
-    <pre class="debug-pre">{{ hubitat_names_json }}</pre>
-    <h3>Full Device Data</h3>
-    <pre class="debug-pre">{{ hubitat_json }}</pre>
+<section id="hubitat-devices">
+  <div class="pure-g">
+    <div class="pure-u-1">
+      <h2>Hubitat Devices</h2>
+      <h3>Device Names</h3>
+      <details open>
+        <summary>Show / hide Hubitat device names</summary>
+        <pre class="debug-pre">{{ hubitat_names_json }}</pre>
+      </details>
+      <h3>Full Device Data</h3>
+      <details>
+        <summary>Show / hide full Hubitat device data</summary>
+        <pre class="debug-pre">{{ hubitat_json }}</pre>
+      </details>
+    </div>
   </div>
-</div>
+</section>
+
+<section id="ae200-devices">
+  <div class="pure-g">
+    <div class="pure-u-1">
+      <h2>Mitsubishi AE-200 Devices</h2>
+      <h3>Unit Names (from AE-200)</h3>
+      <details open>
+        <summary>Show / hide AE-200 unit names</summary>
+        <pre class="debug-pre">{{ ae200_names_json }}</pre>
+      </details>
+      <h3>Raw Unit List (id + name)</h3>
+      <details>
+        <summary>Show / hide raw AE-200 unit list</summary>
+        <pre class="debug-pre">{{ ae200_json }}</pre>
+      </details>
+      <h3>Per-Unit Status (from AE-200)</h3>
+      <details>
+        <summary>Show / hide AE-200 per-unit status</summary>
+        <pre class="debug-pre">{{ ae200_device_info_json }}</pre>
+      </details>
+    </div>
+  </div>
+</section>
 {% endblock %}
 


### PR DESCRIPTION
Expose Mitsubishi AE-200 unit names and per-unit status on /dbg/all_devices alongside DB and Hubitat data. Simplify the debug page layout with collapsible JSON sections for a clearer view.