### PR TITLE
Disable FCU set temperature in Dry mode

### DIFF
--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -128,6 +128,13 @@ function isFanOperationMode(rawMode) {
   return String(rawMode || "").toUpperCase() === "FAN";
 }
 
+function setTempDisabledTooltip(rawMode) {
+  const mode = String(rawMode || "").toUpperCase();
+  return mode === "DRY" || mode === "FAN"
+    ? `control disabled in ${AE200_MODE_LABELS[mode]} mode.`
+    : "";
+}
+
 function deviceUpdateTimestampSeconds(dev) {
   if (!dev || dev.logtime == null) {
     return null;
@@ -508,6 +515,7 @@ function updateSetTempForDevice(dev) {
   const operationMode = modeValueForDevice(dev);
   if (isAutoOperationMode(operationMode)) {
     setSingleSetTempControlsDisabled(setTempControls, setTempDisplay, false);
+    setTempCell.removeAttribute("title");
     setTempControls.classList.add("hidden");
     autoWidget.classList.remove("hidden");
     if (
@@ -524,11 +532,17 @@ function updateSetTempForDevice(dev) {
 
   autoWidget.classList.add("hidden");
   setTempControls.classList.remove("hidden");
+  const disabledTooltip = setTempDisabledTooltip(operationMode);
   setSingleSetTempControlsDisabled(
     setTempControls,
     setTempDisplay,
-    isFanOperationMode(operationMode),
+    Boolean(disabledTooltip),
   );
+  if (disabledTooltip) {
+    setTempCell.setAttribute("title", disabledTooltip);
+  } else {
+    setTempCell.removeAttribute("title");
+  }
   const rawSetTemp = dev.set_temp_c ?? status.SetTemp;
 
   if (rawSetTemp !== undefined && rawSetTemp !== "") {
@@ -3122,6 +3136,7 @@ if (typeof module !== "undefined" && module.exports) {
     fcuTempSourcesTitle,
     isAutoOperationMode,
     isFanOperationMode,
+    setTempDisabledTooltip,
     modeLabelForDevice,
     modeValueForDevice,
     enableRulesForDevice,

--- a/tests/test_unit_speed.js
+++ b/tests/test_unit_speed.js
@@ -30,6 +30,7 @@ const {
   markSingleSetTempPending,
   modeLabelForDevice,
   modeValueForDevice,
+  setTempDisabledTooltip,
   normalizeSetRange,
   oldestUpdateTimestampForTable,
   parseFcuTempSourceMultiplier,
@@ -447,6 +448,17 @@ check("auto mode token is auto operation", isAutoOperationMode("AUTO"), true);
 check("lc_auto mode token is auto operation", isAutoOperationMode("LC_AUTO"), true);
 check("fan mode token is fan operation", isFanOperationMode("fan"), true);
 check("cool mode token is not fan operation", isFanOperationMode("COOL"), false);
+check(
+  "dry mode set temperature tooltip",
+  setTempDisabledTooltip("dry"),
+  "control disabled in Dry mode.",
+);
+check(
+  "fan mode set temperature tooltip",
+  setTempDisabledTooltip("FAN"),
+  "control disabled in Fan mode.",
+);
+check("cool mode has no set temperature tooltip", setTempDisabledTooltip("COOL"), "");
 
 const coolSetRangeWidget = fakeWidget();
 updateSetRangeModeState(coolSetRangeWidget, "COOL");
@@ -638,8 +650,10 @@ function withSetTempDocument(callback) {
 
 withSetTempDocument(
   ({
+    "settemp-12": cell,
     "settemp-display-12": display,
     "settemp-controls-12": controls,
+    "autosettemp-widget-12": autoWidget,
     downButton,
     upButton,
   }) => {
@@ -662,6 +676,21 @@ withSetTempDocument(
     );
     check("fan mode set temp down button disabled", downButton.disabled, true);
     check("fan mode set temp up button disabled", upButton.disabled, true);
+    check("fan mode set temp cell tooltip", cell.attributes.title, "control disabled in Fan mode.");
+
+    updateSetTempForDevice({
+      device_id: 12,
+      mode: "DRY",
+      set_temp_c: 22,
+      logtime: Math.floor(Date.now() / 1000),
+    });
+    check("dry mode set temp down button disabled", downButton.disabled, true);
+    check("dry mode set temp up button disabled", upButton.disabled, true);
+    check("dry mode set temp cell tooltip", cell.attributes.title, "control disabled in Dry mode.");
+
+    autoWidget.dataset.dragging = "true";
+    updateSetTempForDevice({ device_id: 12, mode: "AUTO" });
+    check("auto mode clears set temp cell tooltip", cell.attributes.title, undefined);
 
     updateSetTempForDevice({
       device_id: 12,
@@ -681,6 +710,7 @@ withSetTempDocument(
     );
     check("cool mode set temp down button enabled", downButton.disabled, false);
     check("cool mode set temp up button enabled", upButton.disabled, false);
+    check("cool mode clears set temp cell tooltip", cell.attributes.title, undefined);
   },
 );
 


### PR DESCRIPTION
## Summary

- disable FCU set-temperature controls in Dry mode, matching existing Fan-mode behavior
- show mode-specific tooltips on the set-temperature cell when control is disabled
- clear the tooltip when the FCU returns to a temperature-controllable mode

## Why

The FCU matrix previously disabled set-temperature controls only in Fan mode. Dry mode also does not accept temperature control, but the UI left those controls enabled and provided no explanation for disabled controls in either mode.

## User impact

Users now see `control disabled in Dry mode.` or `control disabled in Fan mode.` when hovering over the disabled set-temperature cell. Switching to Cool, Heat, or Auto clears the stale tooltip and restores the appropriate controls.

## Validation

- `make test-js` (147 passed)
- `make eslint`
- `make djlint` attempted; blocked by the local sandbox denying Python semaphore inspection. No templates changed in this PR.

Authored by Codex AI Assistant.
