### PR TITLE
Refine dashboard freshness handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,14 +157,14 @@ validate-migrations:
 # Run web backend locally, with simulated data. (needs populated db too)
 local-dev: $(REQ)
 	@echo Running with simulator
-	export AE200_SIMULATOR=1 && $(MAKE) _local-dev-web
+	export AE200_SIMULATOR=1 HUBITAT_SIMULATOR=1 AIRTHINGS_SIMULATOR=1 && $(MAKE) _local-dev-web
 
 # Run web backend locally against live AE-200 hardware.
 local-live-dev: $(REQ)
 	@echo updating database
-	make every-minute
+	AE200_SIMULATOR= HUBITAT_SIMULATOR= AIRTHINGS_SIMULATOR= $(MAKE) every-minute
 	@echo Running without simulator
-	AE200_SIMULATOR= $(MAKE) _local-dev-web
+	AE200_SIMULATOR= HUBITAT_SIMULATOR= AIRTHINGS_SIMULATOR= $(MAKE) _local-dev-web
 
 # Shared web backend runner for local-dev and local-live-dev.
 _local-dev-web: $(REQ)

--- a/app/constants.py
+++ b/app/constants.py
@@ -12,6 +12,9 @@ RULES_DISABLE_SECONDS = 60*60*3
 # calculated room temperature.
 TEMP_SOURCE_STALE_SECONDS = 10 * 60
 
+# Air-quality-like devices older than this are hidden from the main dashboard.
+DASHBOARD_AIR_QUALITY_DEVICE_EXPIRATION_SECONDS = 30 * 24 * 60 * 60
+
 # FCU set ranges must be at least this wide, in degrees Celsius.
 MIN_SET_RANGE_C = 3.0
 DEFAULT_SET_RANGE_CENTER_C = 21.0

