### PR TITLE
Replace dict-shaped contracts with Pydantic models

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Temperatures are stored as integer Celsius tenths (`temp10x`) in `devlog`.
 Consecutive readings with the same state are run-length encoded by extending
 the row duration instead of inserting duplicate rows.
 
+## Data Contracts
+
+Stable app-owned data should use Pydantic models from `app/models.py` rather
+than ad hoc dictionaries. Named models document the expected fields, make type
+and runtime validation useful, and give humans and LLM coding agents a clearer
+source of truth. External service payloads may remain dictionaries at the
+edge, but shared keys should be centralized instead of repeated inline.
+
 ## Operations
 
 The periodic runner is `bin/runner.py`; production cron/systemd entries run it

--- a/app/aq_metrics.py
+++ b/app/aq_metrics.py
@@ -13,13 +13,15 @@ too-many-lines ceiling and because these helpers form a small,
 self-contained unit that is easier to reason about in isolation.
 """
 
-from typing import Any, Dict
+from typing import Any
+
+from .models import StatusPayload
 
 
 # URL-safe metric name -> top-level key in devlog.status_json.
 # Used by the Air Quality click-to-chart feature: main-page cells link to
 # /metric_chart?metric=<key>, and /api/v1/metric looks up the status_json key.
-AQ_METRIC_STATUS_KEYS: Dict[str, str] = {
+AQ_METRIC_STATUS_KEYS: dict[str, str] = {
     "humidity": "humidity",
     "co2": "co2",
     "voc": "voc",
@@ -28,6 +30,9 @@ AQ_METRIC_STATUS_KEYS: Dict[str, str] = {
     "pm1": "pm1",
     "pressure": "pressure",
 }
+
+VALUE_KEY = "value"
+ATTRIBUTES_KEY = "attributes"
 
 
 def coerce_metric_value(raw: Any) -> float | None:
@@ -40,7 +45,7 @@ def coerce_metric_value(raw: Any) -> float | None:
     if raw is None or raw == "":
         return None
     if isinstance(raw, dict):
-        raw = raw.get("value")
+        raw = raw.get(VALUE_KEY)
         if raw is None or raw == "":
             return None
     try:
@@ -49,16 +54,20 @@ def coerce_metric_value(raw: Any) -> float | None:
         return None
 
 
-def extract_metric_from_status(status: Dict[str, Any], status_key: str) -> float | None:
+def extract_metric_from_status(
+    status: dict[str, Any] | StatusPayload, status_key: str
+) -> float | None:
     """Pull a single metric value out of a status_json dict.
 
     Looks at the top-level key, then falls back to ``attributes.<key>`` to
     match the pattern Hubitat devices use for humidity and illuminance.
     """
-    val = coerce_metric_value(status.get(status_key))
+    payload = status if isinstance(status, StatusPayload) else StatusPayload.model_validate(status)
+    status_data = payload.model_dump()
+    val = coerce_metric_value(status_data.get(status_key))
     if val is not None:
         return val
-    attrs = status.get("attributes")
+    attrs = status_data.get(ATTRIBUTES_KEY)
     if isinstance(attrs, dict):
         return coerce_metric_value(attrs.get(status_key))
     return None

--- a/app/db.py
+++ b/app/db.py
@@ -34,7 +34,16 @@ from typing import List, Dict, Any
 from flask import request
 
 from .constants import DB_PATH, TEST_DB_NAME
-from .models import AqiSummary, DeviceStatus, json_ready
+from .models import (
+    AqiSummary,
+    AqiWeatherResponse,
+    ChangelogResponse,
+    ChangelogRow,
+    DeviceStatus,
+    TimeSeries,
+    json_ready,
+    json_ready_list,
+)
 from .paths import SCHEMA_FILE_PATH
 from .util import github_style_duration
 from . import ae200
@@ -673,7 +682,7 @@ def get_temperature_series(
     if not device_ids:
         device_ids = [dev["device_id"] for dev in devices]
 
-    series = []
+    series: list[TimeSeries] = []
     for dev in devices:
         if dev["device_id"] in device_ids:
             cmd = """
