### PR TITLE
Prevent dashboard polling from blocking FCU controls

### DIFF
--- a/app/static/room_dashboard.js
+++ b/app/static/room_dashboard.js
@@ -30,6 +30,9 @@ async function apiCall(endpoint, body, errorMessage) {
             body: JSON.stringify(body)
         });
         const result = await response.json();
+        if (!response.ok) {
+            throw new Error(result.error || `Request failed (${response.status})`);
+        }
         if (DEBUG) {
             console.log(`${endpoint} result:`, result);
         }
@@ -372,22 +375,35 @@ function updateSensorTemperatures() {
     });
 }
 
-/**
- * Refresh device status from API.
- */
-function refreshStatus() {
-    fetch('/api/v1/status')
-        .then(response => response.json())
-        .then(data => {
+/** Create a status refresher that permits only one request at a time. */
+function createStatusRefresher(request = fetch, update = updateDeviceStatus) {
+    let inFlight = false;
+    return async function refresh() {
+        if (inFlight) {
+            return false;
+        }
+        inFlight = true;
+        try {
+            const response = await request('/api/v1/status');
+            if (!response.ok) {
+                throw new Error(`Status request failed (${response.status})`);
+            }
+            const data = await response.json();
             if (DEBUG) {
                 console.log('Status data received:', data);
             }
-            updateDeviceStatus(data.devices);
-        })
-        .catch(error => {
+            update(data.devices);
+            return true;
+        } catch (error) {
             console.error('Failed to refresh status:', error);
-        });
+            return false;
+        } finally {
+            inFlight = false;
+        }
+    };
 }
+
+const refreshStatus = createStatusRefresher();
 
 /**
  * Initialize sensor temperatures from template data.
@@ -462,13 +478,24 @@ function setDimmerLevel(level) {
 /**
  * Fetch room control status and update UI.
  */
-function refreshRoomStatus() {
-    fetch(roomControlEndpoint('room_status'))
-        .then(response => response.json())
+function requestRoomStatus(endpoint, request = fetch) {
+    return request(endpoint).then(response => {
+        if (!response.ok) {
+            throw new Error(`Room status request failed: ${response.status}`);
+        }
+        return response.json();
+    });
+}
+
+function refreshRoomStatus(request = fetch, documentRef = document) {
+    if (!documentRef.querySelector('.room-controls-card')) {
+        return Promise.resolve(false);
+    }
+    return requestRoomStatus(roomControlEndpoint('room_status'), request)
         .then(data => {
             if (data.dimmer) {
-                const slider = document.getElementById('dimmer-slider');
-                const valueEl = document.getElementById('dimmer-value');
+                const slider = documentRef.getElementById('dimmer-slider');
+                const valueEl = documentRef.getElementById('dimmer-value');
                 if (slider && !slider.matches(':active')) {
                     slider.value = data.dimmer.level;
                 }
@@ -482,11 +509,13 @@ function refreshRoomStatus() {
             if (data.wall_outer) {
                 updateWallButton('outer', data.wall_outer.switch);
             }
+            return true;
         })
         .catch(error => {
             if (DEBUG) {
                 console.error('Failed to refresh room status:', error);
             }
+            return false;
         });
 }
 
@@ -733,5 +762,11 @@ if (typeof window !== 'undefined') {
 
 // Node.js export for testing.
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { computeFitScale, roomControlEndpoint };
+    module.exports = {
+        computeFitScale,
+        createStatusRefresher,
+        refreshRoomStatus,
+        requestRoomStatus,
+        roomControlEndpoint,
+    };
 }

--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -60,12 +60,37 @@ const DEVICE_DISPLAY_NAME_KEY = "display_name";
 // Refresh logic
 var start = Date.now();
 var forceRefresh = false;
+const pendingFanRadioIds = new Map();
 
 // Store weather data globally so it can be re-rendered when unit changes
 let currentWeatherData = null;
 
 ////////////////////////////////////////////////////////////////
 // Shared helpers
+
+/**
+ * Run at most one instance of an asynchronous operation at a time.
+ * Calls made while the operation is active are skipped.
+ *
+ * @returns {Function} Single-flight async runner.
+ */
+function createSingleFlight() {
+  let inFlight = false;
+  return async (operation) => {
+    if (inFlight) {
+      return false;
+    }
+    inFlight = true;
+    try {
+      await operation();
+      return true;
+    } finally {
+      inFlight = false;
+    }
+  };
+}
+
+const runStatusRefresh = createSingleFlight();
 
 /**
  * Decide which fan-speed radio button should be selected for a device.
@@ -78,9 +103,13 @@ let currentWeatherData = null;
  * Auto (-1) case — matching room_dashboard.js.
  *
  * @param {Object} dev - Device data object from /api/v1/status.
+ * @param {string|null} pendingRadioId - User selection awaiting confirmation.
  * @returns {string|null} The id of the radio to select, or null if undetermined.
  */
-function fanRadioIdForDevice(dev) {
+function fanRadioIdForDevice(dev, pendingRadioId = null) {
+  if (pendingRadioId) {
+    return pendingRadioId;
+  }
   const isOff = dev.drive === "Off" || dev.drive === 0 || !dev.drive;
   const currentSpeed = dev.fan_speed || dev.speed;
   const speedValue = currentSpeed != null ? parseInt(currentSpeed) : null;
@@ -1704,11 +1733,16 @@ async function setDrive(device_id, drive) {
       body: JSON.stringify({ device_id: device_id, drive: drive }),
     });
     const result = await response.json();
+    if (!response.ok) {
+      throw new Error(result.error || "Unable to set drive.");
+    }
     console.log("Set drive: result=", result);
     forceRefresh = true;
+    return true;
   } catch (e) {
     console.error("Failed to set drive:", e);
     alert("Error setting drive.");
+    return false;
   }
 }
 
@@ -1723,11 +1757,16 @@ async function setFanSpeed(device_id, fan_speed) {
       body: JSON.stringify({ device_id: device_id, fan_speed: fan_speed }),
     });
     const result = await response.json();
+    if (!response.ok) {
+      throw new Error(result.error || "Unable to set fan speed.");
+    }
     console.log("Set fan_speed: result=", result);
     forceRefresh = true;
+    return true;
   } catch (e) {
     console.error("Failed to set fan_speed:", e);
     alert("Error setting fan_speed.");
+    return false;
   }
 }
 
