### PR TITLE
Fix shared database schema preflight

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -127,7 +127,7 @@ def format_schema_mismatch_message(
     lines = [
         f"Database schema does not match expected application schema: {db_path}",
         (
-            "Please upgrade the database before starting Flask. "
+            "Please upgrade the database before starting the application. "
             f"Run `{SCHEMA_UPGRADE_COMMAND}`."
         ),
     ]

--- a/app/db.py
+++ b/app/db.py
@@ -361,10 +361,8 @@ def validate_database_schema_on_startup() -> None:
         if has_tables:
             validate_configured_database_schema()
     except KeyError as e:
-        print(
-            "Missing required environment variable %s (path to SQLite database)." % e.args[0],
-            file=sys.stderr,
-        )
+        print(f"Missing required environment variable e.args[0] (path to SQLite database).",
+              file=sys.stderr )
         raise SystemExit(1) from None
     except DatabaseSchemaMismatchError as e:
         print(str(e), file=sys.stderr)

--- a/app/db.py
+++ b/app/db.py
@@ -91,26 +91,6 @@ def _chart_logtime(row: sqlite3.Row) -> int:
     return int(row["logtime"])
 
 
-# Cache the schema file's modification time so we only re-apply the schema
-# when the file actually changes on disk. This keeps the convenient
-# auto-setup behavior without running the full schema on every request.
-# We do this here (rather than at "server startup") because this module
-# is also used by CLI tools and schedulers that may not go through a single
-# well-defined startup path.
-_SCHEMA_MTIME: float | None = None
-
-
-def reset_schema_mtime_cache() -> None:
-    """Reset the schema mtime cache. For use by tests only."""
-    global _SCHEMA_MTIME  # pylint: disable=global-statement
-    _SCHEMA_MTIME = None
-
-
-def get_schema_mtime() -> float | None:
-    """Return the cached schema mtime. For use by tests only."""
-    return _SCHEMA_MTIME
-
-
 def connect_db(db_path):
     """Establishes a connection to the SQLite database."""
     logger.debug("connect_db(%s)", db_path)
@@ -359,6 +339,40 @@ def validate_configured_database_schema() -> None:
         conn.close()
 
 
+def should_validate_database_schema_on_startup() -> bool:
+    """Return whether this process should validate the runtime DB at startup."""
+    return "PYTEST" not in os.environ and TEST_DB_NAME not in os.environ
+
+
+def validate_database_schema_on_startup() -> None:
+    """Stop a runtime entry point cleanly when a populated database is stale."""
+    if not should_validate_database_schema_on_startup():
+        return
+    try:
+        db_path = os.environ[DB_PATH]
+        conn = connect_db(db_path)
+        try:
+            has_tables = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name NOT LIKE 'sqlite_%' LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+        if has_tables:
+            validate_configured_database_schema()
+    except KeyError as e:
+        issue = DatabaseSchemaIssue(
+            issue_type="missing_config",
+            object_name=e.args[0],
+            detail="database path environment variable is not set",
+        )
+        print(format_schema_mismatch_message("<unset>", [issue]), file=sys.stderr)
+        raise SystemExit(1) from None
+    except DatabaseSchemaMismatchError as e:
+        print(str(e), file=sys.stderr)
+        raise SystemExit(1) from None
+
+
 def get_db_connection():
     """
     Returns a new SQLite connection for each request.
@@ -373,35 +387,12 @@ def get_db_connection():
             db_path = os.environ[DB_PATH]
         conn = connect_db(db_path)
 
-        # Ensure the database schema is applied for fresh/empty DBs
-        # and optionally when the schema file is newer than the DB file.
-        needs_schema = False
-
-        try:
-            cursor = conn.execute(
-                "SELECT name FROM sqlite_master "
-                "WHERE type='table' AND name NOT LIKE 'sqlite_%';"
-            )
-            existing_tables = [row[0] for row in cursor.fetchall()]
-            if not existing_tables:
-                # Fresh database with no user tables.
-                needs_schema = True
-        except sqlite3.Error:
-            # If we cannot introspect the schema, fall back to applying it.
-            needs_schema = True
-
-        if not needs_schema:
-            # Best-effort mtime-based schema auto-apply for existing DBs.
-            try:
-                schema_mtime = os.path.getmtime(SCHEMA_FILE_PATH)
-                db_mtime = os.path.getmtime(db_path)
-            except OSError:
-                schema_mtime = None
-                db_mtime = None
-
-            if schema_mtime is not None and db_mtime is not None:
-                if schema_mtime > db_mtime:
-                    needs_schema = True
+        # Compatibility schema setup is only safe for a fresh, empty database.
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name NOT LIKE 'sqlite_%';"
+        )
+        needs_schema = cursor.fetchone() is None
 
         if needs_schema:
             logger.info(

--- a/app/db.py
+++ b/app/db.py
@@ -361,8 +361,12 @@ def validate_database_schema_on_startup() -> None:
         if has_tables:
             validate_configured_database_schema()
     except KeyError as e:
-        print(f"Missing required environment variable e.args[0] (path to SQLite database).",
-              file=sys.stderr )
+        missing_variable = e.args[0] if e.args else DB_PATH
+        print(
+            f"Missing required environment variable {missing_variable} "
+            "(path to SQLite database).",
+            file=sys.stderr,
+        )
         raise SystemExit(1) from None
     except DatabaseSchemaMismatchError as e:
         print(str(e), file=sys.stderr)

--- a/app/db.py
+++ b/app/db.py
@@ -361,12 +361,10 @@ def validate_database_schema_on_startup() -> None:
         if has_tables:
             validate_configured_database_schema()
     except KeyError as e:
-        issue = DatabaseSchemaIssue(
-            issue_type="missing_config",
-            object_name=e.args[0],
-            detail="database path environment variable is not set",
+        print(
+            "Missing required environment variable %s (path to SQLite database)." % e.args[0],
+            file=sys.stderr,
         )
-        print(format_schema_mismatch_message("<unset>", [issue]), file=sys.stderr)
         raise SystemExit(1) from None
     except DatabaseSchemaMismatchError as e:
         print(str(e), file=sys.stderr)

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,6 @@ Refactored main.py - Flask application with modular structure
 import datetime
 import logging
 import os
-import sys
 from functools import lru_cache
 from os.path import abspath
 from pathlib import Path
@@ -78,22 +77,6 @@ def fix_boto_log_level():
             logging.getLogger(name).setLevel(logging.INFO)
 
 
-def should_validate_database_schema_on_startup() -> bool:
-    """Return whether this process should validate the runtime DB at startup."""
-    return "PYTEST" not in os.environ and db.TEST_DB_NAME not in os.environ
-
-
-def validate_database_schema_on_startup() -> None:
-    """Stop Flask startup when the configured database is not current."""
-    if not should_validate_database_schema_on_startup():
-        return
-    try:
-        db.validate_configured_database_schema()
-    except db.DatabaseSchemaMismatchError as e:
-        print(str(e), file=sys.stderr)
-        raise SystemExit(1) from None
-
-
 def create_app():
     """Create and configure the Flask application"""
 
@@ -110,7 +93,7 @@ def create_app():
     logging.basicConfig(format=LOGGING_CONFIG, level=log_level, force=True)
     app.logger.info("new Flask(__name__=%s) log_level=%s", __name__, log_level)
     fix_boto_log_level()
-    validate_database_schema_on_startup()
+    db.validate_database_schema_on_startup()
 
     @app.context_processor
     def simulator_context():

--- a/bin/runner.py
+++ b/bin/runner.py
@@ -385,6 +385,7 @@ def main():
         update_from_airthings(None)
         sys.exit(0)
 
+    db.validate_database_schema_on_startup()
     conn = db.get_db_connection()
     if args.report:
         report(conn)

--- a/tests/test_schema_flyway.py
+++ b/tests/test_schema_flyway.py
@@ -7,9 +7,9 @@ from pathlib import Path
 import pytest
 
 from app import db
-from app import main
 from app.constants import DB_PATH, TEST_DB_NAME
 from app.paths import ROOT_DIR, SCHEMA_FILE_PATH
+from bin import runner
 
 BASELINE_APP_TABLES = {"devices", "devlog", "changelog", "aqi", "alerts"}
 MIGRATED_APP_TABLES = BASELINE_APP_TABLES | {
@@ -142,7 +142,7 @@ def test_runtime_schema_validator_rejects_baseline_schema():
     assert "idx_changelog_device_id_logtime" in message
 
 
-def test_flask_startup_schema_check_stops_for_stale_database(
+def test_shared_startup_schema_check_stops_for_stale_database(
     tmp_path, monkeypatch, capsys
 ):
     stale_db = tmp_path / "stale.db"
@@ -155,7 +155,7 @@ def test_flask_startup_schema_check_stops_for_stale_database(
     monkeypatch.setenv(DB_PATH, str(stale_db))
 
     with pytest.raises(SystemExit) as excinfo:
-        main.validate_database_schema_on_startup()
+        db.validate_database_schema_on_startup()
 
     captured = capsys.readouterr()
     assert excinfo.value.code == 1
@@ -163,3 +163,67 @@ def test_flask_startup_schema_check_stops_for_stale_database(
     assert "Please upgrade the database" in captured.err
     assert "missing_table rooms" in captured.err
     assert "Traceback" not in captured.err
+
+
+def test_runner_uses_shared_schema_check_before_opening_database(
+    tmp_path, monkeypatch, capsys
+):
+    stale_db = tmp_path / "stale.db"
+    with closing(sqlite3.connect(stale_db)) as conn:
+        with open(BASELINE_MIGRATION_PATH, "r", encoding="utf-8") as schema_file:
+            conn.executescript(schema_file.read())
+
+    monkeypatch.delenv("PYTEST", raising=False)
+    monkeypatch.delenv(TEST_DB_NAME, raising=False)
+    monkeypatch.setenv(DB_PATH, str(stale_db))
+    monkeypatch.setattr("sys.argv", ["runner"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        runner.main()
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 1
+    assert "Run `make migrate-db`" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_get_db_connection_does_not_replay_schema_on_populated_database(
+    tmp_path, monkeypatch
+):
+    stale_db = tmp_path / "stale.db"
+    with closing(sqlite3.connect(stale_db)) as conn:
+        with open(BASELINE_MIGRATION_PATH, "r", encoding="utf-8") as schema_file:
+            conn.executescript(schema_file.read())
+
+    monkeypatch.setenv(TEST_DB_NAME, str(stale_db))
+    conn = db.get_db_connection()
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+    assert "devices" in tables
+    assert "rooms" not in tables
+
+
+def test_get_db_connection_initializes_empty_database(tmp_path, monkeypatch):
+    empty_db = tmp_path / "empty.db"
+    monkeypatch.setenv(TEST_DB_NAME, str(empty_db))
+
+    conn = db.get_db_connection()
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+    assert MIGRATED_APP_TABLES <= tables

--- a/tests/test_schema_flyway.py
+++ b/tests/test_schema_flyway.py
@@ -165,6 +165,24 @@ def test_shared_startup_schema_check_stops_for_stale_database(
     assert "Traceback" not in captured.err
 
 
+def test_shared_startup_schema_check_requires_db_path(monkeypatch, capsys):
+    monkeypatch.delenv("PYTEST", raising=False)
+    monkeypatch.delenv(TEST_DB_NAME, raising=False)
+    monkeypatch.delenv(DB_PATH, raising=False)
+
+    with pytest.raises(SystemExit) as excinfo:
+        db.validate_database_schema_on_startup()
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 1
+    assert captured.out == ""
+    assert (
+        f"Missing required environment variable {DB_PATH} "
+        "(path to SQLite database)." in captured.err
+    )
+    assert "Traceback" not in captured.err
+
+
 def test_runner_uses_shared_schema_check_before_opening_database(
     tmp_path, monkeypatch, capsys
 ):


### PR DESCRIPTION
## Summary

- move the clean runtime schema preflight into `app.db`
- call that exact preflight from both Flask and `bin.runner`
- restrict compatibility-schema setup to genuinely empty databases
- remove mtime-based schema replay for populated databases

## Root cause

`make local-live-dev` runs `bin.runner` before Flask. The runner bypassed
Flask's schema check and entered `get_db_connection()`, where a newer
`etc/schema.sql` mtime caused final-state DDL to be replayed against a populated
stale database. `CREATE TABLE IF NOT EXISTS` could not add missing columns, so
later index creation failed with an internal SQLite error instead of migration
guidance.

## User impact

Flask and the runner now stop stale populated databases with the same concise
instruction to run `make migrate-db`. Neither path attempts compatibility DDL
as an upgrade. Empty databases still initialize normally.

## Validation

- `make pytest PYTEST_ARGS='tests/test_schema_flyway.py'` — 11 passed
- `make check`

Fixes #173

Authored by Codex AI Assistant.