@@ -685,14 +694,16 @@ def get_temperature_series(
             cmd += " ORDER BY logtime "
             c.execute(cmd, args)
             rows = c.fetchall()
-            data = [[row["logtime"], row["temp10x"] / 10] for row in rows]
+            data = [(row["logtime"], row["temp10x"] / 10) for row in rows]
             if data:
-                series.append({
-                    "device_id": dev["device_id"],
-                    "name": dev["device_name"],
-                    "data": data,
-                })
-    return series
+                series.append(
+                    TimeSeries(
+                        device_id=dev["device_id"],
+                        name=dev["device_name"],
+                        data=data,
+                    )
+                )
+    return json_ready_list(series)
 
 
 def get_device_metric_series(
@@ -711,7 +722,7 @@ def get_device_metric_series(
     if not device_ids:
         device_ids = [dev["device_id"] for dev in devices]
 
-    series: List[Dict[str, Any]] = []
+    series: list[TimeSeries] = []
 
     for dev in devices:
         device_id = dev["device_id"]
@@ -729,7 +740,7 @@ def get_device_metric_series(
         c.execute(cmd, args)
         rows = c.fetchall()
 
-        data: List[List[float]] = []
+        data: list[tuple[int, float]] = []
         for row in rows:
             try:
                 status = json.loads(row["status_json"])
@@ -738,12 +749,14 @@ def get_device_metric_series(
             val = extract_metric_from_status(status, status_key)
             if val is None:
                 continue
-            data.append([row["logtime"], val])
+            data.append((row["logtime"], val))
 
         if data:
-            series.append({"name": dev["device_name"], "device_id": device_id, "data": data})
+            series.append(
+                TimeSeries(name=dev["device_name"], device_id=device_id, data=data)
+            )
 
-    return series
+    return json_ready_list(series)
 
 
 def get_lighting_series(
@@ -762,7 +775,7 @@ def get_lighting_series(
     if not device_ids:
         device_ids = [dev["device_id"] for dev in devices]
 
-    series: List[Dict[str, Any]] = []
+    series: list[TimeSeries] = []
 
     for dev in devices:
         device_id = dev["device_id"]
@@ -780,7 +793,7 @@ def get_lighting_series(
         c.execute(cmd, args)
         rows = c.fetchall()
 
-        data: List[List[float]] = []
+        data: list[tuple[int, float]] = []
         for row in rows:
             status_json = row["status_json"]
             try:
@@ -804,12 +817,14 @@ def get_lighting_series(
             except (TypeError, ValueError):
                 continue
 
-            data.append([row["logtime"], illum_val])
+            data.append((row["logtime"], illum_val))
 
         if data:
-            series.append({"name": dev["device_name"], "device_id": device_id, "data": data})
+            series.append(
+                TimeSeries(name=dev["device_name"], device_id=device_id, data=data)
+            )
 
-    return series
+    return json_ready_list(series)
 
 
 def get_device_status(conn) -> List[Dict[str, Any]]:
@@ -875,12 +890,16 @@ def get_changelog(
         except TypeError as e:
             logging.error("e=%s data=%s", e, row)
 
-    return {
-        "draw": draw,
-        "recordsTotal": len(rows),
-        "recordsFiltered": len(rows),  # Adjust if implementing search
-        "data": rows,
-    }
+    return json_ready(
+        ChangelogResponse.model_validate(
+            {
+                "draw": draw,
+                "recordsTotal": len(rows),
+                "recordsFiltered": len(rows),  # Adjust if implementing search
+                "data": [ChangelogRow.model_validate(row) for row in rows],
+            }
+        )
+    )
 
 
 def get_device_log(conn, device_id: int) -> Dict[str, Any]:
@@ -941,7 +960,9 @@ def get_aqi_and_weather_data(conn) -> Dict[str, Any]:
     """Get combined weather and AQI data"""
     aqi_data = get_db_aqi(conn)
     weather_data = weather.get_weather_data()
-    return {"aqi": aqi_data, "weather": weather_data}
+    return json_ready(
+        AqiWeatherResponse.model_validate({"aqi": aqi_data, "weather": weather_data})
+    )
 
 def get_all_device_aqi(conn) -> List[Dict[str, Any]]:
     """

--- a/app/models.py
+++ b/app/models.py
@@ -87,6 +87,8 @@ class WeatherStation(BaseModel):
 class WeatherData(BaseModel):
     """Weather payload returned by the app weather endpoint."""
 
+    model_config = ConfigDict(extra="forbid")
+
     stations: list[WeatherStation] = Field(default_factory=list)
     forecast: list[Dict[str, Any]] = Field(default_factory=list)
     daily: list[Dict[str, Any]] = Field(default_factory=list)

--- a/app/models.py
+++ b/app/models.py
@@ -14,9 +14,125 @@ add display-only fields such as ``display_name`` and CSS annotations. Use
 actually validated before it becomes a mapping.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 from pydantic import BaseModel, ConfigDict, Field
+
+
+class StatusPayload(BaseModel):
+    """Decoded integration payload from ``devlog.status_json``.
+
+    Integrations own the nested vendor keys, so this model deliberately allows
+    extra fields while still making the app-owned boundary explicit.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+
+class RoomConfig(BaseModel):
+    """Static dashboard configuration for one room."""
+
+    model_config = ConfigDict(frozen=True)
+
+    url: str = Field(description="Dashboard route for the room.")
+    ervs: list[str] = Field(default_factory=list, description="AE-200 ERV names.")
+    fans: list[str] = Field(default_factory=list, description="AE-200 fan names.")
+    sensors: list[str] = Field(default_factory=list, description="Hubitat sensor names.")
+    tv_control: bool = Field(default=False, description="Whether to render TV controls.")
+    dimmer_id: str | None = Field(default=None, description="Hubitat dimmer device id.")
+    wall_inner_id: str | None = Field(default=None, description="Inner wall light device id.")
+    wall_outer_id: str | None = Field(default=None, description="Outer wall light device id.")
+
+
+class TimeSeries(BaseModel):
+    """One chart series for a single device."""
+
+    device_id: int = Field(description="Local device id from the devices table.")
+    name: str = Field(description="Display name for the chart series.")
+    data: list[tuple[int, float]] = Field(description="Ordered (unix time, value) samples.")
+
+
+class ChangelogRow(BaseModel):
+    """One changelog row returned to the DataTables endpoint."""
+
+    logtime: int | None = None
+    ipaddr: str | None = None
+    unit: str | None = None
+    new_value: Any | None = None
+    agent: str | None = None
+    comment: str | None = None
+    age: str | None = None
+
+
+class ChangelogResponse(BaseModel):
+    """Paginated changelog response for ``/api/v1/changelog``."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    draw: int
+    records_total: int = Field(alias="recordsTotal")
+    records_filtered: int = Field(alias="recordsFiltered")
+    data: list[ChangelogRow]
+
+
+class WeatherStation(BaseModel):
+    """Current weather observation from one station."""
+
+    temperature: float | int | None = None
+    conditions: str = "Unknown"
+    icon: str = ""
+    station_name: str = ""
+
+
+class WeatherData(BaseModel):
+    """Weather payload returned by the app weather endpoint."""
+
+    stations: list[WeatherStation] = Field(default_factory=list)
+    forecast: list[Dict[str, Any]] = Field(default_factory=list)
+    daily: list[Dict[str, Any]] = Field(default_factory=list)
+
+
+class AirMetricThreshold(BaseModel):
+    """Threshold rule for an indoor air-quality metric."""
+
+    limit: float
+    score: int
+    label: str
+
+
+class AirMetricRange(BaseModel):
+    """Range rule for metrics scored by acceptable bands."""
+
+    problem_min: float
+    problem_max: float
+    elevated_min: float
+    elevated_max: float
+
+
+class AirMetricRule(BaseModel):
+    """Scoring configuration for one indoor air-quality metric."""
+
+    short_name: str
+    thresholds: list[AirMetricThreshold] = Field(default_factory=list)
+    ranges: AirMetricRange | None = None
+
+
+class AirMetricScore(BaseModel):
+    """Scored indoor air-quality reading."""
+
+    severity_score: int
+    label: str
+    short_name: str
+
+    def as_tuple(self) -> tuple[int, str, str]:
+        """Return the historical tuple shape used by existing callers."""
+        return (self.severity_score, self.label, self.short_name)
+
+
+class AirQualityAnnotation(BaseModel):
+    """Template annotations derived from indoor air-quality readings."""
+
+    aq_classes: dict[str, str] = Field(default_factory=dict)
 
 
 class AqiSummary(BaseModel):
@@ -30,6 +146,13 @@ class AqiSummary(BaseModel):
     name: str = Field(description="Human-readable AQI category.")
     color_name: str = Field(description="EPA AQI color category name.")
     color: str = Field(description="Display hex color for the AQI category.")
+
+
+class AqiWeatherResponse(BaseModel):
+    """Combined outdoor AQI and weather payload."""
+
+    aqi: AqiSummary
+    weather: WeatherData | Dict[str, Any]
 
 
 class SpeedControl(BaseModel):
@@ -74,6 +197,19 @@ class SetTempControl(BaseModel):
     set_temp_c: float = Field(description="Requested set point in degrees Celsius.")
 
 
+class CommandResponse(BaseModel):
+    """Successful command response returned by control endpoints."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str = "ok"
+    device_id: int | None = None
+    level: int | None = None
+    light: str | None = None
+    state: str | None = None
+    direction: str | None = None
+
+
 class DeviceStatus(BaseModel):
     """Latest database status row plus derived display annotations.
 
@@ -103,7 +239,7 @@ class DeviceStatus(BaseModel):
         default=None,
         description="AE-200 unit id linked to this local device, when present.",
     )
-    status: Dict[str, Any] | None = Field(
+    status: StatusPayload | None = Field(
         default=None,
         description="Decoded vendor payload from devlog.status_json.",
     )
@@ -123,4 +259,9 @@ def json_ready(model: BaseModel) -> Dict[str, Any]:
     ``exclude_none=True`` intentionally omits optional fields whose source data
     is unavailable instead of serializing those fields as explicit nulls.
     """
-    return model.model_dump(exclude_none=True)
+    return model.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def json_ready_list(models: Iterable[BaseModel]) -> list[Dict[str, Any]]:
+    """Dump validated models to JSON-ready mappings."""
+    return [json_ready(model) for model in models]

--- a/app/room_config.py
+++ b/app/room_config.py
@@ -1,41 +1,41 @@
-"""
-Configuration for room dashboards (kitchen/hickory).
+"""Configuration for room dashboards (kitchen/hickory).
 
 Each room specifies which ERVs, fans, and sensors to display.
 All device names must match exactly with names in the database or Hubitat.
 """
 
-from typing import Dict, Any
+from .models import RoomConfig
 
-RoomConfig = Dict[str, Any]
-"""Type alias for room configuration dict.
-Keys: 'url' (str), 'ervs' (list[str]), 'fans' (list[str]), 'sensors' (list[str]),
-'tv_control' (bool), 'dimmer_id' (str), 'wall_inner_id' (str), 'wall_outer_id' (str)
-"""
+EMPTY_ROOM_CONFIG = RoomConfig(url="")
 
-ROOM_CONFIGS: Dict[str, RoomConfig] = {
-    "kitchen": {
-        "url": "/kitchen",
-        "ervs": ["ERV Kitchen"],
-        "fans": ["Kitchen"],
-        "sensors": [
+ROOM_CONFIGS: dict[str, RoomConfig] = {
+    "kitchen": RoomConfig(
+        url="/kitchen",
+        ervs=["ERV Kitchen"],
+        fans=["Kitchen"],
+        sensors=[
             "Lobby Sensor on Somerville Broadway",
             "Broadway Sensor Center on Somerville Broadway",
             "Broadway Sensor North on Somerville Broadway",
             "Broadway Sensor South on Somerville Broadway",
         ],
-    },
-    "hickory": {
-        "url": "/hickory",
-        "ervs": ["ERV Restrooms"],
-        "fans": ["Restrooms/BOH", "Dungeon"],
-        "sensors": [
+    ),
+    "hickory": RoomConfig(
+        url="/hickory",
+        ervs=["ERV Restrooms"],
+        fans=["Restrooms/BOH", "Dungeon"],
+        sensors=[
             "Hickory Sensor",
             "Dungeon Cage",
         ],
-        "tv_control": True,
-        "dimmer_id": "581",
-        "wall_inner_id": "454",
-        "wall_outer_id": "550",
-    },
+        tv_control=True,
+        dimmer_id="581",
+        wall_inner_id="454",
+        wall_outer_id="550",
+    ),
 }
+
+
+def get_room_config(room_key: str) -> RoomConfig:
+    """Return room dashboard configuration, or an empty config for unknown rooms."""
+    return ROOM_CONFIGS.get(room_key, EMPTY_ROOM_CONFIG)

--- a/app/routes_api.py
+++ b/app/routes_api.py
@@ -24,7 +24,14 @@ from . import room_config
 from .utils.request_utils import parse_device_ids
 from .utils.db_utils import with_db_connection
 
-from .models import SpeedControl, DriveControl, NoteControl, SetTempControl
+from .models import (
+    CommandResponse,
+    DriveControl,
+    NoteControl,
+    SetTempControl,
+    SpeedControl,
+    json_ready,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +59,7 @@ def set_fan_speed(conn, body: SpeedControl):
         ipaddr=request.remote_addr,
         agent=request.headers.get("User-Agent"),
     )
-    return jsonify({"status": "ok", **ret})
+    return jsonify(json_ready(CommandResponse.model_validate({"status": "ok", **ret})))
 
 
 @api_v1.route("/set_drive", methods=["POST"])
@@ -71,7 +78,7 @@ def set_drive(conn, body: DriveControl):
         agent=request.headers.get("User-Agent"),
         comment=f"rules for disabled for {constants.RULES_DISABLE_SECONDS / 60} minutes",
     )
-    return jsonify({"status": "ok", **ret})
+    return jsonify(json_ready(CommandResponse.model_validate({"status": "ok", **ret})))
 
 
 @api_v1.route("/set_temp", methods=["POST"])
@@ -85,7 +92,7 @@ def set_temp(conn, body: SetTempControl):
     """
     logger.debug("/set_temp: body=[%s]", body)
     ret = rules_engine.set_body_set_temp(conn, body, request.remote_addr, "web")
-    return jsonify({"status": "ok", **ret})
+    return jsonify(json_ready(CommandResponse.model_validate({"status": "ok", **ret})))
 
 
 @api_v1.route("/status")
@@ -306,27 +313,29 @@ def update_note(conn, body: NoteControl):
     logger.debug("/update_note: body=[%s]", body)
     notes = body.notes if body.notes else None
     device_id = db.update_device_notes(conn, body.device_id, notes)
-    return jsonify({"status": "ok", "device_id": device_id})
+    return jsonify(json_ready(CommandResponse(device_id=device_id)))
 
 
 @api_v1.route("/hickory/room_status")
 def hickory_room_status():
     """Return current state of Hickory room control devices."""
-    config = room_config.ROOM_CONFIGS.get("hickory", {})
+    config = room_config.get_room_config("hickory")
     result = {}
     try:
         all_devices = hubitat.get_all_devices()
         by_id = {str(d.get("id")): d for d in all_devices}
 
-        dimmer_id = config.get("dimmer_id")
+        dimmer_id = config.dimmer_id
         if dimmer_id and dimmer_id in by_id:
             attrs = by_id[dimmer_id].get("attributes", {})
             result["dimmer"] = {
                 "level": int(attrs.get("level", 0)),
                 "switch": attrs.get("switch", "off"),
             }
-        for key in ("wall_inner_id", "wall_outer_id"):
-            dev_id = config.get(key)
+        for key, dev_id in {
+            "wall_inner_id": config.wall_inner_id,
+            "wall_outer_id": config.wall_outer_id,
+        }.items():
             if dev_id and dev_id in by_id:
                 attrs = by_id[dev_id].get("attributes", {})
                 result[key.replace("_id", "")] = {
@@ -341,8 +350,8 @@ def hickory_room_status():
 @api_v1.route("/hickory/dimmer", methods=["POST"])
 def hickory_dimmer():
     """Set the Hickory room light dimmer level (0-100)."""
-    config = room_config.ROOM_CONFIGS.get("hickory", {})
-    device_id = config.get("dimmer_id")
+    config = room_config.get_room_config("hickory")
+    device_id = config.dimmer_id
     if not device_id:
         return jsonify({"error": "No dimmer configured"}), 404
     payload = request.get_json(silent=True) or {}
@@ -351,7 +360,7 @@ def hickory_dimmer():
         return jsonify({"error": "level must be an integer 0-100"}), 400
     try:
         hubitat.set_dimmer_level(device_id, level)
-        return jsonify({"status": "ok", "level": level})
+        return jsonify(json_ready(CommandResponse(level=level)))
     except (RuntimeError, OSError) as e:
         logger.warning("Dimmer control failed: %s", e)
         return jsonify({"error": str(e)}), 500
@@ -360,12 +369,12 @@ def hickory_dimmer():
 @api_v1.route("/hickory/wall_light", methods=["POST"])
 def hickory_wall_light():
     """Toggle a Hickory wall light on or off."""
-    config = room_config.ROOM_CONFIGS.get("hickory", {})
+    config = room_config.get_room_config("hickory")
     payload = request.get_json(silent=True) or {}
     light = payload.get("light")
     state = payload.get("state")
 
-    id_map = {"inner": config.get("wall_inner_id"), "outer": config.get("wall_outer_id")}
+    id_map = {"inner": config.wall_inner_id, "outer": config.wall_outer_id}
     if not isinstance(light, str):
         return jsonify({"error": "light must be 'inner' or 'outer'"}), 400
     device_id = id_map.get(light)
@@ -375,7 +384,7 @@ def hickory_wall_light():
         return jsonify({"error": "state must be 'on' or 'off'"}), 400
     try:
         hubitat.set_switch(device_id, state)
-        return jsonify({"status": "ok", "light": light, "state": state})
+        return jsonify(json_ready(CommandResponse(light=light, state=state)))
     except (RuntimeError, OSError) as e:
         logger.warning("Wall light control failed: %s", e)
         return jsonify({"error": str(e)}), 500
@@ -390,7 +399,7 @@ def hickory_tv():
         return jsonify({"error": "direction must be 'up' or 'down'"}), 400
     try:
         hubitat.control_hickory_tv(direction)
-        return jsonify({"status": "ok", "direction": direction})
+        return jsonify(json_ready(CommandResponse(direction=direction)))
     except (RuntimeError, OSError) as e:
         logger.warning("TV control failed: %s", e)
         return jsonify({"error": str(e)}), 500

--- a/app/routes_web.py
+++ b/app/routes_web.py
@@ -382,17 +382,17 @@ def _collect_device_notes(devices):
 def _render_room_dashboard_with_data(conn, location: str):
     """Render room dashboard with device data filtered by configuration."""
     room_key = location.lower()
-    config = room_config.ROOM_CONFIGS.get(room_key, {})
+    config = room_config.get_room_config(room_key)
 
     all_devices = db.get_device_status(conn)
 
     # Filter ERVs and fans
-    erv_devices = _filter_speed_control_devices(all_devices, config.get("ervs", []))
+    erv_devices = _filter_speed_control_devices(all_devices, config.ervs)
 
-    fan_devices = _filter_speed_control_devices(all_devices, config.get("fans", []))
+    fan_devices = _filter_speed_control_devices(all_devices, config.fans)
 
     # Get Hubitat sensors
-    hubitat_sensors = _get_hubitat_sensors(config.get("sensors", []))
+    hubitat_sensors = _get_hubitat_sensors(config.sensors)
 
     # Attach display names for sensors using the centralized helper. We prefer
     # Hubitat labels when available and then apply generic display transforms.
@@ -419,10 +419,10 @@ def _render_room_dashboard_with_data(conn, location: str):
         fan_devices=fan_devices,
         hubitat_sensors=hubitat_sensors,
         notes=notes,
-        show_tv_control=config.get("tv_control", False),
-        dimmer_id=config.get("dimmer_id"),
-        wall_inner_id=config.get("wall_inner_id"),
-        wall_outer_id=config.get("wall_outer_id"),
+        show_tv_control=config.tv_control,
+        dimmer_id=config.dimmer_id,
+        wall_inner_id=config.wall_inner_id,
+        wall_outer_id=config.wall_outer_id,
     )
 
 

--- a/app/routes_web_airquality_utils.py
+++ b/app/routes_web_airquality_utils.py
@@ -2,133 +2,175 @@
 
 import datetime
 import time
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Any, Optional
 
+from .aq_metrics import VALUE_KEY
+from .models import (
+    AirMetricRange,
+    AirMetricRule,
+    AirMetricScore,
+    AirMetricThreshold,
+    AirQualityAnnotation,
+)
 from .util import github_style_duration
 
 
 # Data-driven thresholds to keep branching complexity low.
 # Each entry maps a metric name to a short display name and ordered thresholds:
 # thresholds are evaluated from highest to lowest.
-_METRIC_RULES: Dict[str, Dict[str, Any]] = {
-    "co2": {
-        "short_name": "CO₂",
-        "thresholds": [(1200, 2, "problem"), (800, 1, "elevated")],
-    },
-    "pm25": {
-        "short_name": "PM2.5",
-        "thresholds": [(35, 2, "problem"), (12, 1, "elevated")],
-    },
-    "pm1": {
-        "short_name": "PM1",
-        "thresholds": [(35, 2, "problem"), (12, 1, "elevated")],
-    },
-    "humidity": {
-        "short_name": "RH",
-        # Problem outside [30, 60], elevated just outside [35, 55].
-        "ranges": {
-            "problem": lambda v: v < 30 or v > 60,
-            "elevated": lambda v: (30 <= v < 35) or (55 < v <= 60),
-        },
-    },
-    "temp": {
-        "short_name": "Temp",
-        # Problem outside [18, 27], elevated just outside [20, 25].
-        "ranges": {
-            "problem": lambda v: v < 18 or v > 27,
-            "elevated": lambda v: (18 <= v < 20) or (25 < v <= 27),
-        },
-    },
-    "radonShortTermAvg": {
-        "short_name": "Radon",
-        "thresholds": [(150, 2, "problem"), (100, 1, "elevated")],
-    },
-    "voc": {
-        "short_name": "VOC",
-        "thresholds": [(2000, 2, "problem"), (500, 1, "elevated")],
-    },
+_METRIC_RULES: dict[str, AirMetricRule] = {
+    "co2": AirMetricRule(
+        short_name="CO₂",
+        thresholds=[
+            AirMetricThreshold(limit=1200, score=2, label="problem"),
+            AirMetricThreshold(limit=800, score=1, label="elevated"),
+        ],
+    ),
+    "pm25": AirMetricRule(
+        short_name="PM2.5",
+        thresholds=[
+            AirMetricThreshold(limit=35, score=2, label="problem"),
+            AirMetricThreshold(limit=12, score=1, label="elevated"),
+        ],
+    ),
+    "pm1": AirMetricRule(
+        short_name="PM1",
+        thresholds=[
+            AirMetricThreshold(limit=35, score=2, label="problem"),
+            AirMetricThreshold(limit=12, score=1, label="elevated"),
+        ],
+    ),
+    "humidity": AirMetricRule(
+        short_name="RH",
+        ranges=AirMetricRange(
+            problem_min=30,
+            problem_max=60,
+            elevated_min=35,
+            elevated_max=55,
+        ),
+    ),
+    "temp": AirMetricRule(
+        short_name="Temp",
+        ranges=AirMetricRange(
+            problem_min=18,
+            problem_max=27,
+            elevated_min=20,
+            elevated_max=25,
+        ),
+    ),
+    "radonShortTermAvg": AirMetricRule(
+        short_name="Radon",
+        thresholds=[
+            AirMetricThreshold(limit=150, score=2, label="problem"),
+            AirMetricThreshold(limit=100, score=1, label="elevated"),
+        ],
+    ),
+    "voc": AirMetricRule(
+        short_name="VOC",
+        thresholds=[
+            AirMetricThreshold(limit=2000, score=2, label="problem"),
+            AirMetricThreshold(limit=500, score=1, label="elevated"),
+        ],
+    ),
 }
 
 
 def _score_with_thresholds(
-    value: float, thresholds: List[Tuple[float, int, str]]
-) -> Tuple[int, str]:
-    for limit, score, label in thresholds:
-        if value > limit:
-            return score, label
-    return 0, "good"
+    value: float, thresholds: list[AirMetricThreshold]
+) -> AirMetricScore:
+    for threshold in thresholds:
+        if value > threshold.limit:
+            return AirMetricScore(
+                severity_score=threshold.score,
+                label=threshold.label,
+                short_name="",
+            )
+    return AirMetricScore(severity_score=0, label="good", short_name="")
 
 
-def _score_with_ranges(
-    value: float, ranges: Dict[str, Any]
-) -> Tuple[int, str]:
-    if ranges["problem"](value):
-        return 2, "problem"
-    if ranges["elevated"](value):
-        return 1, "elevated"
-    return 0, "good"
+def _score_with_ranges(value: float, ranges: AirMetricRange) -> AirMetricScore:
+    if value < ranges.problem_min or value > ranges.problem_max:
+        return AirMetricScore(severity_score=2, label="problem", short_name="")
+    if value < ranges.elevated_min or value > ranges.elevated_max:
+        return AirMetricScore(severity_score=1, label="elevated", short_name="")
+    return AirMetricScore(severity_score=0, label="good", short_name="")
 
 
-def score_air_metric(metric_name: str, value: Any) -> Tuple[int, str, str]:
-    """Return (severity_score, label, short_name) for a metric value.
+def score_air_metric_model(metric_name: str, value: Any) -> AirMetricScore:
+    """Return a structured severity score for a metric value.
 
     severity_score: 0=good, 1=elevated, 2=problem
     """
     if value is None:
-        return (0, "good", metric_name)
+        return AirMetricScore(severity_score=0, label="good", short_name=metric_name)
 
     rules = _METRIC_RULES.get(metric_name)
     if not rules:
-        return (0, "good", metric_name)
+        return AirMetricScore(severity_score=0, label="good", short_name=metric_name)
 
-    short_name = rules["short_name"]
     numeric_value = float(value)
 
-    if "thresholds" in rules:
-        score, label = _score_with_thresholds(numeric_value, rules["thresholds"])
+    if rules.thresholds:
+        score = _score_with_thresholds(numeric_value, rules.thresholds)
+    elif rules.ranges is not None:
+        score = _score_with_ranges(numeric_value, rules.ranges)
     else:
-        score, label = _score_with_ranges(numeric_value, rules["ranges"])
+        score = AirMetricScore(severity_score=0, label="good", short_name="")
 
-    return (score, label, short_name)
+    return AirMetricScore(
+        severity_score=score.severity_score,
+        label=score.label,
+        short_name=rules.short_name,
+    )
 
 
-def annotate_air_quality_cells(airmon: List[Dict[str, Any]]) -> None:
+def score_air_metric(metric_name: str, value: Any) -> tuple[int, str, str]:
+    """Return (severity_score, label, short_name) for a metric value."""
+    return score_air_metric_model(metric_name, value).as_tuple()
+
+
+def _air_quality_annotation(status: dict[str, Any]) -> AirQualityAnnotation:
+    """Build template CSS annotations for one indoor air-quality status payload."""
+    cell_classes: dict[str, str] = {}
+    for metric_name in [
+        "co2",
+        "pm25",
+        "pm1",
+        "humidity",
+        "temp",
+        "radonShortTermAvg",
+        "voc",
+    ]:
+        val_dict = status.get(metric_name)
+        value: Optional[float]
+        if isinstance(val_dict, dict):
+            value = val_dict.get(VALUE_KEY)
+        elif isinstance(val_dict, (int, float)):
+            value = float(val_dict)
+        else:
+            value = None
+
+        score = score_air_metric_model(metric_name, value)
+        if score.severity_score == 1:
+            cell_classes[metric_name] = "aq-elevated"
+        elif score.severity_score == 2:
+            cell_classes[metric_name] = "aq-problem"
+    return AirQualityAnnotation(aq_classes=cell_classes)
+
+
+def annotate_air_quality_cells(airmon: list[dict[str, Any]]) -> None:
     """Annotate indoor air-quality rows with CSS classes based on metric severity."""
     for row in airmon:
         status = row.get("status") or {}
         if "aqi" in status:
             continue
 
-        cell_classes: Dict[str, str] = {}
-        for metric_name in [
-            "co2",
-            "pm25",
-            "pm1",
-            "humidity",
-            "temp",
-            "radonShortTermAvg",
-            "voc",
-        ]:
-            val_dict = status.get(metric_name)
-            value: Optional[float]
-            if isinstance(val_dict, dict):
-                value = val_dict.get("value")
-            elif isinstance(val_dict, (int, float)):
-                value = float(val_dict)
-            else:
-                value = None
-
-            score, _label, _short_name = score_air_metric(metric_name, value)
-            if score == 1:
-                cell_classes[metric_name] = "aq-elevated"
-            elif score == 2:
-                cell_classes[metric_name] = "aq-problem"
-
-        if cell_classes:
-            row["aq_classes"] = cell_classes
+        annotation = _air_quality_annotation(status)
+        if annotation.aq_classes:
+            row["aq_classes"] = annotation.aq_classes
 
 
-def annotate_staleness(airmon: List[Dict[str, Any]]) -> None:
+def annotate_staleness(airmon: list[dict[str, Any]]) -> None:
     """Add ``age`` and ``is_stale`` to each device row for template rendering."""
     now_ts = int(time.time())
     for row in airmon:

--- a/tests/helpers/data_factories.py
+++ b/tests/helpers/data_factories.py
@@ -5,7 +5,20 @@ Test data factories for creating consistent test data.
 import json
 import time
 from typing import Dict, Any, Optional
+from pydantic import BaseModel, Field
+
 from app import db
+from app.models import StatusPayload, WeatherData, json_ready
+
+
+class AlertSpec(BaseModel):
+    """Validated alert fixture passed to create_device_with_alert."""
+
+    alert_type: str
+    status_json: StatusPayload
+    alert_start_time: int
+    alert_value: str = "ON"
+    end_time: int | None = Field(default=None)
 
 
 def alert_spec(
@@ -16,14 +29,15 @@ def alert_spec(
     end_time: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Build a dict suitable for create_device_with_alert(conn, device_name, spec)."""
-    out: Dict[str, Any] = {
-        "alert_type": alert_type,
-        "status_json": status_json,
-        "alert_start_time": alert_start_time,
-        "alert_value": alert_value,
-        "end_time": end_time,
-    }
-    return out
+    return json_ready(
+        AlertSpec(
+            alert_type=alert_type,
+            status_json=StatusPayload.model_validate(status_json),
+            alert_start_time=alert_start_time,
+            alert_value=alert_value,
+            end_time=end_time,
+        )
+    )
 
 
 class TestDataFactory:
@@ -63,13 +77,14 @@ class TestDataFactory:
         """Create a device with initial status data."""
         if logtime is None:
             logtime = int(time.time())
+        status_payload = StatusPayload.model_validate(status_dict).model_dump()
 
         device_id = db.get_or_create_device_id(conn, device_name)
         db.insert_devlog_entry(
             conn,
             device_id=device_id,
-            temp=float(status_dict.get("InletTemp", 24.0)),
-            statusdict=status_dict,
+            temp=float(status_payload.get("InletTemp", 24.0)),
+            statusdict=status_payload,
             logtime=logtime,
             force=True,
         )
@@ -78,10 +93,9 @@ class TestDataFactory:
     @staticmethod
     def create_mock_weather_data(temperature: int = 32) -> Dict[str, Any]:
         """Create mock weather data for testing."""
-        return {
-            "current": {"temperature": temperature, "conditions": "Sunny"},
-            "forecast": [],
-        }
+        return json_ready(
+            WeatherData(forecast=[{"temperature": temperature, "conditions": "Sunny"}])
+        )
 
     @staticmethod
     def create_mock_aqi_data() -> int:
@@ -91,12 +105,16 @@ class TestDataFactory:
     @staticmethod
     def create_broadway_south_initial_status() -> Dict[str, Any]:
         """Create initial status data for Broadway Test device."""
-        return {"Drive": "ON", "FanSpeed": "LOW", "InletTemp": "24.0"}
+        return StatusPayload.model_validate(
+            {"Drive": "ON", "FanSpeed": "LOW", "InletTemp": "24.0"}
+        ).model_dump()
 
     @staticmethod
     def create_no_speed_device_status() -> Dict[str, Any]:
         """Create status data for a device without speed control."""
-        return {"Drive": "ON", "InletTemp": "22.0"}
+        return StatusPayload.model_validate(
+            {"Drive": "ON", "InletTemp": "22.0"}
+        ).model_dump()
 
     @staticmethod
     def create_speed_mapping() -> Dict[int, str]:
@@ -118,12 +136,12 @@ class DeviceTestData:
     @staticmethod
     def get_initial_status() -> Dict[str, Any]:
         """Get initial status for Broadway Test."""
-        return {"Drive": "ON", "FanSpeed": "LOW", "InletTemp": "24.0"}
+        return TestDataFactory.create_broadway_south_initial_status()
 
     @staticmethod
     def get_no_speed_status() -> Dict[str, Any]:
         """Get status for device without speed control."""
-        return {"Drive": "ON", "InletTemp": "22.0"}
+        return TestDataFactory.create_no_speed_device_status()
 
     @staticmethod
     def get_speed_names() -> Dict[int, str]:
@@ -144,10 +162,9 @@ class WeatherTestData:
         temperature: int = 32, conditions: str = "Sunny"
     ) -> Dict[str, Any]:
         """Get mock weather data."""
-        return {
-            "current": {"temperature": temperature, "conditions": conditions},
-            "forecast": [],
-        }
+        return json_ready(
+            WeatherData(forecast=[{"temperature": temperature, "conditions": conditions}])
+        )
 
     @staticmethod
     def get_mock_aqi(aqi_value: int = 45) -> int:

--- a/tests/helpers/mock_helpers.py
+++ b/tests/helpers/mock_helpers.py
@@ -3,32 +3,42 @@ Mock helpers for consistent test mocking patterns.
 """
 from typing import Any, Dict
 
+from app.models import WeatherData, WeatherStation, json_ready
+
 
 class MockHelper:
     """Helper class for setting up common mocks."""
 
     @staticmethod
-    def setup_weather_mocks(mock_get_airquality, mock_get_weather_data,
-                           aqi_value: int = 45, temperature: int = 32):
+    def setup_weather_mocks(
+        mock_get_airquality,
+        mock_get_weather_data,
+        aqi_value: int = 45,
+        temperature: int = 32,
+    ):
         """Setup common weather and AQI mocks."""
         mock_get_airquality.return_value = aqi_value
-        mock_get_weather_data.return_value = {
-            "stations": [{"temperature": temperature, "conditions": "Sunny",
-                          "icon": "", "station_name": "Test Station"}],
-            "forecast": [],
-            "daily": [],
-        }
+        mock_get_weather_data.return_value = MockHelper.create_mock_weather_data(
+            temperature=temperature
+        )
 
 
     @staticmethod
-    def create_mock_weather_data(temperature: int = 32, conditions: str = "Sunny") -> Dict[str, Any]:
+    def create_mock_weather_data(
+        temperature: int = 32, conditions: str = "Sunny"
+    ) -> Dict[str, Any]:
         """Create mock weather data for testing."""
-        return {
-            "stations": [{"temperature": temperature, "conditions": conditions,
-                          "icon": "", "station_name": "Test Station"}],
-            "forecast": [],
-            "daily": [],
-        }
+        return json_ready(
+            WeatherData(
+                stations=[
+                    WeatherStation(
+                        temperature=temperature,
+                        conditions=conditions,
+                        station_name="Test Station",
+                    )
+                ]
+            )
+        )
 
     @staticmethod
     def create_mock_aqi_data(aqi_value: int = 45) -> int:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -253,6 +253,19 @@ def test_weather_endpoint(
     assert "weather" in response_json
 
 
+@patch("app.weather.get_weather_data")
+def test_weather_endpoint_preserves_weather_errors(
+    mock_get_weather_data, flask_test_client
+):  # noqa: F811
+    """Weather service errors remain visible in the API response."""
+    mock_get_weather_data.return_value = {"error": "weather offline"}
+
+    response = flask_test_client.get("/api/v1/weather")
+
+    assert response.status_code == 200
+    assert response.json["weather"] == {"error": "weather offline"}
+
+
 # pylint: disable=too-many-arguments, disable=too-many-positional-arguments
 BROADWAY_SOUTH = 10
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -495,7 +495,7 @@ def test_tv_hubitat_error(_mock, flask_test_client):  # noqa: F811
 
 def test_room_config_kitchen_has_fcu():
     """Kitchen must list its FCU so set-temp controls render."""
-    fans = room_config.ROOM_CONFIGS["kitchen"]["fans"]
+    fans = room_config.ROOM_CONFIGS["kitchen"].fans
     assert "Kitchen" in fans
 
 
@@ -503,7 +503,7 @@ def test_room_config_erv_names_start_with_erv():
     """ERV device names must start with 'ERV' — the template uses device_type
     to decide whether to show set-temp controls (fans only, not ERVs)."""
     for room_key, config in room_config.ROOM_CONFIGS.items():
-        for name in config.get("ervs", []):
+        for name in config.ervs:
             assert name.startswith("ERV"), (
                 f"{room_key} ERV device '{name}' must start with 'ERV'"
             )
@@ -520,7 +520,7 @@ def test_room_config_no_erv_in_fans():
     temperature controls that send meaningless API calls.
     """
     for room_key, config in room_config.ROOM_CONFIGS.items():
-        for fan_name in config.get("fans", []):
+        for fan_name in config.fans:
             assert not fan_name.startswith("ERV"), (
                 f"{room_key} fans list contains ERV device '{fan_name}'"
             )


### PR DESCRIPTION
## Summary

Replace remaining stable dict-shaped internal contracts with Pydantic models.

- Add typed models for room config, status payloads, time series, changelog responses, AQ/weather responses, command responses, and air-quality scoring/annotation rules.
- Route DB/API/template-boundary data through Pydantic validation before dumping JSON-ready mappings.
- Keep external/vendor payload dictionaries at the edge, with shared keys centralized.
- Update test helpers to validate generated fixture payloads.
- Document the motivation for these contracts in the top-level README.

Closes #126.

## Validation

- `make check`
- `SKIP_BROWSER_TEST=1 make test`
- `git diff --check`