### PR TITLE
Optimize temperature navigation probes

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -2043,7 +2043,7 @@ def temperature_data_availability(
     end: int | None,
 ) -> tuple[bool, bool]:
     """Return whether selected devices have temperature samples outside a window."""
-    if device_ids == []:
+    if device_ids is not None and not device_ids:
         return (False, False)
 
     if device_ids is None:

--- a/app/db.py
+++ b/app/db.py
@@ -2043,31 +2043,37 @@ def temperature_data_availability(
     end: int | None,
 ) -> tuple[bool, bool]:
     """Return whether selected devices have temperature samples outside a window."""
-    if device_ids is None:
-        device_ids = [
-            row["device_id"]
-            for row in conn.execute("SELECT device_id FROM devices").fetchall()
-        ]
-    if not device_ids:
+    if device_ids == []:
         return (False, False)
 
-    placeholders = ",".join("?" for _ in device_ids)
+    if device_ids is None:
+        index = "idx_devlog_temperature_logtime_device"
+        device_clause = ""
+        device_args: list[int] = []
+    elif len(device_ids) == 1:
+        index = "idx_devlog_temperature_device_logtime"
+        device_clause = " AND device_id = ?"
+        device_args = device_ids
+    else:
+        index = "idx_devlog_temperature_logtime_device"
+        placeholders = ",".join("?" for _ in device_ids)
+        device_clause = f" AND device_id IN ({placeholders})"
+        device_args = device_ids
 
     def exists_outside(boundary: int | None, before_window: bool) -> bool:
         if boundary is None:
             return False
         sql = f"""
             SELECT logtime
-            FROM devlog INDEXED BY idx_devlog_temperature_logtime_device
-            WHERE device_id IN ({placeholders})
-                AND temp10x IS NOT NULL
+            FROM devlog INDEXED BY {index}
+            WHERE temp10x IS NOT NULL{device_clause}
         """
         sql += (
             " AND logtime < ? ORDER BY logtime DESC LIMIT 1"
             if before_window
             else " AND logtime > ? ORDER BY logtime ASC LIMIT 1"
         )
-        return conn.execute(sql, [*device_ids, boundary]).fetchone() is not None
+        return conn.execute(sql, [*device_args, boundary]).fetchone() is not None
 
     return (
         exists_outside(start, True),

--- a/tests/test_chart_functionality.py
+++ b/tests/test_chart_functionality.py
@@ -4,6 +4,7 @@ test_chart_functionality.py
 
 import json
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -44,10 +45,17 @@ def test_temperature_chart_page_has_exclusion_controls(flask_test_client):  # no
     assert "temperature_chart_support.js" in content
     assert 'id="checkboxes"' in content
     assert 'id="temp-chart"' in content
-    assert 'id="earlierDataBtn"' in content
-    assert 'id="laterDataBtn"' in content
-    assert 'id="earlierDataBtn" class="chart-navigation-button" aria-label="Show earlier data" title="Show earlier data" disabled' in content
-    assert 'id="laterDataBtn" class="chart-navigation-button" aria-label="Show later data" title="Show later data" disabled' in content
+    for button_id, label in (
+        ("earlierDataBtn", "Show earlier data"),
+        ("laterDataBtn", "Show later data"),
+    ):
+        match = re.search(rf'<button\b[^>]*\bid="{button_id}"[^>]*>', content)
+        assert match is not None
+        button = match.group()
+        assert 'class="chart-navigation-button"' in button
+        assert f'aria-label="{label}"' in button
+        assert f'title="{label}"' in button
+        assert "disabled" in button
     assert 'id="calculated-temperature-explanation"' in content
     assert "current room temperature weights, not historical weights" in content
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -58,6 +58,41 @@ def test_temperature_data_availability_checks_selected_devices(test_database_con
         test_database_conn, [], 150, 250
     ) == (False, False)
 
+
+def test_temperature_data_availability_uses_direct_all_device_probe(
+    test_database_conn,
+):
+    device_id = db.get_or_create_device_id(test_database_conn, "device")
+    test_database_conn.execute(
+        "INSERT INTO devlog (device_id, logtime, duration, temp10x) VALUES (?, 100, 1, 200)",
+        (device_id,),
+    )
+    statements = []
+    test_database_conn.set_trace_callback(statements.append)
+
+    assert db.temperature_data_availability(
+        test_database_conn, None, 150, 50
+    ) == (True, True)
+
+    test_database_conn.set_trace_callback(None)
+    probes = [sql for sql in statements if "SELECT logtime" in sql]
+    assert len(probes) == 2
+    assert all("device_id" not in sql for sql in probes)
+
+
+def test_temperature_data_availability_uses_device_first_index_for_one_device(
+    test_database_conn,
+):
+    device_id = db.get_or_create_device_id(test_database_conn, "device")
+    statements = []
+    test_database_conn.set_trace_callback(statements.append)
+
+    db.temperature_data_availability(test_database_conn, [device_id], 150, None)
+
+    test_database_conn.set_trace_callback(None)
+    probe = next(sql for sql in statements if "SELECT logtime" in sql)
+    assert "INDEXED BY idx_devlog_temperature_device_logtime" in probe
+
 def test_temperature_insert(test_database_conn_with_test_data):
     conn = test_database_conn_with_test_data[0]
 


### PR DESCRIPTION
Codex-authored follow-up to #168.

## What changed

- avoid expanding every device into an `IN (...)` list when checking availability for all devices
- use the device-first temperature index for a single selected device and the time-first index for all-device and multi-device probes
- make navigation-button template assertions independent of harmless attribute ordering
- add regression tests against the SQL actually executed by the availability helper

## Why

Post-merge review identified unnecessary all-device parameter expansion, a less-selective forced index for single-device probes, and brittle template assertions. These changes address those remaining comments without changing chart behavior.

## Validation

- `make PYTEST_ARGS='tests/test_db.py::test_temperature_data_availability_checks_selected_devices tests/test_db.py::test_temperature_data_availability_uses_direct_all_device_probe tests/test_db.py::test_temperature_data_availability_uses_device_first_index_for_one_device tests/test_chart_functionality.py::test_temperature_chart_page_has_exclusion_controls' pytest`
- `make check`