--- a/app/db.py
+++ b/app/db.py
@@ -724,7 +724,8 @@ def fetch_last_status(conn, flag=EVERY_DEVICE):
     cursor = conn.cursor()
     cursor.execute(f"""
         SELECT a.*,b.device_name,b.display_name,b.device_type,b.rules_enabled,
-               b.ae200_device_id,b.notes,b.disabled_until,b.room_id,r.room_name
+               b.aqi_mon,b.ae200_device_id,b.notes,b.disabled_until,
+               b.room_id,r.room_name
         FROM (SELECT * FROM devlog GROUP BY device_id HAVING logtime=max(logtime)) AS a
         JOIN devices b ON a.device_id = b.device_id
         LEFT JOIN rooms r ON b.room_id = r.room_id

--- a/app/models.py
+++ b/app/models.py
@@ -488,6 +488,10 @@ class DeviceStatus(BaseModel):
         description="Age cutoff for excluding stale calculated-temperature sources.",
     )
     notes: str | None = Field(default=None, description="Operator note from the devices table.")
+    aqi_mon: bool | None = Field(
+        default=None,
+        description="Whether the device is configured as an indoor air-quality monitor.",
+    )
     room_id: int | None = Field(default=None, description="Assigned room id.")
     room_name: str | None = Field(default=None, description="Assigned room name.")
     disabled_until: int | None = Field(
@@ -538,6 +542,7 @@ class DeviceStatus(BaseModel):
         default=None,
         description="Maximum allowed AE-200 Auto set temperature in degrees Celsius.",
     )
+
     set_range_low_c: float | None = Field(
         default=None,
         description="Lower configured FCU set-range end in degrees Celsius.",
@@ -550,6 +555,16 @@ class DeviceStatus(BaseModel):
         default=None,
         description="System-wide minimum FCU set-range width in degrees Celsius.",
     )
+
+
+class TableUpdateSummary(BaseModel):
+    """Oldest timestamp represented by the data currently shown in a table."""
+
+    oldest_update_at: int
+    oldest_update_datetime: str
+    oldest_update_age: str
+    source_device_name: str | None = None
+    label: str
 
 
 def json_ready(model: BaseModel) -> Dict[str, Any]:

--- a/app/routes_web.py
+++ b/app/routes_web.py
@@ -11,18 +11,22 @@
 import logging
 import datetime
 import time
+from collections.abc import Callable
+from typing import Any
 from flask import render_template, request, redirect, url_for
 
 from .constants import __version__
+from .constants import DASHBOARD_AIR_QUALITY_DEVICE_EXPIRATION_SECONDS
 from . import db
 from . import db_alerts
 from . import rules_engine
 from . import hubitat
 from . import room_config
 from .display_names import display_device_name
-from .models import DeviceMetadataControl
+from .models import DeviceMetadataControl, TableUpdateSummary
 from .utils.request_utils import parse_device_ids
 from .utils.db_utils import with_db_connection
+from .util import github_style_duration
 from .routes_web_airquality_utils import (
     annotate_staleness,
     format_unix_as_asc,
@@ -87,6 +91,116 @@ METRIC_CHART_CONFIG = {
 }
 
 
+def _status_update_timestamp(row: dict[str, Any]) -> int | None:
+    """Return the timestamp when a status row stopped being current."""
+    try:
+        logtime = int(row["logtime"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    try:
+        duration_value = row.get("duration", 1)
+        duration = int(1 if duration_value is None else duration_value)
+    except (TypeError, ValueError):
+        duration = 1
+    return logtime + duration
+
+
+def _dashboard_air_quality_device_is_active(device: dict[str, Any], now: int) -> bool:
+    """Return whether a device belongs in the dashboard Air Quality table."""
+    if device.get("has_speed_control") or device.get("temp10x") is None:
+        return False
+    updated_at = _status_update_timestamp(device)
+    if updated_at is None:
+        return False
+    return now - updated_at <= DASHBOARD_AIR_QUALITY_DEVICE_EXPIRATION_SECONDS
+
+
+def _table_update_summary(
+    devices: list[dict[str, Any]],
+    include_device: Callable[[dict[str, Any]], bool],
+    now: int,
+) -> TableUpdateSummary | None:
+    """Summarize the oldest updated timestamp represented in a table."""
+    candidates = [
+        (update_time, _dashboard_device_label(device))
+        for device in devices
+        if include_device(device)
+        for update_time in [_status_update_timestamp(device)]
+        if update_time is not None
+    ]
+    if not candidates:
+        return None
+
+    oldest_update_at, source_device_name = min(candidates, key=lambda item: item[0])
+    oldest_update_datetime = format_unix_as_asc(oldest_update_at) or ""
+    oldest_update_age = github_style_duration(oldest_update_at, now=now)
+    return TableUpdateSummary(
+        oldest_update_at=oldest_update_at,
+        oldest_update_datetime=oldest_update_datetime,
+        oldest_update_age=oldest_update_age,
+        source_device_name=source_device_name,
+        label=(
+            f"(oldest update at {oldest_update_datetime} - "
+            f"{oldest_update_age} ago from {source_device_name})"
+        ),
+    )
+
+
+def _index_table_update_summaries(
+    devices: list[dict[str, Any]], now: int
+) -> dict[str, TableUpdateSummary | None]:
+    """Build update summaries for the index page's three device tables."""
+    return {
+        "erv": _table_update_summary(
+            devices,
+            lambda device: device.get("device_type") == "ERV",
+            now,
+        ),
+        "fcu": _table_update_summary(
+            devices,
+            lambda device: device.get("device_type") == "FCU",
+            now,
+        ),
+        "air_quality": _table_update_summary(
+            devices,
+            lambda device: _dashboard_air_quality_device_is_active(device, now),
+            now,
+        ),
+    }
+
+
+def _dashboard_device_label(device: dict[str, Any]) -> str:
+    """Return a dashboard label without doing live network enrichment."""
+    raw_name = device.get("device_name", "")
+    status = device.get("status") or {}
+    stored_label = status.get("label") if isinstance(status, dict) else None
+    return device.get("display_name") or display_device_name(
+        raw_name,
+        hubitat_label=stored_label,
+        source="db",
+    )
+
+
+def _dashboard_device_tooltip(device: dict[str, Any], now: int) -> str:
+    """Return the Unit-column tooltip for a device row."""
+    device_name = device.get("device_name", "")
+    update_text = _dashboard_device_update_text(device, now)
+    if not update_text:
+        return device_name
+    return f"{device_name}\nLast updated at {update_text}"
+
+
+def _dashboard_device_update_text(device: dict[str, Any], now: int) -> str:
+    """Return the last-update text shown in device metadata UI."""
+    updated_at = _status_update_timestamp(device)
+    if updated_at is None:
+        return ""
+    updated_datetime = format_unix_as_asc(updated_at) or ""
+    updated_age = github_style_duration(updated_at, now=now)
+    return f"{updated_datetime} - {updated_age} ago"
+
+
 def _register_core_routes(app):
     """Register core web routes that back the main navigation."""
 
@@ -97,27 +211,23 @@ def _register_core_routes(app):
         # Get device data for the template
         device_data = db.get_device_status(conn)
 
-        # Enrich with Hubitat label for display (Air Quality section).
-        # The central helper handles any display-only transforms so we can
-        # easily tweak naming strategy in one place.
-        name_to_label = hubitat.get_name_to_label()
-        for d in device_data:
-            raw_name = d.get("device_name", "")
-            hub_label = name_to_label.get(raw_name)
-            d["device_label"] = d.get("display_name") or display_device_name(
-                raw_name,
-                hubitat_label=hub_label,
-                source="hubitat",
-            )
-
-        # Add current timestamp for temporal links
+        # Add current timestamp for temporal links and update-age labels.
         now = int(time.time())
+
+        for d in device_data:
+            d["device_label"] = _dashboard_device_label(d)
+            d["device_update_text"] = _dashboard_device_update_text(d, now)
+            d["device_update_tooltip"] = _dashboard_device_tooltip(d, now)
+            d["dashboard_air_quality_active"] = (
+                _dashboard_air_quality_device_is_active(d, now)
+            )
 
         return render_template(
             "index.html",
             develop=False,
             devices=device_data,
             now=now,
+            table_update_summaries=_index_table_update_summaries(device_data, now),
             current_page="home",
         )
 

--- a/app/routes_web.py
+++ b/app/routes_web.py
@@ -11,18 +11,22 @@
 import logging
 import datetime
 import time
+from collections.abc import Callable
+from typing import Any
 from flask import render_template, request, redirect, url_for
 
 from .constants import __version__
+from .constants import DASHBOARD_AIR_QUALITY_DEVICE_EXPIRATION_SECONDS
 from . import db
 from . import db_alerts
 from . import rules_engine
 from . import hubitat
 from . import room_config
 from .display_names import display_device_name
-from .models import DeviceMetadataControl
+from .models import DeviceMetadataControl, TableUpdateSummary
 from .utils.request_utils import parse_device_ids
 from .utils.db_utils import with_db_connection
+from .util import github_style_duration
 from .routes_web_airquality_utils import (
     annotate_staleness,
     format_unix_as_asc,
@@ -87,6 +91,117 @@ METRIC_CHART_CONFIG = {
 }
 
 
+def _status_update_timestamp(row: dict[str, Any]) -> int | None:
+    """Return the timestamp when a status row stopped being current."""
+    try:
+        logtime = int(row["logtime"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    try:
+        duration_value = row.get("duration", 1)
+        duration = int(1 if duration_value is None else duration_value)
+    except (TypeError, ValueError):
+        duration = 1
+    return logtime + duration
+
+
+def _dashboard_air_quality_device_is_active(device: dict[str, Any], now: int) -> bool:
+    """Return whether a device belongs in the dashboard Air Quality table."""
+    if device.get("has_speed_control") or device.get("temp10x") is None:
+        return False
+    updated_at = _status_update_timestamp(device)
+    if updated_at is None:
+        return False
+    return now - updated_at <= DASHBOARD_AIR_QUALITY_DEVICE_EXPIRATION_SECONDS
+
+
+def _table_update_summary(
+    devices: list[dict[str, Any]],
+    include_device: Callable[[dict[str, Any]], bool],
+    now: int,
+) -> TableUpdateSummary | None:
+    """Summarize the oldest updated timestamp represented in a table."""
+    candidates = [
+        (update_time, _dashboard_device_label(device))
+        for device in devices
+        if include_device(device)
+        for update_time in [_status_update_timestamp(device)]
+        if update_time is not None
+    ]
+    if not candidates:
+        return None
+
+    oldest_update_at, source_device_name = min(candidates, key=lambda item: item[0])
+    oldest_update_datetime = format_unix_as_asc(oldest_update_at) or ""
+    oldest_update_age = github_style_duration(oldest_update_at, now=now)
+    return TableUpdateSummary(
+        oldest_update_at=oldest_update_at,
+        oldest_update_datetime=oldest_update_datetime,
+        oldest_update_age=oldest_update_age,
+        source_device_name=source_device_name,
+        label=(
+            f"(oldest update at {oldest_update_datetime} - "
+            f"{oldest_update_age} ago from {source_device_name})"
+        ),
+    )
+
+
+def _index_table_update_summaries(
+    devices: list[dict[str, Any]], now: int
+) -> dict[str, TableUpdateSummary | None]:
+    """Build update summaries for the index page's three device tables."""
+    return {
+        "erv": _table_update_summary(
+            devices,
+            lambda device: device.get("device_type") == "ERV",
+            now,
+        ),
+        "fcu": _table_update_summary(
+            devices,
+            lambda device: device.get("device_type") == "FCU",
+            now,
+        ),
+        "air_quality": _table_update_summary(
+            devices,
+            lambda device: _dashboard_air_quality_device_is_active(device, now),
+            now,
+        ),
+    }
+
+
+def _dashboard_device_label(device: dict[str, Any]) -> str:
+    """Return a dashboard label without doing live network enrichment."""
+    raw_name = device.get("device_name", "")
+    status = device.get("status") or {}
+    stored_label = status.get("label") if isinstance(status, dict) else None
+    return device.get("display_name") or display_device_name(
+        raw_name,
+        hubitat_label=stored_label,
+        source="db",
+    )
+
+
+def _dashboard_device_tooltip(device: dict[str, Any], now: int) -> str:
+    """Return the Unit-column tooltip for a device row."""
+    raw_device_name = device.get("device_name", "")
+    device_name = raw_device_name if isinstance(raw_device_name, str) else ""
+    update_text = _dashboard_device_update_text(device, now)
+    if not update_text:
+        return device_name
+    return f"{device_name}\nLast updated at {update_text}"
+
+
+def _dashboard_device_update_text(device: dict[str, Any], now: int) -> str:
+    """Return the last-update text shown in device metadata UI."""
+    updated_at = _status_update_timestamp(device)
+    if updated_at is None:
+        return ""
+    updated_datetime = format_unix_as_asc(updated_at) or ""
+    updated_age = github_style_duration(updated_at, now=now)
+    return f"{updated_datetime} - {updated_age} ago"
+
+
 def _register_core_routes(app):
     """Register core web routes that back the main navigation."""
 
@@ -97,27 +212,23 @@ def _register_core_routes(app):
         # Get device data for the template
         device_data = db.get_device_status(conn)
 
-        # Enrich with Hubitat label for display (Air Quality section).
-        # The central helper handles any display-only transforms so we can
-        # easily tweak naming strategy in one place.
-        name_to_label = hubitat.get_name_to_label()
-        for d in device_data:
-            raw_name = d.get("device_name", "")
-            hub_label = name_to_label.get(raw_name)
-            d["device_label"] = d.get("display_name") or display_device_name(
-                raw_name,
-                hubitat_label=hub_label,
-                source="hubitat",
-            )
-
-        # Add current timestamp for temporal links
+        # Add current timestamp for temporal links and update-age labels.
         now = int(time.time())
+
+        for d in device_data:
+            d["device_label"] = _dashboard_device_label(d)
+            d["device_update_text"] = _dashboard_device_update_text(d, now)
+            d["device_update_tooltip"] = _dashboard_device_tooltip(d, now)
+            d["dashboard_air_quality_active"] = (
+                _dashboard_air_quality_device_is_active(d, now)
+            )
 
         return render_template(
             "index.html",
             develop=False,
             devices=device_data,
             now=now,
+            table_update_summaries=_index_table_update_summaries(device_data, now),
             current_page="home",
         )
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -127,18 +127,26 @@ body {
 
 .settemp-thermostat .settemp-display,
 .disable-thermostat .disable-display {
-    min-width: 3.5em;
     text-align: center;
     font-weight: 600;
     color: #1a202c;
 }
 
+.settemp-thermostat .settemp-display {
+    min-width: 3em;
+}
+
+.disable-thermostat .disable-display {
+    min-width: 0;
+    text-align: center;
+}
+
 /* Thermostat adjust: wide tap targets, minimal look — doesn’t add row height */
 .settemp-thermostat .settemp-btn,
 .disable-thermostat .disable-btn {
-    /* Wide enough for touch (44px min); no min-height so row stays compact */
-    min-width: 44px;
-    padding: 0.2rem 0.35rem;
+    width: auto;
+    min-width: 0;
+    padding: 0.15rem 4px;
     font-size: 1.1rem;
     font-weight: 600;
     line-height: 1;
@@ -232,7 +240,7 @@ button {
 
 .column-temp-set,
 .cell-temp-set {
-    min-width: 160px;
+    min-width: 96px;
 }
 
 .column-temp-range,
@@ -292,8 +300,8 @@ button {
 
 .cell-disable-for {
     text-align: center;
-    padding-left: 0.5em;
-    padding-right: 0.5em;
+    padding-left: 4px;
+    padding-right: 4px;
 }
 
 .data-table tbody td.cell-mode {
@@ -325,18 +333,30 @@ button {
     text-align: center;
 }
 
+.data-table tbody td.cell-disable-for {
+    text-align: center;
+}
+
+.data-table tbody td.cell-disable-for.rules-disabled-active {
+    text-align: left;
+}
+
+.data-table tbody td.cell-temp-set {
+    text-align: left;
+}
+
 .setrange-widget {
     width: 190px;
     display: flex;
     flex-direction: column;
-    gap: 0.2rem;
-    padding: 0.15rem 0;
+    gap: 0.05rem;
+    padding: 0;
 }
 
 .setrange-track {
     position: relative;
     width: 100%;
-    height: 20px;
+    height: 16px;
     touch-action: none;
     cursor: pointer;
 }
@@ -346,16 +366,16 @@ button {
     position: absolute;
     left: 0;
     right: 0;
-    top: 7px;
-    height: 6px;
+    top: 6px;
+    height: 4px;
     border-radius: 999px;
     background: #d7dde3;
 }
 
 .setrange-fill {
     position: absolute;
-    top: 7px;
-    height: 6px;
+    top: 6px;
+    height: 4px;
     border-radius: 999px;
     background: #2f855a;
     cursor: grab;
@@ -369,8 +389,8 @@ button {
 .setrange-handle {
     position: absolute;
     top: 50%;
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
     padding: 0;
     border: 2px solid #1f2937;
     border-radius: 50%;
@@ -391,9 +411,9 @@ button {
     justify-content: space-between;
     align-items: center;
     gap: 0.2rem;
-    font-size: 0.85rem;
+    font-size: 0.78rem;
     font-weight: 600;
-    line-height: 1;
+    line-height: 0.95;
     color: #1a202c;
 }
 
@@ -406,14 +426,14 @@ button {
     width: 190px;
     display: flex;
     flex-direction: column;
-    gap: 0.2rem;
-    padding: 0.15rem 0;
+    gap: 0.05rem;
+    padding: 0;
 }
 
 .autosettemp-track {
     position: relative;
     width: 100%;
-    height: 20px;
+    height: 16px;
 }
 
 .autosettemp-track::before {
@@ -421,16 +441,16 @@ button {
     position: absolute;
     left: 0;
     right: 0;
-    top: 7px;
-    height: 6px;
+    top: 6px;
+    height: 4px;
     border-radius: 999px;
     background: #d7dde3;
 }
 
 .autosettemp-fill {
     position: absolute;
-    top: 7px;
-    height: 6px;
+    top: 6px;
+    height: 4px;
     border-radius: 999px;
     background: #805ad5;
 }
@@ -438,8 +458,8 @@ button {
 .autosettemp-handle {
     position: absolute;
     top: 50%;
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
     border: 2px solid #1f2937;
     border-radius: 50%;
     background: #fff;
@@ -450,9 +470,9 @@ button {
     display: flex;
     justify-content: space-between;
     gap: 0.2rem;
-    font-size: 0.78rem;
+    font-size: 0.74rem;
     font-weight: 600;
-    line-height: 1.05;
+    line-height: 0.95;
     color: #1a202c;
 }
 
@@ -901,6 +921,54 @@ td.cell-speed-auto {
 .cell-unit {
     white-space: nowrap;
     vertical-align: top;
+}
+
+.data-table th {
+    padding-top: 6px;
+    padding-bottom: 6px;
+}
+
+.data-table tr.device-row td {
+    padding-top: 4px;
+    padding-bottom: 4px;
+}
+
+.data-table thead th.column-disable-for,
+.data-table thead th.column-temp-set,
+.data-table tbody td.cell-disable-for,
+.data-table tbody td.cell-temp-set {
+    padding-left: 4px !important;
+    padding-right: 4px !important;
+}
+
+table.data-table tbody tr.device-row td.cell-temp-set {
+    padding-left: 4px !important;
+    padding-right: 4px !important;
+    text-align: left !important;
+}
+
+.data-table .settemp-thermostat .settemp-btn,
+.data-table .disable-thermostat .disable-btn {
+    width: auto;
+    min-width: 0;
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
+.data-table .editable-notes {
+    padding-top: 2px;
+    padding-bottom: 2px;
+    min-height: 1.2em;
+}
+
+.table-update-summary {
+    color: #666;
+    font-size: 0.85em;
+    font-style: italic;
+    border-top: 1px solid #d6d6d6;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    text-align: left;
 }
 
 /* optional: make tables respect the column width instead of expanding it */

--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -16,6 +16,7 @@ const DEBUG = false;
 const REFRESH_INTERVAL = 10; // seconds between refreshes
 const RUNNING_MINUTES = 10; // minutes to run before stopping
 const SHOW_REFRESH_COUNTDOWN = false;
+const DASHBOARD_AIR_QUALITY_DEVICE_EXPIRATION_SECONDS = 30 * 24 * 60 * 60;
 let lastRefreshTime = 0;
 const AE200_MODE_LABELS = {
   COOL: "Cool",
@@ -107,6 +108,196 @@ function modeValueForDevice(dev) {
 
 function isAutoOperationMode(rawMode) {
   return AE200_AUTO_MODE_VALUES.includes(String(rawMode || "").toUpperCase());
+}
+
+function deviceUpdateTimestampSeconds(dev) {
+  if (!dev || dev.logtime == null) {
+    return null;
+  }
+  const logtime = Number(dev.logtime);
+  if (!Number.isFinite(logtime)) {
+    return null;
+  }
+  const duration = dev.duration == null ? 1 : Number(dev.duration);
+  return Math.floor(logtime + (Number.isFinite(duration) ? duration : 1));
+}
+
+function dashboardAirQualityDeviceIsActive(dev, nowDate = new Date()) {
+  if (dev?.has_speed_control || dev?.temp10x == null) {
+    return false;
+  }
+  const updatedAt = deviceUpdateTimestampSeconds(dev);
+  if (updatedAt == null) {
+    return false;
+  }
+  return (
+    nowDate.getTime() / 1000 - updatedAt <=
+    DASHBOARD_AIR_QUALITY_DEVICE_EXPIRATION_SECONDS
+  );
+}
+
+function updateDashboardAirQualityRowVisibility(dev, nowDate = new Date()) {
+  if (dev?.has_speed_control || dev?.temp10x == null) {
+    return;
+  }
+  const row = document.querySelector(
+    `.device-row[x-data-device-id="${dev.device_id}"]`,
+  );
+  if (row) {
+    row.classList.toggle("hidden", !dashboardAirQualityDeviceIsActive(dev, nowDate));
+  }
+}
+
+function indexTableIncludesDevice(tableName, dev, nowDate = new Date()) {
+  if (tableName === "erv") {
+    return dev.device_type === "ERV";
+  }
+  if (tableName === "fcu") {
+    return dev.device_type === "FCU";
+  }
+  if (tableName === "air-quality") {
+    return dashboardAirQualityDeviceIsActive(dev, nowDate);
+  }
+  return false;
+}
+
+function displayNameForDevice(dev) {
+  return dev?.display_name || dev?.device_label || dev?.device_name || "";
+}
+
+function oldestUpdateForTable(devices, tableName, nowDate = new Date()) {
+  if (!Array.isArray(devices)) {
+    return null;
+  }
+  let oldest = null;
+  for (const dev of devices) {
+    if (!indexTableIncludesDevice(tableName, dev, nowDate)) {
+      continue;
+    }
+    const updateTime = deviceUpdateTimestampSeconds(dev);
+    if (
+      updateTime != null &&
+      (oldest == null || updateTime < oldest.timestampSeconds)
+    ) {
+      oldest = {
+        timestampSeconds: updateTime,
+        deviceName: displayNameForDevice(dev),
+      };
+    }
+  }
+  return oldest;
+}
+
+function oldestUpdateTimestampForTable(devices, tableName, nowDate = new Date()) {
+  return oldestUpdateForTable(devices, tableName, nowDate)?.timestampSeconds ?? null;
+}
+
+function compactAgeFromSeconds(ageSeconds) {
+  const seconds = Math.max(0, Math.floor(ageSeconds));
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  if (days < 30) {
+    return `${days}d`;
+  }
+  const months = Math.floor(days / 30);
+  if (months < 12) {
+    return `${months}mo`;
+  }
+  return `${Math.floor(months / 12)}y`;
+}
+
+function padDatePart(value) {
+  return String(value).padStart(2, "0");
+}
+
+function localDateTimeFromTimestamp(timestampSeconds) {
+  const date = new Date(timestampSeconds * 1000);
+  return [
+    date.getFullYear(),
+    "-",
+    padDatePart(date.getMonth() + 1),
+    "-",
+    padDatePart(date.getDate()),
+    " ",
+    padDatePart(date.getHours()),
+    ":",
+    padDatePart(date.getMinutes()),
+    ":",
+    padDatePart(date.getSeconds()),
+  ].join("");
+}
+
+function tableUpdateSummaryText(
+  timestampSeconds,
+  nowDate = new Date(),
+  sourceDeviceName = "",
+) {
+  if (timestampSeconds == null) {
+    return "";
+  }
+  const ageSeconds = nowDate.getTime() / 1000 - timestampSeconds;
+  const sourceSuffix = sourceDeviceName ? ` from ${sourceDeviceName}` : "";
+  return (
+    `(oldest update at ${localDateTimeFromTimestamp(timestampSeconds)} - ` +
+    `${compactAgeFromSeconds(ageSeconds)} ago${sourceSuffix})`
+  );
+}
+
+function deviceUpdateText(dev, nowDate = new Date()) {
+  const timestampSeconds = deviceUpdateTimestampSeconds(dev);
+  if (timestampSeconds == null) {
+    return "";
+  }
+  const ageText =
+    dev?.age || compactAgeFromSeconds(nowDate.getTime() / 1000 - timestampSeconds);
+  return `${localDateTimeFromTimestamp(timestampSeconds)} - ${ageText} ago`;
+}
+
+function deviceUpdateTooltipText(dev, fallbackDeviceName = "", nowDate = new Date()) {
+  const deviceName = dev?.device_name || fallbackDeviceName || "";
+  const updateText = deviceUpdateText(dev, nowDate);
+  if (!updateText) {
+    return deviceName;
+  }
+  return `${deviceName}\nLast updated at ${updateText}`;
+}
+
+function updateDeviceNameTooltip(dev, nowDate = new Date()) {
+  const labels = document.querySelectorAll(
+    `.device-name-context[data-device-id="${dev.device_id}"]`,
+  );
+  labels.forEach((element) => {
+    element.dataset.deviceUpdate = deviceUpdateText(dev, nowDate);
+    element.setAttribute(
+      "title",
+      deviceUpdateTooltipText(dev, element.dataset.deviceName || "", nowDate),
+    );
+  });
+}
+
+function updateTableUpdateSummaries(devices, nowDate = new Date()) {
+  for (const tableName of ["erv", "fcu", "air-quality"]) {
+    const element = document.getElementById(`oldest-update-${tableName}`);
+    if (!element) {
+      continue;
+    }
+    const summary = oldestUpdateForTable(devices, tableName, nowDate);
+    element.textContent = tableUpdateSummaryText(
+      summary?.timestampSeconds,
+      nowDate,
+      summary?.deviceName,
+    );
+  }
 }
 
 function ensureModeSelectOption(select, rawMode) {
@@ -755,6 +946,7 @@ function setDeviceRenameControlsDisabled(popup, disabled) {
     const rulesEnabledInput = document.getElementById(
       "device-rename-rules-enabled",
     );
+    const lastUpdateInput = document.getElementById("device-rename-last-update");
     if (deviceNameInput) {
       deviceNameInput.readOnly = true;
     }
@@ -763,6 +955,9 @@ function setDeviceRenameControlsDisabled(popup, disabled) {
     }
     if (rulesEnabledInput) {
       rulesEnabledInput.disabled = true;
+    }
+    if (lastUpdateInput) {
+      lastUpdateInput.readOnly = true;
     }
     setDeviceRenameButtonState(popup);
   }
@@ -779,6 +974,7 @@ function closeDeviceRenamePopup() {
   delete popup.dataset.deviceName;
   delete popup.dataset.deviceType;
   delete popup.dataset.rulesEnabled;
+  delete popup.dataset.deviceUpdate;
   delete popup.dataset.currentDisplayName;
 }
 
@@ -819,6 +1015,7 @@ function openDeviceRenamePopup(target, event) {
   const popup = document.getElementById("device-rename-popup");
   const deviceNameInput = document.getElementById("device-rename-device-name");
   const displayNameInput = document.getElementById("device-rename-display-name");
+  const lastUpdateInput = document.getElementById("device-rename-last-update");
   if (!popup || !deviceNameInput || !displayNameInput) {
     return;
   }
@@ -831,14 +1028,19 @@ function openDeviceRenamePopup(target, event) {
     target.dataset.deviceName || target.getAttribute("title") || target.textContent;
   const displayName = target.dataset.displayName || target.textContent;
   const deviceType = target.dataset.deviceType || "";
+  const deviceUpdate = target.dataset.deviceUpdate || "";
   const rulesEnabled =
     target.dataset.rulesEnabled === undefined ? true : target.dataset.rulesEnabled;
 
   popup.dataset.deviceId = String(deviceId);
   popup.dataset.deviceName = deviceName;
+  popup.dataset.deviceUpdate = deviceUpdate;
   popup.dataset.currentDisplayName = displayName;
   deviceNameInput.value = deviceName;
   displayNameInput.value = displayName;
+  if (lastUpdateInput) {
+    lastUpdateInput.value = deviceUpdate || "--";
+  }
   setDeviceReadonlyMetadata(popup, deviceType, rulesEnabled);
 
   popup.classList.remove("hidden");
@@ -895,7 +1097,12 @@ function applyDeviceDisplayName(
           deviceRulesEnabledValue(rulesEnabled),
         );
       }
-      element.setAttribute("title", deviceName);
+      element.setAttribute(
+        "title",
+        element.dataset.deviceUpdate
+          ? `${deviceName}\nLast updated at ${element.dataset.deviceUpdate}`
+          : deviceName,
+      );
     });
 }
 
@@ -1828,8 +2035,10 @@ const refreshGridRows = () => {
         }
 
         // Update the tables with the new data
+        const refreshDate = new Date();
         if (data.devices)
           for (const dev of data.devices) {
+            updateDashboardAirQualityRowVisibility(dev, refreshDate);
             updateTemperatureCell(
               document.getElementById(`temp-${dev.device_id}`),
               dev.temp10x,
@@ -1995,9 +2204,11 @@ const refreshGridRows = () => {
             }
             updateDeviceNotes(dev);
             updateDeviceDisplayName(dev);
+            updateDeviceNameTooltip(dev);
             updateRulesDisabledBadge(dev);
             updateDisableForCell(dev);
           }
+        updateTableUpdateSummaries(data.devices || [], refreshDate);
 
         // Update last refresh time
         const lr = document.getElementById("last-refresh");
@@ -2199,6 +2410,7 @@ function renderDisableCell(deviceId, until) {
   const now = Math.floor(Date.now() / 1000);
   const secondsRemaining = (until || 0) - now;
   if (secondsRemaining <= 0) {
+    cell?.classList.remove("rules-disabled-active");
     display.textContent = "—";
     display.removeAttribute("data-disabled-until");
     buttons.forEach((b) => b.classList.add("hidden"));
@@ -2209,6 +2421,7 @@ function renderDisableCell(deviceId, until) {
   const minutes = totalMinutes % 60;
   display.textContent = `${hours}:${String(minutes).padStart(2, "0")}`;
   display.setAttribute("data-disabled-until", String(until));
+  cell?.classList.add("rules-disabled-active");
   buttons.forEach((b) => b.classList.remove("hidden"));
 }
 
@@ -2255,9 +2468,14 @@ if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     collectFcuTempSourceChanges,
     autoSetTempRangeForDevice,
+    compactAgeFromSeconds,
+    dashboardAirQualityDeviceIsActive,
     deviceDisplayNameChanged,
     deviceDisplayNamePatchBody,
     deviceRulesEnabledValue,
+    deviceUpdateText,
+    deviceUpdateTooltipText,
+    deviceUpdateTimestampSeconds,
     ensureModeSelectOption,
     fanRadioIdForDevice,
     FCU_MODE_OPTIONS,
@@ -2267,10 +2485,13 @@ if (typeof module !== "undefined" && module.exports) {
     modeValueForDevice,
     moveSetRange,
     normalizeSetRange,
+    oldestUpdateTimestampForTable,
     parseFcuTempSourceMultiplier,
+    renderDisableCell,
     resizeSetRangeEndpoint,
     saveFcuTempSourceMultipliers,
     setAutoSetTempUnavailable,
     sortedFcuTempSources,
+    tableUpdateSummaryText,
   };
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -49,10 +49,8 @@
       <li class="pure-menu-item{% if current_page in ['kitchen', 'hickory'] %} pure-menu-selected{% endif %}">
         <a href="#" id="rooms-menu-link" class="pure-menu-link">Rooms ▾</a>
         <div id="rooms-popup" class="github-popup">
-          <a href="/hickory?embedded">Hickory</a>
-          <a href="/hickory">Hickory (no-return)</a>
-          <a href="/kitchen?embedded">Kitchen</a>
-          <a href="/kitchen">Kitchen (no-return)</a>
+          <a href="/hickory">Hickory</a>
+          <a href="/kitchen">Kitchen</a>
         </div>
       </li>
       <li class="pure-menu-item{% if current_page == 'air-quality' %} pure-menu-selected{% endif %}">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -17,7 +17,7 @@
           <thead>
             <tr>
               <th class="column-unit" rowspan="2">Unit</th>
-              <th class="column-disable-for" rowspan="2" title="Remaining time rules are disabled for this device (H:MM)">Disabled<br>for</th>
+              <th class="column-disable-for" rowspan="2" title="Remaining time rules are disabled for this device (H:MM)">Rules<br>disabled<br>for</th>
               <th class="column-temp" rowspan="2">Temp<br><small id="erv-temp-unit-label">°C</small></th>
               <th class="column-speed" colspan="5">Fan Speed</th>
               <th class="column-notes" rowspan="2">Notes</th>
@@ -41,7 +41,8 @@
                           data-display-name="{{ device.device_label }}"
                           data-device-type="{{ device.device_type or '' }}"
                           data-rules-enabled="{{ 'true' if device.rules_enabled|default(true) else 'false' }}"
-                          title="{{ device.device_name }}">{{ device.device_label }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
+                          data-device-update="{{ device.device_update_text|default('', true) }}"
+                          title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
                     <span id="device-{{ device.device_id }}-notes"></span>
                   </td>
                   <td class="cell-disable-for" id="disable-for-{{ device.device_id }}">
@@ -93,6 +94,11 @@
             {% endif %}
             {% endfor %}
           </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="9" class="table-update-summary" id="oldest-update-erv">{{ table_update_summaries.erv.label if table_update_summaries.erv else '' }}</td>
+            </tr>
+          </tfoot>
         </table>
 
         <h2>Heating and Cooling - Fan Control Units (FCUs)</h2>
@@ -100,10 +106,10 @@
           <thead>
             <tr>
               <th class="column-unit" rowspan="2">Unit</th>
-              <th class="column-disable-for" rowspan="2" title="Remaining time rules are disabled for this device (H:MM)">Disabled<br>for</th>
+              <th class="column-disable-for" rowspan="2" title="Remaining time rules are disabled for this device (H:MM)">Rules<br>disabled<br>for</th>
               <th class="column-temp" rowspan="2">FCU Temp<br><small id="fcu-temp-unit-label">°C</small></th>
               <th class="column-temp" rowspan="2">Room Temp<br><small id="fcu-room-temp-unit-label">°C</small></th>
-              <th class="column-temp column-temp-set" rowspan="2">FCU Set Temp<br><small id="fcu-settemp-unit-label">°C</small></th>
+              <th class="column-temp column-temp-set" rowspan="2">FCU Set<br>Temp<br><small id="fcu-settemp-unit-label">°C</small></th>
               <th class="column-temp column-temp-range" rowspan="2">Set Range<br><small id="fcu-setrange-unit-label">°C</small></th>
               <th class="column-mode" rowspan="2">Mode</th>
               <th class="column-speed" colspan="5">Fan Speed</th>
@@ -128,7 +134,8 @@
                           data-display-name="{{ device.device_label }}"
                           data-device-type="{{ device.device_type or '' }}"
                           data-rules-enabled="{{ 'true' if device.rules_enabled|default(true) else 'false' }}"
-                          title="{{ device.device_name }}">{{ device.device_label }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
+                          data-device-update="{{ device.device_update_text|default('', true) }}"
+                          title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
                     <span id="device-{{ device.device_id }}-notes"></span>
                   </td>
                   <td class="cell-disable-for" id="disable-for-{{ device.device_id }}">
@@ -275,6 +282,11 @@
             {% endif %}
             {% endfor %}
           </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="13" class="table-update-summary" id="oldest-update-fcu">{{ table_update_summaries.fcu.label if table_update_summaries.fcu else '' }}</td>
+            </tr>
+          </tfoot>
         </table>
 
         <!-- Section 3: Air Quality — devices without speed control that have temp -->
@@ -296,7 +308,7 @@
           </thead>
           <tbody>
             {% for device in devices %}
-            {% if not device.has_speed_control and device.temp10x %}
+            {% if device.dashboard_air_quality_active %}
                 <tr class="device-row" x-data-device-id="{{ device.device_id }}">
                   <td class="cell-unit">
                     <span class="device-name-context"
@@ -305,7 +317,8 @@
                           data-display-name="{{ device.device_label }}"
                           data-device-type="{{ device.device_type or '' }}"
                           data-rules-enabled="{{ 'true' if device.rules_enabled|default(true) else 'false' }}"
-                          title="{{ device.device_name }}">{{ device.device_label }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
+                          data-device-update="{{ device.device_update_text|default('', true) }}"
+                          title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
                     <span id="device-{{ device.device_id }}-notes"></span>
                   </td>
                   <td class="cell-humidity{% if device.has_humidity %} cell-metric-link{% endif %}" id="humidity-{{ device.device_id }}"
@@ -333,6 +346,11 @@
             {% endif %}
             {% endfor %}
           </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="10" class="table-update-summary" id="oldest-update-air-quality">{{ table_update_summaries.air_quality.label if table_update_summaries.air_quality else '' }}</td>
+            </tr>
+          </tfoot>
         </table>
       </form>
     </div> <!-- main-grid -->
@@ -358,6 +376,11 @@
   <div class="device-rename-row">
     <label for="device-rename-rules-enabled">rules enabled</label>
     <input id="device-rename-rules-enabled" type="checkbox" disabled>
+    <span aria-hidden="true"></span>
+  </div>
+  <div class="device-rename-row">
+    <label for="device-rename-last-update">last update</label>
+    <input id="device-rename-last-update" type="text" readonly>
     <span aria-hidden="true"></span>
   </div>
   <div class="device-rename-actions">

--- a/bin/runner.py
+++ b/bin/runner.py
@@ -77,9 +77,13 @@ def update_from_hubitat(conn):
     try:
         devices = hubitat.get_all_devices()
         temps = hubitat.extract_temperatures(devices)
-    except requests.exceptions.ConnectTimeout as e:
-        logger.error("update_from_hubitat: timeout %s", e)
+    except requests.exceptions.RequestException as e:
+        logger.error("update_from_hubitat: request failed: %s", e)
         return
+    except RuntimeError as e:
+        logger.error("update_from_hubitat: %s", e)
+        return
+    updated_names = []
     for item in temps:
         statusdict = item.get("status") or {}
         db.insert_devlog_entry(
@@ -88,10 +92,17 @@ def update_from_hubitat(conn):
             temp=item["temperature"],
             statusdict=statusdict,
         )
+        updated_names.append(item["name"])
+    logger.info(
+        "update_from_hubitat: updated %d temperature devices: %s",
+        len(updated_names),
+        ", ".join(updated_names),
+    )
 
 def update_from_airthings(conn):
     logtime = time.time()
     data = airthings.read_airthings_now()
+    updated_names = []
     for dev in data:
         sensors = {sensor['sensorType']:{'value':sensor['value'],'unit':sensor['unit']} for sensor in dev['sensors']}
         name = "Airthings "+dev['name']
@@ -100,6 +111,13 @@ def update_from_airthings(conn):
             print("name=",name,"temp=",temp,'status',sensors)
             continue
         db.insert_devlog_entry(conn, device_name=name, temp=temp, statusdict=sensors, logtime=logtime)
+        updated_names.append(name)
+    if conn is not None:
+        logger.info(
+            "update_from_airthings: updated %d devices: %s",
+            len(updated_names),
+            ", ".join(updated_names),
+        )
 
 
 def update_aqi(conn):

--- a/tests/test_bin_tools.py
+++ b/tests/test_bin_tools.py
@@ -9,6 +9,7 @@ import subprocess
 import sqlite3
 import datetime
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -82,6 +83,65 @@ def test_runner_default_lock_uses_runner_file(monkeypatch, temp_db):
     runner.main()
 
     assert captured["lockfile"] == str(Path(runner.__file__).resolve())
+
+
+def test_makefile_local_targets_control_sensor_simulators():
+    """Local dev targets must make simulator/live intent explicit for all sensors."""
+    makefile = (Path(__file__).resolve().parents[1] / "Makefile").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        "export AE200_SIMULATOR=1 HUBITAT_SIMULATOR=1 AIRTHINGS_SIMULATOR=1"
+        in makefile
+    )
+    assert (
+        "AE200_SIMULATOR= HUBITAT_SIMULATOR= AIRTHINGS_SIMULATOR= $(MAKE) every-minute"
+        in makefile
+    )
+    assert (
+        "AE200_SIMULATOR= HUBITAT_SIMULATOR= AIRTHINGS_SIMULATOR= $(MAKE) _local-dev-web"
+        in makefile
+    )
+
+
+def test_update_from_airthings_persists_sensor_status(monkeypatch, test_database_conn):
+    """Airthings updater should write both temperature and rich air-quality payloads."""
+    monkeypatch.setattr(
+        runner.airthings,
+        "read_airthings_now",
+        lambda: [
+            {
+                "name": "Lab",
+                "sensors": [
+                    {"sensorType": "temp", "value": 21.4, "unit": "c"},
+                    {"sensorType": "humidity", "value": 45.0, "unit": "pct"},
+                    {"sensorType": "co2", "value": 744.0, "unit": "ppm"},
+                    {"sensorType": "pm25", "value": 3.2, "unit": "ug/m3"},
+                ],
+            }
+        ],
+    )
+
+    runner.update_from_airthings(test_database_conn)
+
+    row = test_database_conn.execute(
+        """
+        SELECT d.device_name, l.temp10x, l.status_json
+        FROM devices d
+        JOIN devlog l ON d.device_id = l.device_id
+        WHERE d.device_name = ?
+        ORDER BY l.logtime DESC
+        LIMIT 1
+        """,
+        ("Airthings Lab",),
+    ).fetchone()
+    assert row is not None
+    assert row["temp10x"] == 214
+    status = json.loads(row["status_json"])
+    assert status["humidity"]["value"] == 45.0
+    assert status["co2"]["value"] == 744.0
+    assert status["pm25"]["value"] == 3.2
 
 
 def test_runner_database_access(bin_dir, temp_db):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -6,7 +6,14 @@ Simple test to check if Flask routes are working
 from unittest.mock import patch
 
 from conftest import flask_test_client  # noqa: F401
-from app.routes_web import _filter_speed_control_devices, _get_hubitat_sensors
+from app.routes_web import (
+    _dashboard_air_quality_device_is_active,
+    _dashboard_device_label,
+    _dashboard_device_tooltip,
+    _filter_speed_control_devices,
+    _get_hubitat_sensors,
+    _table_update_summary,
+)
 from app import room_config
 
 def test_status_endpoint(flask_test_client): # noqa: F811
@@ -54,6 +61,216 @@ def test_simulator_banner_is_rendered(flask_test_client):  # noqa: F811
     html = response.data.decode("utf-8")
     assert 'class="simulator-banner"' in html
     assert ">simulator</div>" in html
+
+
+def test_rooms_menu_has_one_plain_link_per_room(flask_test_client):  # noqa: F811
+    """Rooms menu should not duplicate embedded/no-return variants."""
+    response = flask_test_client.get("/")
+    assert response.status_code == 200
+    html = response.data.decode("utf-8")
+    assert html.count('href="/hickory"') == 1
+    assert html.count('href="/kitchen"') == 1
+    assert "/hickory?embedded" not in html
+    assert "/kitchen?embedded" not in html
+    assert "no-return" not in html
+
+
+def test_dashboard_device_label_uses_stored_status_label():
+    """Index labels must not require a live Hubitat fetch."""
+    label = _dashboard_device_label(
+        {
+            "device_name": "Lobby Sensor on Somerville Broadway",
+            "status": {"label": "Lobby Sensor"},
+        }
+    )
+
+    assert label == "Lobby Sensor"
+
+
+def test_dashboard_device_tooltip_uses_device_update_time():
+    tooltip = _dashboard_device_tooltip(
+        {
+            "device_name": "Area 51",
+            "logtime": 1000,
+            "duration": 60,
+        },
+        now=1300,
+    )
+
+    assert tooltip.startswith("Area 51\nLast updated at ")
+    assert tooltip.endswith(" - 4m ago")
+
+
+def test_dashboard_air_quality_device_expires_after_30_days():
+    current_device = {
+        "has_speed_control": False,
+        "temp10x": 220,
+        "logtime": 1000,
+        "duration": 60,
+    }
+    expired_device = {
+        "has_speed_control": False,
+        "temp10x": 220,
+        "logtime": 1000,
+        "duration": 60,
+    }
+
+    assert _dashboard_air_quality_device_is_active(current_device, now=1300)
+    assert not _dashboard_air_quality_device_is_active(
+        expired_device,
+        now=1000 + 60 + 31 * 24 * 60 * 60,
+    )
+    assert not _dashboard_air_quality_device_is_active(
+        {**current_device, "has_speed_control": True},
+        now=1300,
+    )
+
+
+@patch("app.routes_web.hubitat.get_name_to_label")
+@patch("app.routes_web.time.time", return_value=1300)
+@patch("app.routes_web.db.get_device_status")
+def test_index_does_not_fetch_hubitat_labels_on_render(
+    mock_get_status, _mock_time, mock_get_name_to_label, flask_test_client
+):  # noqa: F811
+    mock_get_status.return_value = [
+        {
+            "device_id": 12,
+            "device_name": "Lobby Sensor on Somerville Broadway",
+            "has_speed_control": False,
+            "temp10x": 220,
+            "logtime": 1000,
+            "duration": 1,
+            "status": {"label": "Lobby Sensor", "humidity": 40},
+        }
+    ]
+
+    response = flask_test_client.get("/")
+    assert response.status_code == 200
+    assert "Lobby Sensor" in response.data.decode("utf-8")
+    mock_get_name_to_label.assert_not_called()
+
+
+def test_table_update_summary_uses_oldest_status_end_time():
+    summary = _table_update_summary(
+        [
+            {"device_type": "ERV", "logtime": 900, "duration": 1},
+            {
+                "device_name": "Older FCU",
+                "device_type": "FCU",
+                "logtime": 1000,
+                "duration": 60,
+            },
+            {
+                "device_name": "Newer FCU",
+                "device_type": "FCU",
+                "logtime": 1100,
+                "duration": 20,
+            },
+            {"device_type": "FCU", "duration": 20},
+            {
+                "device_name": "Newest FCU",
+                "device_type": "FCU",
+                "logtime": 1200,
+                "duration": 0,
+            },
+        ],
+        lambda device: device.get("device_type") == "FCU",
+        now=1300,
+    )
+
+    assert summary is not None
+    assert summary.oldest_update_at == 1060
+    assert summary.oldest_update_age == "4m"
+    assert summary.source_device_name == "Older FCU"
+    assert summary.label == (
+        f"(oldest update at {summary.oldest_update_datetime} - "
+        "4m ago from Older FCU)"
+    )
+
+
+@patch("app.routes_web.hubitat.get_name_to_label", return_value={})
+@patch("app.routes_web.time.time", return_value=1300)
+@patch("app.routes_web.db.get_device_status")
+def test_index_table_update_summaries_render_at_table_bottom(
+    mock_get_status, _mock_time, _mock_labels, flask_test_client
+):  # noqa: F811
+    mock_get_status.return_value = [
+        {
+            "device_id": 10,
+            "device_name": "ERV Test",
+            "device_type": "ERV",
+            "has_speed_control": True,
+            "temp10x": 210,
+            "logtime": 1000,
+            "duration": 1,
+        },
+        {
+            "device_id": 11,
+            "device_name": "FCU Test",
+            "device_type": "FCU",
+            "has_speed_control": True,
+            "temp10x": 220,
+            "calculated_temp10x": 221,
+            "logtime": 1010,
+            "duration": 1,
+            "status": {"Mode": "COOL"},
+        },
+        {
+            "device_id": 12,
+            "device_name": "Air Test",
+            "has_speed_control": False,
+            "temp10x": 230,
+            "logtime": 1020,
+            "duration": 1,
+            "status": {"humidity": 40},
+        },
+    ]
+
+    response = flask_test_client.get("/")
+    assert response.status_code == 200
+    html = response.data.decode("utf-8")
+
+    assert 'id="oldest-update-erv"' in html
+    assert 'id="oldest-update-fcu"' in html
+    assert 'id="oldest-update-air-quality"' in html
+    assert html.count("oldest update at") == 3
+
+
+@patch("app.routes_web.hubitat.get_name_to_label", return_value={})
+@patch("app.routes_web.time.time", return_value=1300)
+@patch("app.routes_web.db.get_device_status")
+def test_index_air_quality_table_hides_expired_devices(
+    mock_get_status, _mock_time, _mock_labels, flask_test_client
+):  # noqa: F811
+    mock_get_status.return_value = [
+        {
+            "device_id": 12,
+            "device_name": "Current Air",
+            "has_speed_control": False,
+            "temp10x": 230,
+            "logtime": 1020,
+            "duration": 1,
+            "status": {"humidity": 40},
+        },
+        {
+            "device_id": 13,
+            "device_name": "Expired Air",
+            "has_speed_control": False,
+            "temp10x": 240,
+            "logtime": 1000 - 31 * 24 * 60 * 60,
+            "duration": 1,
+            "status": {"humidity": 40},
+        },
+    ]
+
+    response = flask_test_client.get("/")
+    assert response.status_code == 200
+    html = response.data.decode("utf-8")
+
+    assert "Current Air" in html
+    assert "Expired Air" not in html
+    assert "from Current Air" in html
+    assert "from Expired Air" not in html
 
 
 @patch("app.routes_web.hubitat.get_name_to_label", return_value={})
@@ -123,9 +340,10 @@ def test_fcu_matrix_room_temp_cell_opens_weight_popup(
 
 
 @patch("app.routes_web.hubitat.get_name_to_label", return_value={})
+@patch("app.routes_web.time.time", return_value=1300)
 @patch("app.routes_web.db.get_device_status")
 def test_index_device_names_expose_rename_popup_contract(
-    mock_get_status, _mock_labels, flask_test_client
+    mock_get_status, _mock_time, _mock_labels, flask_test_client
 ):  # noqa: F811
     mock_get_status.return_value = [
         {
@@ -137,6 +355,8 @@ def test_index_device_names_expose_rename_popup_contract(
             "has_speed_control": True,
             "temp10x": 220,
             "calculated_temp10x": 235,
+            "logtime": 1000,
+            "duration": 60,
             "status": {"Mode": "COOL"},
         }
     ]
@@ -151,9 +371,12 @@ def test_index_device_names_expose_rename_popup_contract(
     assert 'data-display-name="Server Room"' in html
     assert 'data-device-type="FCU"' in html
     assert 'data-rules-enabled="false"' in html
+    assert 'data-device-update="' in html
+    assert " - 4m ago" in html
     assert 'id="device-rename-popup"' in html
     assert 'id="device-rename-device-type"' in html
     assert 'id="device-rename-rules-enabled"' in html
+    assert 'id="device-rename-last-update"' in html
     assert 'data-action="reset-device-name"' in html
     assert 'data-action="rename-device"' in html
     assert 'data-action="cancel-device-rename"' in html

--- a/tests/test_temporal_quantifiers.py
+++ b/tests/test_temporal_quantifiers.py
@@ -220,7 +220,7 @@ def test_index_fcu_speeds_exclude_one(
     assert f'id="radio-{device_id}-0"' in html
     assert f'id="radio-{device_id}-auto"' in html
     assert '<th class="column-mode" rowspan="2">Mode</th>' in html
-    assert '<th class="column-temp column-temp-set" rowspan="2">FCU Set Temp' in html
+    assert '<th class="column-temp column-temp-set" rowspan="2">FCU Set<br>Temp' in html
     assert 'class="mode-select"' in html
     assert f'id="mode-{device_id}"' in html
     assert f'id="autosettemp-widget-{device_id}"' in html

--- a/tests/test_unit_speed.js
+++ b/tests/test_unit_speed.js
@@ -8,9 +8,14 @@
 const {
   collectFcuTempSourceChanges,
   autoSetTempRangeForDevice,
+  compactAgeFromSeconds,
+  dashboardAirQualityDeviceIsActive,
   deviceDisplayNameChanged,
   deviceDisplayNamePatchBody,
   deviceRulesEnabledValue,
+  deviceUpdateText,
+  deviceUpdateTooltipText,
+  deviceUpdateTimestampSeconds,
   ensureModeSelectOption,
   fanRadioIdForDevice,
   FCU_MODE_OPTIONS,
@@ -20,11 +25,14 @@ const {
   modeValueForDevice,
   moveSetRange,
   normalizeSetRange,
+  oldestUpdateTimestampForTable,
   parseFcuTempSourceMultiplier,
+  renderDisableCell,
   resizeSetRangeEndpoint,
   saveFcuTempSourceMultipliers,
   setAutoSetTempUnavailable,
   sortedFcuTempSources,
+  tableUpdateSummaryText,
 } = require("../app/static/unit_speed.js");
 
 let passed = 0;
@@ -54,6 +62,17 @@ function checkRange(label, actual, expectedLow, expectedHigh) {
   }
 }
 
+function checkContains(label, actual, expectedFragment) {
+  if (String(actual).includes(expectedFragment)) {
+    passed++;
+  } else {
+    failed++;
+    console.error(
+      `FAIL ${label}: got "${actual}", expected to include "${expectedFragment}"`,
+    );
+  }
+}
+
 // -- The bug: off unit holding Auto must show Off, not Auto --
 check(
   "off + held Auto (-1) -> Off",
@@ -70,6 +89,181 @@ check(
   fanRadioIdForDevice({ device_id: 7, drive: "Off", fan_speed: -1 }),
   "radio-7-0",
 );
+
+// -- Table update timestamps --
+check(
+  "device update timestamp uses logtime plus duration",
+  deviceUpdateTimestampSeconds({ logtime: 1000, duration: 60 }),
+  1060,
+);
+check(
+  "device update timestamp defaults missing duration",
+  deviceUpdateTimestampSeconds({ logtime: "1000" }),
+  1001,
+);
+check(
+  "oldest FCU update ignores other tables",
+  oldestUpdateTimestampForTable(
+    [
+      { device_type: "ERV", logtime: 900, duration: 1 },
+      { device_type: "FCU", logtime: 1000, duration: 60 },
+      { device_type: "FCU", logtime: 1100, duration: 20 },
+    ],
+    "fcu",
+  ),
+  1060,
+);
+check(
+  "fresh air quality device is included",
+  dashboardAirQualityDeviceIsActive(
+    { has_speed_control: false, temp10x: 220, logtime: 1000, duration: 60 },
+    new Date(1300 * 1000),
+  ),
+  true,
+);
+check(
+  "expired air quality device is hidden",
+  dashboardAirQualityDeviceIsActive(
+    { has_speed_control: false, temp10x: 220, logtime: 1000, duration: 60 },
+    new Date((1060 + 31 * 24 * 60 * 60) * 1000),
+  ),
+  false,
+);
+check(
+  "oldest air quality update ignores expired devices",
+  oldestUpdateTimestampForTable(
+    [
+      {
+        device_name: "Expired Air",
+        has_speed_control: false,
+        temp10x: 220,
+        logtime: 2000 - 31 * 24 * 60 * 60,
+        duration: 1,
+      },
+      {
+        device_name: "Current Air",
+        has_speed_control: false,
+        temp10x: 230,
+        logtime: 2000,
+        duration: 20,
+      },
+    ],
+    "air-quality",
+    new Date(2200 * 1000),
+  ),
+  2020,
+);
+check(
+  "compact age minutes",
+  compactAgeFromSeconds(240),
+  "4m",
+);
+checkContains(
+  "table update summary includes compact age",
+  tableUpdateSummaryText(1060, new Date(1300 * 1000)),
+  " - 4m ago)",
+);
+checkContains(
+  "table update summary includes source device",
+  tableUpdateSummaryText(1060, new Date(1300 * 1000), "Older FCU"),
+  " from Older FCU)",
+);
+checkContains(
+  "device update text includes compact age",
+  deviceUpdateText(
+    { device_name: "Area 51", logtime: 1000, duration: 60 },
+    new Date(1300 * 1000),
+  ),
+  " - 4m ago",
+);
+checkContains(
+  "device update tooltip includes device name",
+  deviceUpdateTooltipText(
+    { device_name: "Area 51", logtime: 1000, duration: 60 },
+    "",
+    new Date(1300 * 1000),
+  ),
+  "Area 51",
+);
+checkContains(
+  "device update tooltip includes update age",
+  deviceUpdateTooltipText(
+    { device_name: "Area 51", logtime: 1000, duration: 60 },
+    "",
+    new Date(1300 * 1000),
+  ),
+  " - 4m ago",
+);
+check(
+  "device update tooltip falls back to device name without timestamp",
+  deviceUpdateTooltipText({}, "Fallback Device"),
+  "Fallback Device",
+);
+
+// -- Rules disabled cell alignment state --
+{
+  const originalDocument = global.document;
+  const cellClasses = new Set(["rules-disabled-active"]);
+  const downButtonClasses = new Set();
+  const upButtonClasses = new Set();
+  const display = {
+    attributes: {},
+    textContent: "",
+    removeAttribute: (name) => {
+      delete display.attributes[name];
+    },
+    setAttribute: (name, value) => {
+      display.attributes[name] = value;
+    },
+  };
+  const classListFromSet = (set) => ({
+    add: (name) => set.add(name),
+    remove: (name) => set.delete(name),
+    contains: (name) => set.has(name),
+  });
+  const cell = {
+    classList: classListFromSet(cellClasses),
+    querySelectorAll: () => [
+      { classList: classListFromSet(downButtonClasses) },
+      { classList: classListFromSet(upButtonClasses) },
+    ],
+  };
+  global.document = {
+    getElementById: (id) => {
+      if (id === "disable-display-44") return display;
+      if (id === "disable-for-44") return cell;
+      return null;
+    },
+  };
+  try {
+    renderDisableCell(44, 0);
+    check("enabled rules show centered dash", display.textContent, "—");
+    check(
+      "enabled rules remove active alignment class",
+      cell.classList.contains("rules-disabled-active"),
+      false,
+    );
+    check(
+      "enabled rules hide decrement button",
+      downButtonClasses.has("hidden"),
+      true,
+    );
+
+    renderDisableCell(44, Math.floor(Date.now() / 1000) + 90);
+    check(
+      "disabled rules add active alignment class",
+      cell.classList.contains("rules-disabled-active"),
+      true,
+    );
+    check(
+      "disabled rules show decrement button",
+      downButtonClasses.has("hidden"),
+      false,
+    );
+  } finally {
+    global.document = originalDocument;
+  }
+}
 
 // -- On states still resolve correctly --
 check(


### PR DESCRIPTION
Hide air-quality dashboard devices whose latest update is older than 30 days while preserving their history and metadata in the database.

Show per-device last-update timestamps in unit tooltips and the device metadata popup, and include the source device in each table's oldest-update footer so stale rows are traceable.

Keep dashboard rendering off live Hubitat label lookups, wire local-dev simulator settings consistently, and add runner logging for Hubitat and Airthings update counts.

Tighten table spacing and room/menu labels, and cover the freshness, popup, table footer, simulator, and JavaScript refresh behavior with focused tests.