@@ -1797,22 +1836,26 @@ function setupMatrixListeners() {
     'input[type="radio"][x-data-device-id]',
   );
   radioButtons.forEach((radio) => {
-    radio.addEventListener("change", function () {
+    radio.addEventListener("change", async function () {
       const deviceId = parseInt(this.getAttribute("x-data-device-id"));
       const fan_speed = parseInt(this.getAttribute("x-data-fan_speed"));
+      pendingFanRadioIds.set(deviceId, this.id);
 
-      // Off button (0): turn off drive
-      if (fan_speed === 0) {
-        setDrive(deviceId, 0);
-      }
-      // Speed buttons: turn on drive AND set speed
-      else {
-        Promise.all([
-          setDrive(deviceId, 1),
-          setFanSpeed(deviceId, fan_speed),
-        ]).catch((error) => {
-          console.error("Error setting drive and speed:", error);
-        });
+      try {
+        // Off button (0): turn off drive
+        if (fan_speed === 0) {
+          await setDrive(deviceId, 0);
+        }
+        // Speed buttons: turn on drive AND set speed
+        else {
+          await Promise.all([
+            setDrive(deviceId, 1),
+            setFanSpeed(deviceId, fan_speed),
+          ]);
+        }
+      } finally {
+        pendingFanRadioIds.delete(deviceId);
+        forceRefresh = true;
       }
     });
   });
@@ -2684,8 +2727,14 @@ const refreshGridRows = () => {
 
   // If it's time to refresh, run the status api and update all of the temps, fan_speeds, and status columsn
   if (secondsUntilRefresh <= 0) {
-    fetch("/api/v1/status", { method: "GET" })
-      .then((response) => response.json())
+    runStatusRefresh(() =>
+      fetch("/api/v1/status", { method: "GET" })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Status request failed (${response.status})`);
+        }
+        return response.json();
+      })
       .then((data) => {
         if (DEBUG) {
           console.log("Status data received:", data);
@@ -2872,7 +2921,10 @@ const refreshGridRows = () => {
             updateModeControlForDevice(dev);
 
             // Update radio button selection based on drive and speed state.
-            const radioId = fanRadioIdForDevice(dev);
+            const radioId = fanRadioIdForDevice(
+              dev,
+              pendingFanRadioIds.get(dev.device_id),
+            );
             if (radioId) {
               const radio = document.getElementById(radioId);
               if (radio) {
@@ -2905,7 +2957,8 @@ const refreshGridRows = () => {
         console.error("Error refreshing leaderboard:", error);
         // Still update the refresh time on error to prevent rapid retries
         lastRefreshTime = now;
-      });
+      }),
+    );
   }
   setTimeout(refreshGridRows, 1000); // Schedule next check in 1 second
 };
@@ -3207,6 +3260,7 @@ if (typeof module !== "undefined" && module.exports) {
     collectFcuTempSourceChanges,
     autoSetTempRangeForDevice,
     compactAgeFromSeconds,
+    createSingleFlight,
     dashboardAirQualityDeviceIsActive,
     deviceDisplayNameChanged,
     deviceDisplayNamePatchBody,

--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -92,6 +92,13 @@ function createSingleFlight() {
 
 const runStatusRefresh = createSingleFlight();
 
+/** Clear a pending fan change only if this request still owns it. */
+function clearPendingFanChange(pendingChanges, deviceId, change) {
+  if (pendingChanges.get(deviceId) === change) {
+    pendingChanges.delete(deviceId);
+  }
+}
+
 /**
  * Decide which fan-speed radio button should be selected for a device.
  *
@@ -1839,7 +1846,8 @@ function setupMatrixListeners() {
     radio.addEventListener("change", async function () {
       const deviceId = parseInt(this.getAttribute("x-data-device-id"));
       const fan_speed = parseInt(this.getAttribute("x-data-fan_speed"));
-      pendingFanRadioIds.set(deviceId, this.id);
+      const pendingChange = { radioId: this.id };
+      pendingFanRadioIds.set(deviceId, pendingChange);
 
       try {
         // Off button (0): turn off drive
@@ -1854,7 +1862,7 @@ function setupMatrixListeners() {
           ]);
         }
       } finally {
-        pendingFanRadioIds.delete(deviceId);
+        clearPendingFanChange(pendingFanRadioIds, deviceId, pendingChange);
         forceRefresh = true;
       }
     });
@@ -2923,7 +2931,7 @@ const refreshGridRows = () => {
             // Update radio button selection based on drive and speed state.
             const radioId = fanRadioIdForDevice(
               dev,
-              pendingFanRadioIds.get(dev.device_id),
+              pendingFanRadioIds.get(dev.device_id)?.radioId,
             );
             if (radioId) {
               const radio = document.getElementById(radioId);
@@ -3260,6 +3268,7 @@ if (typeof module !== "undefined" && module.exports) {
     collectFcuTempSourceChanges,
     autoSetTempRangeForDevice,
     compactAgeFromSeconds,
+    clearPendingFanChange,
     createSingleFlight,
     dashboardAirQualityDeviceIsActive,
     deviceDisplayNameChanged,

--- a/tests/test_room_scale.js
+++ b/tests/test_room_scale.js
@@ -11,6 +11,9 @@
  */
 const {
   computeFitScale,
+  createStatusRefresher,
+  refreshRoomStatus,
+  requestRoomStatus,
   roomControlEndpoint,
 } = require("../app/static/room_dashboard.js");
 
@@ -64,5 +67,77 @@ if (roomControlEndpoint("wall_light", "Hickory & East") ===
   console.error("FAIL room control endpoint must encode the dynamic room key");
 }
 
-console.log(`\n${passed} passed, ${failed} failed`);
-process.exit(failed === 0 ? 0 : 1);
+async function testRoomStatusPolling() {
+  let requests = 0;
+  const unconfiguredDocument = { querySelector: () => null };
+  const refreshed = await refreshRoomStatus(
+    () => { requests++; },
+    unconfiguredDocument,
+  );
+  if (refreshed === false && requests === 0) {
+    passed++;
+  } else {
+    failed++;
+    console.error("FAIL unconfigured room must not request room-control status");
+  }
+
+  let parsedErrorBody = false;
+  try {
+    await requestRoomStatus("/room-status", async () => ({
+      ok: false,
+      status: 404,
+      json: async () => { parsedErrorBody = true; return { error: "missing" }; },
+    }));
+    failed++;
+    console.error("FAIL non-OK room status must reject");
+  } catch (error) {
+    if (error.message === "Room status request failed: 404" && !parsedErrorBody) {
+      passed++;
+    } else {
+      failed++;
+      console.error(`FAIL non-OK room status rejection: ${error.message}`);
+    }
+  }
+}
+
+async function testDeviceStatusSingleFlight() {
+  let releaseRequest;
+  let requests = 0;
+  let updates = 0;
+  const responseReady = new Promise(resolve => { releaseRequest = resolve; });
+  const refreshStatus = createStatusRefresher(
+    async () => {
+      requests++;
+      await responseReady;
+      return { ok: true, json: async () => ({ devices: [{ device_id: 1 }] }) };
+    },
+    devices => { updates += devices.length; },
+  );
+
+  const firstRefresh = refreshStatus();
+  const overlappingRefresh = await refreshStatus();
+  if (overlappingRefresh === false && requests === 1 && updates === 0) {
+    passed++;
+  } else {
+    failed++;
+    console.error('FAIL room device status requests must not overlap');
+  }
+  releaseRequest();
+  if (await firstRefresh && updates === 1) {
+    passed++;
+  } else {
+    failed++;
+    console.error('FAIL completed room device status must update once');
+  }
+}
+
+testRoomStatusPolling()
+  .then(testDeviceStatusSingleFlight)
+  .catch(error => {
+    failed++;
+    console.error(`FAIL room status polling tests: ${error.message}`);
+  })
+  .finally(() => {
+    console.log(`\n${passed} passed, ${failed} failed`);
+    process.exit(failed === 0 ? 0 : 1);
+  });

--- a/tests/test_unit_speed.js
+++ b/tests/test_unit_speed.js
@@ -12,6 +12,7 @@ const {
   collectFcuTempSourceChanges,
   autoSetTempRangeForDevice,
   compactAgeFromSeconds,
+  createSingleFlight,
   dashboardAirQualityDeviceIsActive,
   deviceDisplayNameChanged,
   deviceDisplayNamePatchBody,
@@ -122,6 +123,36 @@ function fakeWidget() {
   };
 }
 
+async function testSingleFlightStatusRefresh() {
+  let releaseFirst;
+  let calls = 0;
+  const firstOperation = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+  const runSingleFlight = createSingleFlight();
+
+  const firstRun = runSingleFlight(async () => {
+    calls++;
+    await firstOperation;
+  });
+  const overlappingRun = await runSingleFlight(async () => {
+    calls++;
+  });
+  check("overlapping status refresh is skipped", overlappingRun, false);
+  check("only one status refresh starts", calls, 1);
+
+  releaseFirst();
+  check("first status refresh completes", await firstRun, true);
+  check(
+    "status refresh can run after completion",
+    await runSingleFlight(async () => {
+      calls++;
+    }),
+    true,
+  );
+  check("second sequential status refresh starts", calls, 2);
+}
+
 // -- The bug: off unit holding Auto must show Off, not Auto --
 check(
   "off + held Auto (-1) -> Off",
@@ -136,6 +167,14 @@ check(
 check(
   "drive string 'Off' + held Auto -> Off",
   fanRadioIdForDevice({ device_id: 7, drive: "Off", fan_speed: -1 }),
+  "radio-7-0",
+);
+check(
+  "pending Off selection is not overwritten by stale High status",
+  fanRadioIdForDevice(
+    { device_id: 7, drive: 1, fan_speed: 4 },
+    "radio-7-0",
+  ),
   "radio-7-0",
 );
 
@@ -1378,6 +1417,7 @@ check(
 check("range set temp matching update clears state", pendingRangeWidget.dataset.updateState, undefined);
 
 Promise.resolve()
+  .then(testSingleFlightStatusRefresh)
   .then(testRoomEditorRefreshHandlesRejection)
   .then(testEnableRulesForDevicePost)
   .then(testFcuBatchSavePost)

--- a/tests/test_unit_speed.js
+++ b/tests/test_unit_speed.js
@@ -12,6 +12,7 @@ const {
   collectFcuTempSourceChanges,
   autoSetTempRangeForDevice,
   compactAgeFromSeconds,
+  clearPendingFanChange,
   createSingleFlight,
   dashboardAirQualityDeviceIsActive,
   deviceDisplayNameChanged,
@@ -151,6 +152,22 @@ async function testSingleFlightStatusRefresh() {
     true,
   );
   check("second sequential status refresh starts", calls, 2);
+}
+
+function testPendingFanChangeOwnership() {
+  const pendingChanges = new Map();
+  const olderChange = { radioId: "radio-7-4" };
+  const newerChange = { radioId: "radio-7-0" };
+  pendingChanges.set(7, newerChange);
+
+  clearPendingFanChange(pendingChanges, 7, olderChange);
+  check(
+    "older request cannot clear newer pending fan selection",
+    pendingChanges.get(7),
+    newerChange,
+  );
+  clearPendingFanChange(pendingChanges, 7, newerChange);
+  check("owning request clears pending fan selection", pendingChanges.has(7), false);
 }
 
 // -- The bug: off unit holding Auto must show Off, not Auto --
@@ -1417,6 +1434,7 @@ check(
 check("range set temp matching update clears state", pendingRangeWidget.dataset.updateState, undefined);
 
 Promise.resolve()
+  .then(testPendingFanChangeOwnership)
   .then(testSingleFlightStatusRefresh)
   .then(testRoomEditorRefreshHandlesRejection)
   .then(testEnableRulesForDevicePost)


### PR DESCRIPTION
> Prepared by Codex for the 2026-07-14 production incident. Refs #177.

## What changed

- permit only one `/api/v1/status` request in flight from either the FCU matrix or a room dashboard
- preserve an FCU user's pending Off/speed selection until its control request settles, so stale status cannot flip the radio control back
- reject non-2xx status, drive, fan-speed, and room-control responses instead of treating error payloads as successful data
- avoid polling room-control endpoints on dashboards that do not have configured room controls
- add substantive regression coverage for overlapping requests, pending Off reconciliation, unconfigured rooms, and HTTP errors

## Why

Production `/api/v1/status` became slow after the rooms deployment. Both browser polling loops could start additional requests before earlier requests completed, filling the browser connection pool and all synchronous Gunicorn workers. During Carl's Greenhouse report, nginx received repeated status requests but no Off POST; when a later Off POST reached the backend, it took effect immediately and remained Off.

This hotfix bounds each browser view to one status request at a time and prevents an unresolved user command from being visually overwritten by stale status. The expensive backend query remains tracked in #177 and requires a separate database-focused fix.

## Validation

- `make test-js` (all suites passed; `test_unit_speed.js`: 160, `test_room_scale.js`: 14)
- `make check` (Ruff, no-type-ignore, Pylint 10/10, djlint, ESLint, mypy, and Flyway validation passed)
- `git diff --check`
