### PR TITLE
Add an index on logtime of the changelog table

### DIFF
--- a/etc/schema.sql
+++ b/etc/schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS changelog (
                     agent TEXT,
                     comment TEXT
                 , ipaddr text);
+CREATE INDEX IF NOT EXISTS idx_changelog_logtime ON changelog (logtime DESC);
 CREATE TABLE IF NOT EXISTS aqi (
     logtime INTEGER NOT NULL,
     aqi INTEGER NOT NULL


### PR DESCRIPTION
This should dramatically speed up the Log query, especially with millions of spurious "disabled timer expired" lines in the table.

However:
1) I'm not comfortable yet with your (Simson) strategy for modifying the DB manually. I'd rather that you do this change.
2) This may not even be the correct full fix. Arguably, it would be better to also delete all the spurious "disabled timer expired" rows from the table. I don't think they add any value, and they are over 7.6 million rows. There are less than 600 real rows in the database now.