### PR TITLE
Fix Flyway baseline and pin CI install

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,6 +19,7 @@ jobs:
       AIRNOW_API_KEY: ${{ secrets.AIRNOW_API_KEY }}
       POETRY_VERSION: '2.1.3'
       RUFF_VERSION: '0.13.2'
+      FLYWAY_VERSION: '12.8.1'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -79,29 +80,32 @@ jobs:
         run: |
           make install-macos
 
-      - name: Install Flyway (Linux)
-        if: runner.os == 'Linux'
+      - name: Install Flyway
         run: |
-          FLYWAY_TAG=$(curl --fail --silent --show-error --location \
-            --write-out '%{url_effective}' \
-            --output /dev/null \
-            https://github.com/flyway/flyway/releases/latest | sed 's#.*/##')
-          FLYWAY_VERSION="${FLYWAY_TAG#flyway-}"
-          FLYWAY_TAR="flyway-commandline-${FLYWAY_VERSION}-linux-x64.tar.gz"
+          case "${RUNNER_OS}-$(uname -m)" in
+            Linux-x86_64)
+              FLYWAY_PLATFORM="linux-x64"
+              ;;
+            macOS-arm64)
+              FLYWAY_PLATFORM="macosx-arm64"
+              ;;
+            macOS-x86_64)
+              FLYWAY_PLATFORM="macosx-x64"
+              ;;
+            *)
+              echo "Unsupported Flyway platform: ${RUNNER_OS}-$(uname -m)"
+              exit 1
+              ;;
+          esac
+          FLYWAY_TAR="flyway-commandline-${FLYWAY_VERSION}-${FLYWAY_PLATFORM}.tar.gz"
           curl --fail --silent --show-error --location \
             --output "/tmp/${FLYWAY_TAR}" \
-            "https://github.com/flyway/flyway/releases/download/${FLYWAY_TAG}/${FLYWAY_TAR}"
+            "https://github.com/flyway/flyway/releases/download/flyway-${FLYWAY_VERSION}/${FLYWAY_TAR}"
           mkdir -p /tmp/flyway-install
           tar -xzf "/tmp/${FLYWAY_TAR}" -C /tmp/flyway-install
-          FLYWAY_DIR=$(find /tmp/flyway-install -mindepth 1 -maxdepth 1 -type d | head -n 1)
-          echo "${FLYWAY_DIR}" >> $GITHUB_PATH
+          FLYWAY_DIR="/tmp/flyway-install/flyway-${FLYWAY_VERSION}"
+          echo "${FLYWAY_DIR}" >> "$GITHUB_PATH"
           export PATH="${FLYWAY_DIR}:${PATH}"
-          flyway -v
-
-      - name: Install Flyway (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install flyway
           flyway -v
 
       - name: Lint

--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,8 @@ etc/schema.sql: $(wildcard $(FLYWAY_SQL_DIR)/*.sql)
 	flyway migrate \
 	    -url="jdbc:sqlite:$(FLYWAY_SCHEMA_TEMP)" \
 	    -locations="filesystem:$(FLYWAY_SQL_DIR)"
-	echo ".schema"| sqlite3 $(FLYWAY_SCHEMA_TEMP) \
-		| grep -v 'Run Time: real' \
-		| grep -v 'CREATE TABLE sqlite_sequence' \
+	sqlite3 $(FLYWAY_SCHEMA_TEMP) \
+		"SELECT sql || ';' FROM sqlite_schema WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%' AND name <> 'flyway_schema_history' AND COALESCE(tbl_name, '') <> 'flyway_schema_history' ORDER BY rowid;" \
 		| sed 's/CREATE INDEX/CREATE INDEX IF NOT EXISTS/' \
 		| sed 's/CREATE TABLE/CREATE TABLE IF NOT EXISTS/' \
 		| tee etc/schema.sql

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ export DEV_DB  ?= var/db/temperature-bot.db
 FLYWAY_SQL_DIR := etc/flyway/sql
 # Temporary database used when regenerating etc/schema.sql
 FLYWAY_SCHEMA_TEMP := /tmp/temperature-bot-schema-temp.db
+FLYWAY_SCHEMA_DUMP := /tmp/temperature-bot-schema-temp.sql
 
 # Remote host and paths used by fetch-dev-db (override as needed for your environment)
 FETCH_HOST           ?= air.basistech.net
@@ -90,16 +91,19 @@ fetch-dev-db:
 # temp database and dumping the resulting schema. This keeps schema.sql in sync
 # with the canonical migration history. Run 'make schema' to regenerate.
 etc/schema.sql: $(wildcard $(FLYWAY_SQL_DIR)/*.sql)
-	/bin/rm -f $(FLYWAY_SCHEMA_TEMP)
+	/bin/rm -f $(FLYWAY_SCHEMA_TEMP) $(FLYWAY_SCHEMA_DUMP)
 	flyway migrate \
 	    -url="jdbc:sqlite:$(FLYWAY_SCHEMA_TEMP)" \
 	    -locations="filesystem:$(FLYWAY_SQL_DIR)"
 	sqlite3 $(FLYWAY_SCHEMA_TEMP) \
-		"SELECT sql || ';' FROM sqlite_schema WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%' AND name <> 'flyway_schema_history' AND COALESCE(tbl_name, '') <> 'flyway_schema_history' ORDER BY rowid;" \
-		| sed 's/CREATE INDEX/CREATE INDEX IF NOT EXISTS/' \
+		"SELECT sql || ';' FROM sqlite_master WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%' AND name <> 'flyway_schema_history' AND COALESCE(tbl_name, '') <> 'flyway_schema_history' ORDER BY rowid;" \
+		> $(FLYWAY_SCHEMA_DUMP)
+	test -s $(FLYWAY_SCHEMA_DUMP)
+	sed 's/CREATE INDEX/CREATE INDEX IF NOT EXISTS/' $(FLYWAY_SCHEMA_DUMP) \
 		| sed 's/CREATE TABLE/CREATE TABLE IF NOT EXISTS/' \
-		| tee etc/schema.sql
-	/bin/rm -f $(FLYWAY_SCHEMA_TEMP)
+		> etc/schema.sql
+	test -s etc/schema.sql
+	/bin/rm -f $(FLYWAY_SCHEMA_TEMP) $(FLYWAY_SCHEMA_DUMP)
 
 # Phony target to force regeneration of etc/schema.sql regardless of timestamps
 schema:

--- a/doc/sql-migrations.md
+++ b/doc/sql-migrations.md
@@ -5,8 +5,10 @@ Temperature Bot now tracks SQL schema versions with Flyway.
 ## Baseline schema
 
 - `etc/flyway/sql/V1__baseline_schema.sql` is the baseline migration.
-- It is based on the current `etc/schema.sql`.
-- `flyway_schema_history` is the table used to track applied Flyway versions.
+- It contains only application-owned schema objects and matches the deployed pre-Flyway database.
+- `etc/flyway/sql/V2__changelog_device_logtime_index.sql` upgrades the changelog device index to the current application schema.
+- Flyway creates and manages `flyway_schema_history`; do not add that table to a versioned migration or to `etc/schema.sql`.
+- Existing populated databases are baselined at V1 by `make migrate-db` and `make deploy`, then any later migrations are applied.
 
 ## Make targets
 
@@ -14,12 +16,12 @@ Temperature Bot now tracks SQL schema versions with Flyway.
 |---|---|
 | `make make-dev-db` | Delete and recreate the local dev DB by running all Flyway migrations from scratch. |
 | `make migrate-db` | Apply any pending Flyway migrations to the **existing** local dev DB (safe to run on a populated database). |
-| `make schema` | Regenerate `etc/schema.sql` by applying all migrations to a temp DB and dumping its schema. |
+| `make schema` | Regenerate `etc/schema.sql` by applying all migrations to a temp DB and dumping the application schema. |
 | `make deploy` | Pull latest code, install dependencies, **and** run `flyway migrate` against the production DB. |
 
 ## Validate migrations
 
-Run validation before applying migrations:
+Run validation after the database has been baselined or migrated:
 
 ```bash
 flyway \

--- a/etc/flyway/sql/V1__baseline_schema.sql
+++ b/etc/flyway/sql/V1__baseline_schema.sql
@@ -44,17 +44,4 @@ CREATE INDEX IF NOT EXISTS idx_alerts_active ON alerts (end_time) WHERE end_time
 CREATE INDEX IF NOT EXISTS idx_alerts_type ON alerts (alert_type);
 CREATE INDEX IF NOT EXISTS idx_alerts_start_time ON alerts (start_time);
 CREATE INDEX IF NOT EXISTS idx_changelog_logtime ON changelog (logtime);
-CREATE INDEX IF NOT EXISTS idx_changelog_device_id_logtime ON changelog (device_id, logtime);
-CREATE TABLE IF NOT EXISTS flyway_schema_history (
-    installed_rank INTEGER PRIMARY KEY,
-    version TEXT,
-    description TEXT NOT NULL,
-    type TEXT NOT NULL,
-    script TEXT NOT NULL,
-    checksum INTEGER,
-    installed_by TEXT NOT NULL,
-    installed_on TEXT NOT NULL DEFAULT (datetime('now')),
-    execution_time INTEGER NOT NULL,
-    success INTEGER NOT NULL
-);
-CREATE INDEX IF NOT EXISTS flyway_schema_history_success_idx ON flyway_schema_history (success);
+CREATE INDEX IF NOT EXISTS idx_changelog_device_id ON changelog (device_id);

--- a/etc/flyway/sql/V2__changelog_device_logtime_index.sql
+++ b/etc/flyway/sql/V2__changelog_device_logtime_index.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_changelog_device_id;
+CREATE INDEX IF NOT EXISTS idx_changelog_device_id_logtime ON changelog (device_id, logtime);

--- a/etc/schema.sql
+++ b/etc/schema.sql
@@ -45,16 +45,3 @@ CREATE INDEX IF NOT EXISTS idx_alerts_type ON alerts (alert_type);
 CREATE INDEX IF NOT EXISTS idx_alerts_start_time ON alerts (start_time);
 CREATE INDEX IF NOT EXISTS idx_changelog_logtime ON changelog (logtime);
 CREATE INDEX IF NOT EXISTS idx_changelog_device_id_logtime ON changelog (device_id, logtime);
-CREATE TABLE IF NOT EXISTS flyway_schema_history (
-    installed_rank INTEGER PRIMARY KEY,
-    version TEXT,
-    description TEXT NOT NULL,
-    type TEXT NOT NULL,
-    script TEXT NOT NULL,
-    checksum INTEGER,
-    installed_by TEXT NOT NULL,
-    installed_on TEXT NOT NULL DEFAULT (datetime('now')),
-    execution_time INTEGER NOT NULL,
-    success INTEGER NOT NULL
-);
-CREATE INDEX IF NOT EXISTS flyway_schema_history_success_idx ON flyway_schema_history (success);

--- a/tests/test_schema_flyway.py
+++ b/tests/test_schema_flyway.py
@@ -1,15 +1,59 @@
 """Flyway schema tests."""
 
 import sqlite3
+from pathlib import Path
 
-from app.paths import SCHEMA_FILE_PATH
+from app.paths import ROOT_DIR, SCHEMA_FILE_PATH
+
+APP_TABLES = {"devices", "devlog", "changelog", "aqi", "alerts"}
+BASELINE_MIGRATION_PATH = (
+    Path(ROOT_DIR) / "etc" / "flyway" / "sql" / "V1__baseline_schema.sql"
+)
 
 
-def test_schema_includes_flyway_history_table():
+def table_names_created_by(sql_path):
     conn = sqlite3.connect(":memory:")
-    with open(SCHEMA_FILE_PATH, "r", encoding="utf-8") as schema_file:
+    with open(sql_path, "r", encoding="utf-8") as schema_file:
         conn.executescript(schema_file.read())
-    row = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='flyway_schema_history'"
-    ).fetchone()
-    assert row is not None
+    return {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        )
+    }
+
+
+def index_names_created_by(sql_path):
+    conn = sqlite3.connect(":memory:")
+    with open(sql_path, "r", encoding="utf-8") as schema_file:
+        conn.executescript(schema_file.read())
+    return {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'"
+        )
+    }
+
+
+def test_schema_file_contains_application_tables_only():
+    tables = table_names_created_by(SCHEMA_FILE_PATH)
+    assert APP_TABLES <= tables
+    assert "flyway_schema_history" not in tables
+
+
+def test_baseline_migration_does_not_create_flyway_history_table():
+    tables = table_names_created_by(BASELINE_MIGRATION_PATH)
+    assert APP_TABLES <= tables
+    assert "flyway_schema_history" not in tables
+
+
+def test_baseline_migration_matches_deployed_changelog_device_index():
+    indexes = index_names_created_by(BASELINE_MIGRATION_PATH)
+    assert "idx_changelog_device_id" in indexes
+    assert "idx_changelog_device_id_logtime" not in indexes
+
+
+def test_schema_file_contains_migrated_changelog_device_logtime_index():
+    indexes = index_names_created_by(SCHEMA_FILE_PATH)
+    assert "idx_changelog_device_id_logtime" in indexes
+    assert "idx_changelog_device_id" not in indexes

--- a/tests/test_schema_flyway.py
+++ b/tests/test_schema_flyway.py
@@ -1,5 +1,6 @@
 """Flyway schema tests."""
 
+from contextlib import closing
 import sqlite3
 from pathlib import Path
 
@@ -12,27 +13,27 @@ BASELINE_MIGRATION_PATH = (
 
 
 def table_names_created_by(sql_path):
-    conn = sqlite3.connect(":memory:")
-    with open(sql_path, "r", encoding="utf-8") as schema_file:
-        conn.executescript(schema_file.read())
-    return {
-        row[0]
-        for row in conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
-        )
-    }
+    with closing(sqlite3.connect(":memory:")) as conn:
+        with open(sql_path, "r", encoding="utf-8") as schema_file:
+            conn.executescript(schema_file.read())
+        return {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
 
 
 def index_names_created_by(sql_path):
-    conn = sqlite3.connect(":memory:")
-    with open(sql_path, "r", encoding="utf-8") as schema_file:
-        conn.executescript(schema_file.read())
-    return {
-        row[0]
-        for row in conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'"
-        )
-    }
+    with closing(sqlite3.connect(":memory:")) as conn:
+        with open(sql_path, "r", encoding="utf-8") as schema_file:
+            conn.executescript(schema_file.read())
+        return {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
 
 
 def test_schema_file_contains_application_tables_only():


### PR DESCRIPTION
## Summary
- remove Flyway-owned `flyway_schema_history` from V1 and generated `etc/schema.sql`
- make V1 match the deployed pre-Flyway DB, then add V2 to upgrade the changelog device/logtime index
- pin CI to Flyway 12.8.1 with explicit release downloads on Linux and macOS
- update docs and schema tests for the Flyway ownership boundary

## Validation
- `make schema`
- copied the current development DB and ran `DEV_DB=<copy> make migrate-db` to verify the existing-database adoption path
- `TEMPERATURE_BOT_CONFIG=<local config> AE200_SIMULATOR=1 AIRTHINGS_SIMULATOR=1 SKIP_BROWSER_TEST=1 make test`

Note: browser tests were skipped locally because the temporary worktree does not have Playwright browsers installed.