### PR TITLE
Separate room and HVAC unit naming

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -809,6 +809,27 @@ def update_room(conn, room: Room) -> Room | None:
     return get_room(conn, room.room_id)
 
 
+def delete_empty_room(conn, room_id: int) -> bool:
+    """Delete a room only when it owns no FCU and has no assigned devices."""
+    c = conn.cursor()
+    c.execute(
+        """
+        DELETE FROM rooms
+        WHERE room_id=?
+          AND fcu_device_id IS NULL
+          AND NOT EXISTS (SELECT 1 FROM devices WHERE devices.room_id=rooms.room_id)
+        """,
+        (room_id,),
+    )
+    if c.rowcount == 0:
+        c.execute("SELECT 1 FROM rooms WHERE room_id=?", (room_id,))
+        if c.fetchone() is None:
+            return False
+        raise ValueError("Only rooms without assigned devices can be deleted")
+    conn.commit()
+    return True
+
+
 def update_device_room(conn, device_id: int, room_id: int | None) -> int:
     c = conn.cursor()
     c.execute(

--- a/app/db.py
+++ b/app/db.py
@@ -830,9 +830,12 @@ def delete_empty_room(conn, room_id: int) -> bool:
     )
     if c.rowcount == 0:
         conn.rollback()
-        c.execute("SELECT 1 FROM rooms WHERE room_id=?", (room_id,))
-        if c.fetchone() is None:
+        c.execute("SELECT fcu_device_id FROM rooms WHERE room_id=?", (room_id,))
+        room = c.fetchone()
+        if room is None:
             return False
+        if room["fcu_device_id"] is not None:
+            raise ValueError("FCU-owned rooms cannot be deleted")
         raise ValueError("Only rooms without assigned devices can be deleted")
     conn.commit()
     return True

--- a/app/db.py
+++ b/app/db.py
@@ -818,26 +818,43 @@ def update_room(conn, room: Room) -> Room | None:
 
 def delete_empty_room(conn, room_id: int) -> bool:
     """Delete a room only when it owns no FCU and has no assigned devices."""
-    c = conn.cursor()
-    c.execute(
-        """
-        DELETE FROM rooms
-        WHERE room_id=?
-          AND fcu_device_id IS NULL
-          AND NOT EXISTS (SELECT 1 FROM devices WHERE devices.room_id=rooms.room_id)
-        """,
-        (room_id,),
-    )
-    if c.rowcount == 0:
-        conn.rollback()
-        c.execute("SELECT fcu_device_id FROM rooms WHERE room_id=?", (room_id,))
-        room = c.fetchone()
+    with conn:
+        room = conn.execute(
+            """
+            SELECT fcu_device_id,
+                   EXISTS(
+                       SELECT 1 FROM devices WHERE devices.room_id=rooms.room_id
+                   ) AS has_assigned_devices
+            FROM rooms
+            WHERE room_id=?
+            """,
+            (room_id,),
+        ).fetchone()
         if room is None:
             return False
         if room["fcu_device_id"] is not None:
             raise ValueError("FCU-owned rooms cannot be deleted")
-        raise ValueError("Only rooms without assigned devices can be deleted")
-    conn.commit()
+        if room["has_assigned_devices"]:
+            raise ValueError("Only rooms without assigned devices can be deleted")
+
+        # Presence history describes where an observation happened. Preserve the
+        # event when its now-empty administrative room is removed.
+        conn.execute(
+            "UPDATE presence_events SET room_id=NULL WHERE room_id=?", (room_id,)
+        )
+        deleted = conn.execute(
+            """
+            DELETE FROM rooms
+            WHERE room_id=?
+              AND fcu_device_id IS NULL
+              AND NOT EXISTS(
+                  SELECT 1 FROM devices WHERE devices.room_id=rooms.room_id
+              )
+            """,
+            (room_id,),
+        )
+        if deleted.rowcount != 1:
+            raise ValueError("Only rooms without assigned devices can be deleted")
     return True
 
 

--- a/app/db.py
+++ b/app/db.py
@@ -757,6 +757,13 @@ def get_rooms(conn) -> list[Room]:
     return [_room_from_row(row) for row in c.fetchall()]
 
 
+def get_assigned_room_ids(conn) -> set[int]:
+    """Return room ids referenced by any device, including devices without logs."""
+    c = conn.cursor()
+    c.execute("SELECT DISTINCT room_id FROM devices WHERE room_id IS NOT NULL")
+    return {int(row["room_id"]) for row in c.fetchall()}
+
+
 def get_room(conn, room_id: int) -> Room | None:
     c = conn.cursor()
     c.execute("SELECT * FROM rooms WHERE room_id=?", (room_id,))
@@ -822,6 +829,7 @@ def delete_empty_room(conn, room_id: int) -> bool:
         (room_id,),
     )
     if c.rowcount == 0:
+        conn.rollback()
         c.execute("SELECT 1 FROM rooms WHERE room_id=?", (room_id,))
         if c.fetchone() is None:
             return False

--- a/app/display_names.py
+++ b/app/display_names.py
@@ -87,4 +87,9 @@ def display_device_name(
     return base
 
 
-__all__ = ["display_device_name"]
+def append_display_icon(label: str, icon: str) -> str:
+    """Append one presentation icon unless the label already ends with it."""
+    return f"{label} {icon}" if icon and not label.rstrip().endswith(icon) else label
+
+
+__all__ = ["append_display_icon", "display_device_name"]

--- a/app/models.py
+++ b/app/models.py
@@ -680,6 +680,7 @@ class RoomMatrixGroup(BaseModel):
     fcu_device_id: int | None = None
     calculated_temp10x: int | None = None
     calculated_humidity: float | None = None
+    can_delete: bool = False
     devices: list[DeviceStatus] = Field(default_factory=list)
 
 

--- a/app/routes_api.py
+++ b/app/routes_api.py
@@ -532,6 +532,19 @@ def update_room(conn, room_id: int):
     return jsonify(json_ready(room))
 
 
+@api_v1.delete("/rooms/<int:room_id>")
+@with_db_connection
+def delete_room(conn, room_id: int):
+    """Delete a room only when it has no assigned devices."""
+    try:
+        deleted = db.delete_empty_room(conn, room_id)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 409
+    if not deleted:
+        return jsonify({"error": "room not found"}), 404
+    return "", 204
+
+
 @api_v1.route("/update_device_room", methods=["POST"])
 @validate()
 @with_db_connection

--- a/app/routes_api.py
+++ b/app/routes_api.py
@@ -535,7 +535,7 @@ def update_room(conn, room_id: int):
 @api_v1.delete("/rooms/<int:room_id>")
 @with_db_connection
 def delete_room(conn, room_id: int):
-    """Delete a room only when it has no assigned devices."""
+    """Delete a room only when it has no FCU owner or assigned devices."""
     try:
         deleted = db.delete_empty_room(conn, room_id)
     except ValueError as e:

--- a/app/routes_web.py
+++ b/app/routes_web.py
@@ -182,7 +182,9 @@ def _index_table_update_summaries(
 
 
 def _room_matrix_groups(
-    devices: list[dict[str, Any]], rooms: list[Room]
+    devices: list[dict[str, Any]],
+    rooms: list[Room],
+    assigned_room_ids: set[int],
 ) -> list[RoomMatrixGroup]:
     """Group active sensor rows by canonical room, including empty rooms."""
     fcu_by_room = {
@@ -190,11 +192,6 @@ def _room_matrix_groups(
         for device in devices
         if str(device.get("device_type") or "").upper() == DEVICE_TYPE_FCU
         and device.get("room_id") is not None
-    }
-    assigned_room_ids = {
-        device.get("room_id")
-        for device in devices
-        if device.get("room_id") is not None
     }
     groups = {
         room.room_id: RoomMatrixGroup(
@@ -296,7 +293,11 @@ def _register_core_routes(app):
             devices=device_data,
             now=now,
             table_update_summaries=_index_table_update_summaries(device_data, now),
-            room_groups=_room_matrix_groups(device_data, db.get_rooms(conn)),
+            room_groups=_room_matrix_groups(
+                device_data,
+                db.get_rooms(conn),
+                db.get_assigned_room_ids(conn),
+            ),
             current_page="home",
         )
 

--- a/app/routes_web.py
+++ b/app/routes_web.py
@@ -191,6 +191,11 @@ def _room_matrix_groups(
         if str(device.get("device_type") or "").upper() == DEVICE_TYPE_FCU
         and device.get("room_id") is not None
     }
+    assigned_room_ids = {
+        device.get("room_id")
+        for device in devices
+        if device.get("room_id") is not None
+    }
     groups = {
         room.room_id: RoomMatrixGroup(
             room_id=room.room_id,
@@ -201,6 +206,9 @@ def _room_matrix_groups(
             ),
             calculated_humidity=(fcu_by_room.get(room.room_id) or {}).get(
                 "calculated_humidity"
+            ),
+            can_delete=(
+                room.fcu_device_id is None and room.room_id not in assigned_room_ids
             ),
         )
         for room in rooms

--- a/app/routes_web.py
+++ b/app/routes_web.py
@@ -16,14 +16,19 @@ from typing import Any
 from flask import render_template, request, redirect, url_for
 
 from .constants import DASHBOARD_AIR_QUALITY_DEVICE_EXPIRATION_SECONDS
-from .device_types import DEVICE_TYPE_ERV, DEVICE_TYPE_FCU, DEVICE_TYPE_INTERNAL
+from .device_types import (
+    DEVICE_TYPE_ERV,
+    DEVICE_TYPE_FCU,
+    DEVICE_TYPE_INTERNAL,
+    DEVICE_TYPE_SENSOR,
+)
 from .version import __version__
 from . import db
 from . import db_alerts
 from . import rules_engine
 from . import hubitat
 from . import room_config
-from .display_names import display_device_name
+from .display_names import append_display_icon, display_device_name
 from .models import (
     DeviceMetadataControl,
     DeviceStatus,
@@ -44,6 +49,12 @@ from .room_metrics import RoomMetric, select_room_metric_sources
 from .presence import PRESENCE_STALE_SECONDS, get_room_presence
 
 logger = logging.getLogger(__name__)
+
+DASHBOARD_DEVICE_ICONS = {
+    DEVICE_TYPE_ERV: "♻️",
+    DEVICE_TYPE_FCU: "🌀",
+    DEVICE_TYPE_SENSOR: "📡",
+}
 
 # Display metadata for per-metric chart pages. Keyed on the URL-safe metric
 # name (same keys as db.AQ_METRIC_STATUS_KEYS). Radon uses its default Bq/m³
@@ -246,6 +257,16 @@ def _dashboard_device_label(device: dict[str, Any]) -> str:
     )
 
 
+def _dashboard_device_label_with_icon(device: dict[str, Any]) -> str:
+    """Return the server-rendered label with one device-category marker."""
+    label = str(device.get("device_label") or _dashboard_device_label(device))
+    device_type = str(device.get("device_type") or "").upper()
+    icon = DASHBOARD_DEVICE_ICONS.get(device_type, "")
+    if not icon and device.get("dashboard_air_quality_active"):
+        icon = DASHBOARD_DEVICE_ICONS[DEVICE_TYPE_SENSOR]
+    return append_display_icon(label, icon)
+
+
 def _dashboard_device_tooltip(device: dict[str, Any], now: int) -> str:
     """Return the Unit-column tooltip for a device row."""
     raw_device_name = device.get("device_name", "")
@@ -281,11 +302,12 @@ def _register_core_routes(app):
 
         for d in device_data:
             d["device_label"] = _dashboard_device_label(d)
-            d["device_update_text"] = _dashboard_device_update_text(d, now)
-            d["device_update_tooltip"] = _dashboard_device_tooltip(d, now)
             d["dashboard_air_quality_active"] = (
                 _dashboard_air_quality_device_is_active(d, now)
             )
+            d["device_label_with_icon"] = _dashboard_device_label_with_icon(d)
+            d["device_update_text"] = _dashboard_device_update_text(d, now)
+            d["device_update_tooltip"] = _dashboard_device_tooltip(d, now)
 
         return render_template(
             "index.html",

--- a/app/static/room_matrix.js
+++ b/app/static/room_matrix.js
@@ -3,6 +3,7 @@
 const ROOM_LONG_PRESS_MS = 650;
 const ROOM_POINTER_SLOP_PX = 10;
 const ROOM_SHIFT_MS = 140;
+const ROOM_DELETE_CONFIRM_MS = 5000;
 
 function roomIdFromValue(value) {
   const normalized = String(value ?? "").trim();
@@ -60,7 +61,10 @@ function roomDisplayName(roomName, hasFcu) {
 }
 
 function roomDeleteCountdown(startedAt, now = Date.now()) {
-  const remaining = Math.max(0, Math.ceil((startedAt + 5000 - now) / 1000));
+  const remaining = Math.max(
+    0,
+    Math.ceil((startedAt + ROOM_DELETE_CONFIRM_MS - now) / 1000),
+  );
   return { enabled: remaining === 0, label: remaining ? `OK (${remaining})` : "OK" };
 }
 

--- a/app/static/room_matrix.js
+++ b/app/static/room_matrix.js
@@ -584,9 +584,6 @@ function setupRoomMatrix() {
 
 if (typeof window !== "undefined") {
   window.addEventListener("DOMContentLoaded", setupRoomMatrix);
-  window.addEventListener("roomnamechange", (event) => {
-    applyMatrixRoomName(event.detail.roomId, event.detail.roomName);
-  });
   window.addEventListener("roommetricschange", (event) => {
     applyRoomMetrics(
       event.detail.roomId,

--- a/app/static/room_matrix.js
+++ b/app/static/room_matrix.js
@@ -388,6 +388,7 @@ function closeRoomDeleteDialog() {
   const dialog = document.getElementById("room-delete-dialog");
   if (!dialog) return;
   clearInterval(dialog._countdownTimer);
+  dialog._countdownTimer = null;
   dialog.classList.add("hidden");
 }
 
@@ -395,6 +396,8 @@ function openRoomDeleteDialog(roomId, roomName) {
   const dialog = document.getElementById("room-delete-dialog");
   const button = dialog?.querySelector("[data-action='confirm-room-delete']");
   if (!dialog || !button) return;
+  clearInterval(dialog._countdownTimer);
+  dialog._countdownTimer = null;
   dialog.dataset.roomId = String(roomId);
   dialog.querySelector("[data-role='room-name']").textContent = roomName;
   dialog.querySelector("[data-role='message']").textContent = "";
@@ -404,7 +407,10 @@ function openRoomDeleteDialog(roomId, roomName) {
     const state = roomDeleteCountdown(startedAt);
     button.disabled = !state.enabled;
     button.textContent = state.label;
-    if (state.enabled) clearInterval(dialog._countdownTimer);
+    if (state.enabled) {
+      clearInterval(dialog._countdownTimer);
+      dialog._countdownTimer = null;
+    }
   };
   update();
   dialog._countdownTimer = setInterval(update, 250);
@@ -595,6 +601,7 @@ if (typeof module !== "undefined" && module.exports) {
     compareSensors,
     deviceRoomRequest,
     longPressTriggered,
+    openRoomDeleteDialog,
     persistNewRoom,
     persistRoomDeletion,
     persistRoomName,

--- a/app/static/room_matrix.js
+++ b/app/static/room_matrix.js
@@ -37,6 +37,33 @@ async function persistRoomName(roomId, roomName, request = fetch) {
   return data;
 }
 
+async function persistNewRoom(roomName, request = fetch) {
+  const response = await request("/api/v1/rooms", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ room_name: roomName }),
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(data.error || "Unable to create room.");
+  return data;
+}
+
+async function persistRoomDeletion(roomId, request = fetch) {
+  const response = await request(`/api/v1/rooms/${roomId}`, { method: "DELETE" });
+  if (response.ok) return true;
+  const data = await response.json().catch(() => ({}));
+  throw new Error(data.error || "Unable to delete room.");
+}
+
+function roomDisplayName(roomName, hasFcu) {
+  return `${roomName}${String(hasFcu) === "true" ? " 🌀" : ""}`;
+}
+
+function roomDeleteCountdown(startedAt, now = Date.now()) {
+  const remaining = Math.max(0, Math.ceil((startedAt + 5000 - now) / 1000));
+  return { enabled: remaining === 0, label: remaining ? `OK (${remaining})` : "OK" };
+}
+
 function longPressTriggered(elapsedMs, movementPx) {
   return elapsedMs >= ROOM_LONG_PRESS_MS && movementPx <= ROOM_POINTER_SLOP_PX;
 }
@@ -255,8 +282,8 @@ function applyMatrixRoomName(roomId, roomName) {
   if (!separator || !button) return;
   separator.dataset.roomName = roomName;
   button.dataset.roomName = roomName;
-  button.textContent = roomName;
-  button.setAttribute("aria-label", `Rename ${roomName}`);
+  button.textContent = roomDisplayName(roomName, separator.dataset.hasFcu);
+  button.setAttribute("aria-label", `Manage room ${roomName}`);
   sortRoomGroups();
 }
 
@@ -288,8 +315,15 @@ function openRoomRenameDialog(button) {
   const input = document.getElementById("room-rename-name");
   if (!dialog || !input) return;
   dialog.dataset.roomId = button.dataset.roomId;
+  dialog.dataset.roomName = button.dataset.roomName || button.textContent.trim();
   input.value = button.dataset.roomName || button.textContent.trim();
   dialog.querySelector("[data-role='message']").textContent = "";
+  dialog
+    .querySelector("[data-action='request-room-delete']")
+    ?.classList.toggle(
+      "hidden",
+      button.closest(".room-separator")?.dataset.canDelete !== "true",
+    );
   dialog.classList.remove("hidden");
   input.focus();
   input.select();
@@ -309,17 +343,82 @@ async function renameRoom(dialog) {
     const savedRoomName = data.room_name || roomName;
     applyMatrixRoomName(roomId, savedRoomName);
     document
-      .querySelectorAll(`.fcu-room-editor-trigger[data-room-id="${roomId}"]`)
+      .querySelectorAll(`.fcu-temp-sources-trigger[data-room-id="${roomId}"]`)
       .forEach((trigger) => {
-        trigger.textContent = savedRoomName;
-        trigger.dataset.fcuTempSourcesRoomName = savedRoomName;
-        trigger.setAttribute("aria-label", `Edit room settings for ${savedRoomName}`);
-        trigger.setAttribute("title", `Edit room settings for ${savedRoomName}`);
+        trigger.dataset.roomName = savedRoomName;
       });
     closeRoomRenameDialog();
     showRoomMatrixMessage(`Renamed room to ${data.room_name || roomName}.`);
   } catch (error) {
     message.textContent = error.message || "Unable to rename room.";
+  }
+}
+
+function closeRoomCreateDialog() {
+  document.getElementById("room-create-dialog")?.classList.add("hidden");
+}
+
+function openRoomCreateDialog() {
+  const dialog = document.getElementById("room-create-dialog");
+  const input = document.getElementById("room-create-name");
+  if (!dialog || !input) return;
+  input.value = "";
+  dialog.querySelector("[data-role='message']").textContent = "";
+  dialog.classList.remove("hidden");
+  input.focus();
+}
+
+async function createRoom(dialog) {
+  const input = document.getElementById("room-create-name");
+  const message = dialog.querySelector("[data-role='message']");
+  const roomName = String(input?.value || "").trim();
+  if (!roomName) {
+    message.textContent = "Room name is required.";
+    return;
+  }
+  try {
+    await persistNewRoom(roomName);
+    window.location.reload();
+  } catch (error) {
+    message.textContent = error.message || "Unable to create room.";
+  }
+}
+
+function closeRoomDeleteDialog() {
+  const dialog = document.getElementById("room-delete-dialog");
+  if (!dialog) return;
+  clearInterval(dialog._countdownTimer);
+  dialog.classList.add("hidden");
+}
+
+function openRoomDeleteDialog(roomId, roomName) {
+  const dialog = document.getElementById("room-delete-dialog");
+  const button = dialog?.querySelector("[data-action='confirm-room-delete']");
+  if (!dialog || !button) return;
+  dialog.dataset.roomId = String(roomId);
+  dialog.querySelector("[data-role='room-name']").textContent = roomName;
+  dialog.querySelector("[data-role='message']").textContent = "";
+  dialog.classList.remove("hidden");
+  const startedAt = Date.now();
+  const update = () => {
+    const state = roomDeleteCountdown(startedAt);
+    button.disabled = !state.enabled;
+    button.textContent = state.label;
+    if (state.enabled) clearInterval(dialog._countdownTimer);
+  };
+  update();
+  dialog._countdownTimer = setInterval(update, 250);
+}
+
+async function deleteRoom(dialog) {
+  const roomId = roomIdFromValue(dialog.dataset.roomId);
+  const message = dialog.querySelector("[data-role='message']");
+  if (roomId === null) return;
+  try {
+    await persistRoomDeletion(roomId);
+    window.location.reload();
+  } catch (error) {
+    message.textContent = error.message || "Unable to delete room.";
   }
 }
 
@@ -369,6 +468,36 @@ function setupRoomRename() {
     "click",
     closeRoomRenameDialog,
   );
+  dialog?.querySelector("[data-action='request-room-delete']")?.addEventListener(
+    "click",
+    () => {
+      const roomId = roomIdFromValue(dialog.dataset.roomId);
+      if (roomId === null) return;
+      closeRoomRenameDialog();
+      openRoomDeleteDialog(roomId, dialog.dataset.roomName);
+    },
+  );
+
+  const createDialog = document.getElementById("room-create-dialog");
+  document.getElementById("new-room-button")?.addEventListener(
+    "click",
+    openRoomCreateDialog,
+  );
+  createDialog?.querySelector("form")?.addEventListener("submit", (event) => {
+    event.preventDefault();
+    createRoom(createDialog);
+  });
+  createDialog
+    ?.querySelector("[data-action='cancel-room-create']")
+    ?.addEventListener("click", closeRoomCreateDialog);
+
+  const deleteDialog = document.getElementById("room-delete-dialog");
+  deleteDialog
+    ?.querySelector("[data-action='confirm-room-delete']")
+    ?.addEventListener("click", () => deleteRoom(deleteDialog));
+  deleteDialog
+    ?.querySelector("[data-action='cancel-room-delete']")
+    ?.addEventListener("click", closeRoomDeleteDialog);
 }
 
 function setupRoomDragging() {
@@ -466,11 +595,15 @@ if (typeof module !== "undefined" && module.exports) {
     compareSensors,
     deviceRoomRequest,
     longPressTriggered,
+    persistNewRoom,
+    persistRoomDeletion,
     persistRoomName,
     persistSensorRoom,
     restoreSensorPosition,
     roomRenameKeyTriggered,
     roomHumidityText,
+    roomDeleteCountdown,
+    roomDisplayName,
     roomIdFromValue,
     roomNameSortKey,
     roomTemperatureC,

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -864,12 +864,12 @@ table.rules-table th  {
     cursor: context-menu;
 }
 
-.fcu-room-editor-trigger {
+.fcu-temp-sources-trigger {
     cursor: pointer;
 }
 
-.fcu-room-editor-trigger:hover,
-.fcu-room-editor-trigger:focus {
+.fcu-temp-sources-trigger:hover,
+.fcu-temp-sources-trigger:focus {
     text-decoration: underline;
     text-underline-offset: 0.12em;
 }
@@ -1190,6 +1190,17 @@ table.rules-table th  {
     gap: 0.45rem;
 }
 
+.room-delete-choice {
+    margin-right: auto;
+    color: #b42318;
+}
+
+.room-matrix-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.75rem;
+}
+
 .room-rename-message,
 .room-matrix-message.error {
     color: #b42318;
@@ -1214,6 +1225,11 @@ table.rules-table th  {
     white-space: normal;
     min-width: 150px;
     word-break: break-word;
+}
+
+.column-room,
+.cell-room {
+    min-width: 8rem;
 }
 
 /* Humidity column min width */

--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -948,7 +948,7 @@ function fcuTempSourcesTitle(roomName) {
 
 function deviceLabelWithIcon(label, deviceType) {
   const icon = DEVICE_TYPE_ICONS[normalizedDeviceType(deviceType)];
-  return icon ? `${label} ${icon}` : label;
+  return icon && !label.trimEnd().endsWith(icon) ? `${label} ${icon}` : label;
 }
 
 function setFcuTempSourcesTitle(popup, roomName) {

--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -54,8 +54,9 @@ const AUTO_SET_TEMP_COOL_KEY = "cool_set_temp_c";
 const FCU_TEMP_SOURCE_FCU_DEVICE_ID_KEY = "fcu_device_id";
 const FCU_TEMP_SOURCE_SOURCE_DEVICE_ID_KEY = "source_device_id";
 const FCU_TEMP_SOURCE_MULTIPLIER_KEY = "multiplier";
-const FCU_TEMP_SOURCE_TITLE = "Room Editor";
+const FCU_TEMP_SOURCE_TITLE = "FCU Temperature Sources";
 const DEVICE_DISPLAY_NAME_KEY = "display_name";
+const DEVICE_TYPE_ICONS = { ERV: "♻️", FCU: "🌀", SENSOR: "📡" };
 
 // Refresh logic
 var start = Date.now();
@@ -945,6 +946,11 @@ function fcuTempSourcesTitle(roomName) {
     : FCU_TEMP_SOURCE_TITLE;
 }
 
+function deviceLabelWithIcon(label, deviceType) {
+  const icon = DEVICE_TYPE_ICONS[normalizedDeviceType(deviceType)];
+  return icon ? `${label} ${icon}` : label;
+}
+
 function setFcuTempSourcesTitle(popup, roomName) {
   const title = popup.querySelector("[data-role='title']");
   if (title) {
@@ -1007,7 +1013,7 @@ function setFcuTempSourcesControlsDisabled(popup, disabled) {
   popup.dataset.saving = disabled ? "true" : "false";
   popup
     .querySelectorAll(
-      ".fcu-temp-source-weight, .fcu-room-display-name, .fcu-temp-sources-actions button",
+      ".fcu-temp-source-weight, .fcu-temp-sources-actions button",
     )
     .forEach((control) => {
       control.disabled = disabled;
@@ -1060,42 +1066,10 @@ function collectFcuTempSourceChanges(popup) {
   return { changes, error: "" };
 }
 
-function setFcuRoomEditorDisplayName(popup, displayName) {
-  const input = popup.querySelector("[data-role='display-name']");
-  const normalizedName = normalizedDeviceDisplayName(displayName);
-  popup.dataset.currentDisplayName = normalizedName;
-  if (input) {
-    input.value = normalizedName;
-    input.dataset.initialDisplayName = normalizedName;
-  }
-}
-
-function collectFcuRoomEditorDisplayNameChange(popup) {
-  const input = popup.querySelector("[data-role='display-name']");
-  if (!input) {
-    return { changed: false, displayName: "", error: "" };
-  }
-  const displayName = normalizedDeviceDisplayName(input.value);
-  if (!displayName) {
-    return {
-      changed: false,
-      displayName: "",
-      error: "Room name is required.",
-    };
-  }
-  return {
-    changed:
-      displayName !== normalizedDeviceDisplayName(popup.dataset.currentDisplayName),
-    displayName,
-    error: "",
-  };
-}
-
 function revertFcuTempSourceChanges(popup) {
   popup.querySelectorAll(".fcu-temp-source-weight").forEach((input) => {
     input.value = input.dataset.initialMultiplier;
   });
-  setFcuRoomEditorDisplayName(popup, popup.dataset.currentDisplayName);
   setFcuTempSourcesMessage(popup, "");
 }
 
@@ -1174,15 +1148,14 @@ async function loadFcuTempSourcesForCell(cell) {
   }
 
   const deviceId = parseInt(cell.dataset.deviceId, 10);
-  const displayName =
-    cell.dataset.fcuTempSourcesRoomName || cell.dataset.displayName || cell.textContent;
+  const displayName = cell.dataset.displayName || cell.dataset.deviceName;
   popup.dataset.updateUrl = updateUrl;
-  popup.dataset.roomUpdateUrl = cell.dataset.roomUpdateUrl || "";
   popup.dataset.roomId = cell.dataset.roomId || "";
   popup.dataset.deviceId = Number.isInteger(deviceId) ? String(deviceId) : "";
   popup.dataset.deviceName = cell.dataset.deviceName || "";
-  setFcuRoomEditorDisplayName(popup, displayName);
   setFcuTempSourcesTitle(popup, displayName);
+  const roomName = popup.querySelector("[data-role='room-name']");
+  if (roomName) roomName.textContent = cell.dataset.roomName || "Unassigned";
   popup.classList.remove("hidden");
   setFcuTempSourcesControlsDisabled(popup, false);
   setFcuTempSourcesMessage(popup, "Loading...");
@@ -1211,7 +1184,7 @@ function refreshOpenFcuRoomEditor(loadSources = loadFcuTempSourcesForCell) {
     return false;
   }
   const trigger = document.querySelector(
-    `.fcu-room-editor-trigger[data-device-id="${popup.dataset.deviceId}"]`,
+    `.fcu-temp-sources-trigger[data-device-id="${popup.dataset.deviceId}"]`,
   );
   if (!trigger) return false;
   Promise.resolve(loadSources(trigger)).catch((error) => {
@@ -1228,20 +1201,15 @@ async function saveFcuTempSourceMultipliers() {
 
   const updateUrl = popup.dataset.updateUrl;
   const { changes, error } = collectFcuTempSourceChanges(popup);
-  const displayNameChange = collectFcuRoomEditorDisplayNameChange(popup);
   if (error) {
     setFcuTempSourcesMessage(popup, error, true);
-    return;
-  }
-  if (displayNameChange.error) {
-    setFcuTempSourcesMessage(popup, displayNameChange.error, true);
     return;
   }
   if (!updateUrl) {
     setFcuTempSourcesMessage(popup, "Unable to save without an update URL.", true);
     return;
   }
-  if (changes.length === 0 && !displayNameChange.changed) {
+  if (changes.length === 0) {
     closeFcuTempSourcesPopup();
     return;
   }
@@ -1249,30 +1217,14 @@ async function saveFcuTempSourceMultipliers() {
   setFcuTempSourcesControlsDisabled(popup, true);
   setFcuTempSourcesMessage(popup, "Saving...");
   try {
-    if (displayNameChange.changed) {
-      if (!popup.dataset.roomUpdateUrl) {
-        throw new Error("This FCU does not have an editable room.");
-      }
-      const data = await patchRoomName(
-        popup.dataset.roomUpdateUrl,
-        displayNameChange.displayName,
-      );
-      const savedDisplayName = data.room_name || displayNameChange.displayName;
-      applyRoomName(popup.dataset.roomId, savedDisplayName);
-      setFcuRoomEditorDisplayName(popup, savedDisplayName);
-      setFcuTempSourcesTitle(popup, savedDisplayName);
-    }
-
-    if (changes.length > 0) {
-      const response = await fetch(updateUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(changes),
-      });
-      const data = await response.json();
-      if (!response.ok) {
-        throw new Error(data.error || "Unable to save weights.");
-      }
+    const response = await fetch(updateUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(changes),
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error || "Unable to save weights.");
     }
     forceRefresh = true;
     closeFcuTempSourcesPopup({ force: true });
@@ -1466,42 +1418,6 @@ async function patchDeviceDisplayName(deviceId, displayName, updateUrl = undefin
   return data;
 }
 
-async function patchRoomName(updateUrl, roomName) {
-  let response;
-  try {
-    response = await fetch(updateUrl, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ room_name: roomName }),
-    });
-  } catch (error) {
-    throw new Error(`NETWORK ${error.message}`);
-  }
-  const data = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    throw new Error(`${response.status} ${data.error || response.statusText}`);
-  }
-  return data;
-}
-
-function applyRoomName(roomId, roomName) {
-  document
-    .querySelectorAll(`[data-room-id="${roomId}"]`)
-    .forEach((element) => {
-      if (element.classList.contains("room-name")) element.textContent = roomName;
-      if (element.classList.contains("fcu-room-editor-trigger")) {
-        element.textContent = roomName;
-        element.dataset.fcuTempSourcesRoomName = roomName;
-        element.setAttribute("aria-label", `Edit room settings for ${roomName}`);
-        element.setAttribute("title", `Edit room settings for ${roomName}`);
-      }
-      element.dataset.roomName = roomName;
-    });
-  window.dispatchEvent(
-    new CustomEvent("roomnamechange", { detail: { roomId, roomName } }),
-  );
-}
-
 function applyDeviceDisplayName(
   deviceId,
   deviceName,
@@ -1513,7 +1429,7 @@ function applyDeviceDisplayName(
   document
     .querySelectorAll(`.device-name-context[data-device-id="${deviceId}"]`)
     .forEach((element) => {
-      element.textContent = label;
+      element.textContent = deviceLabelWithIcon(label, deviceType);
       element.dataset.deviceName = deviceName;
       element.dataset.displayName = label;
       if (deviceType !== undefined) {
@@ -1524,14 +1440,13 @@ function applyDeviceDisplayName(
           deviceRulesEnabledValue(rulesEnabled),
         );
       }
-      const isRoomEditorTrigger =
-        element.classList?.contains("fcu-room-editor-trigger");
-      if (isRoomEditorTrigger) {
-        element.dataset.fcuTempSourcesRoomName = label;
-        element.setAttribute("aria-label", `Edit room settings for ${label}`);
+      const isFcuTempSourcesTrigger =
+        element.classList?.contains("fcu-temp-sources-trigger");
+      if (isFcuTempSourcesTrigger) {
+        element.setAttribute("aria-label", `Edit temperature sources for ${label}`);
       }
-      const title = isRoomEditorTrigger
-        ? `Edit room settings for ${label}`
+      const title = isFcuTempSourcesTrigger
+        ? `Edit temperature sources for ${label}`
         : element.dataset.deviceUpdate
           ? `${deviceName}\nLast updated at ${element.dataset.deviceUpdate}`
           : deviceName;
@@ -1947,7 +1862,7 @@ function setupModeControls() {
 }
 
 function setupFcuTempSourcePopupControls() {
-  document.querySelectorAll(".fcu-room-editor-trigger").forEach((trigger) => {
+  document.querySelectorAll(".fcu-temp-sources-trigger").forEach((trigger) => {
     trigger.addEventListener("click", function (event) {
       event.preventDefault();
       loadFcuTempSourcesForCell(this);
@@ -3264,7 +3179,6 @@ if (typeof window !== "undefined") {
 // Node.js export for testing
 if (typeof module !== "undefined" && module.exports) {
   module.exports = {
-    collectFcuRoomEditorDisplayNameChange,
     collectFcuTempSourceChanges,
     autoSetTempRangeForDevice,
     compactAgeFromSeconds,
@@ -3272,6 +3186,7 @@ if (typeof module !== "undefined" && module.exports) {
     createSingleFlight,
     dashboardAirQualityDeviceIsActive,
     deviceDisplayNameChanged,
+    deviceLabelWithIcon,
     deviceDisplayNamePatchBody,
     deviceRulesEnabledValue,
     deviceUpdateText,
@@ -3292,7 +3207,6 @@ if (typeof module !== "undefined" && module.exports) {
     normalizeSetRange,
     oldestUpdateTimestampForTable,
     parseFcuTempSourceMultiplier,
-    patchRoomName,
     pendingRangeUpdateDecision,
     pendingSingleSetTempUpdateDecision,
     renderDisableCell,

--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -939,10 +939,10 @@ function formatAgeSeconds(seconds) {
   return remainder ? `${hours}h ${remainder}m` : `${hours}h`;
 }
 
-function fcuTempSourcesTitle(roomName) {
-  const trimmedRoomName = String(roomName || "").trim();
-  return trimmedRoomName
-    ? `${trimmedRoomName}: ${FCU_TEMP_SOURCE_TITLE}`
+function fcuTempSourcesTitle(unitLabel) {
+  const trimmedUnitLabel = String(unitLabel || "").trim();
+  return trimmedUnitLabel
+    ? `${trimmedUnitLabel}: ${FCU_TEMP_SOURCE_TITLE}`
     : FCU_TEMP_SOURCE_TITLE;
 }
 
@@ -951,10 +951,10 @@ function deviceLabelWithIcon(label, deviceType) {
   return icon && !label.trimEnd().endsWith(icon) ? `${label} ${icon}` : label;
 }
 
-function setFcuTempSourcesTitle(popup, roomName) {
+function setFcuTempSourcesTitle(popup, unitLabel) {
   const title = popup.querySelector("[data-role='title']");
   if (title) {
-    title.textContent = fcuTempSourcesTitle(roomName);
+    title.textContent = fcuTempSourcesTitle(unitLabel);
   }
 }
 

--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -946,8 +946,10 @@ function fcuTempSourcesTitle(unitLabel) {
     : FCU_TEMP_SOURCE_TITLE;
 }
 
-function deviceLabelWithIcon(label, deviceType) {
-  const icon = DEVICE_TYPE_ICONS[normalizedDeviceType(deviceType)];
+function deviceLabelWithIcon(label, deviceType, airQualityActive = false) {
+  const icon =
+    DEVICE_TYPE_ICONS[normalizedDeviceType(deviceType)] ||
+    (airQualityActive ? DEVICE_TYPE_ICONS.SENSOR : "");
   return icon && !label.trimEnd().endsWith(icon) ? `${label} ${icon}` : label;
 }
 
@@ -1424,12 +1426,21 @@ function applyDeviceDisplayName(
   displayName,
   deviceType = undefined,
   rulesEnabled = undefined,
+  airQualityActive = undefined,
 ) {
   const label = normalizedDeviceDisplayName(displayName) || deviceName;
   document
     .querySelectorAll(`.device-name-context[data-device-id="${deviceId}"]`)
     .forEach((element) => {
-      element.textContent = deviceLabelWithIcon(label, deviceType);
+      const elementAirQualityActive =
+        airQualityActive === undefined
+          ? element.dataset.airQualityActive === "true"
+          : Boolean(airQualityActive);
+      element.textContent = deviceLabelWithIcon(
+        label,
+        deviceType,
+        elementAirQualityActive,
+      );
       element.dataset.deviceName = deviceName;
       element.dataset.displayName = label;
       if (deviceType !== undefined) {
@@ -1439,6 +1450,9 @@ function applyDeviceDisplayName(
         element.dataset.rulesEnabled = String(
           deviceRulesEnabledValue(rulesEnabled),
         );
+      }
+      if (airQualityActive !== undefined) {
+        element.dataset.airQualityActive = String(elementAirQualityActive);
       }
       const isFcuTempSourcesTrigger =
         element.classList?.contains("fcu-temp-sources-trigger");
@@ -2960,6 +2974,7 @@ function updateDeviceDisplayName(dev) {
     displayName,
     deviceType,
     rulesEnabled,
+    dashboardAirQualityDeviceIsActive(dev),
   );
 }
 

--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -1178,7 +1178,7 @@ async function loadFcuTempSourcesForCell(cell) {
   }
 }
 
-function refreshOpenFcuRoomEditor(loadSources = loadFcuTempSourcesForCell) {
+function refreshOpenFcuTempSources(loadSources = loadFcuTempSourcesForCell) {
   const popup = document.getElementById("fcu-temp-sources-popup");
   if (!popup || popup.classList.contains("hidden") || !popup.dataset.deviceId) {
     return false;
@@ -1188,7 +1188,7 @@ function refreshOpenFcuRoomEditor(loadSources = loadFcuTempSourcesForCell) {
   );
   if (!trigger) return false;
   Promise.resolve(loadSources(trigger)).catch((error) => {
-    console.error("Failed to refresh FCU room editor:", error);
+    console.error("Failed to refresh FCU temperature sources:", error);
   });
   return true;
 }
@@ -3172,7 +3172,7 @@ if (typeof window !== "undefined") {
   });
   window.addEventListener("roomassignmentchange", () => {
     forceRefresh = true;
-    refreshOpenFcuRoomEditor();
+    refreshOpenFcuTempSources();
   });
 }
 
@@ -3211,7 +3211,7 @@ if (typeof module !== "undefined" && module.exports) {
     pendingSingleSetTempUpdateDecision,
     renderDisableCell,
     renderAutoSetTempRange,
-    refreshOpenFcuRoomEditor,
+    refreshOpenFcuTempSources,
     resizeSetRangeEndpoint,
     saveAutoSetTempWidget,
     saveFcuTempSourceMultipliers,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -41,6 +41,7 @@
                           data-device-name="{{ device.device_name }}"
                           data-display-name="{{ device.device_label }}"
                           data-device-type="{{ device.device_type or '' }}"
+                          data-air-quality-active="{{ 'true' if device.dashboard_air_quality_active else 'false' }}"
                           data-rules-enabled="{{ 'true' if device.rules_enabled|default(true) else 'false' }}"
                           data-device-update="{{ device.device_update_text|default('', true) }}"
                           title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label_with_icon }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
@@ -144,6 +145,7 @@
                           data-device-name="{{ device.device_name }}"
                           data-display-name="{{ device.device_label }}"
                           data-device-type="{{ device.device_type or '' }}"
+                          data-air-quality-active="{{ 'true' if device.dashboard_air_quality_active else 'false' }}"
                           data-rules-enabled="{{ 'true' if device.rules_enabled|default(true) else 'false' }}"
                           data-device-update="{{ device.device_update_text|default('', true) }}"
                           data-device-update-url="/api/v1/devices/{{ device.device_id }}"
@@ -373,6 +375,7 @@
                           data-device-name="{{ device.device_name }}"
                           data-display-name="{{ device.device_label }}"
                           data-device-type="{{ device.device_type or '' }}"
+                          data-air-quality-active="{{ 'true' if device.dashboard_air_quality_active else 'false' }}"
                           data-rules-enabled="{{ 'true' if device.rules_enabled|default(true) else 'false' }}"
                           data-device-update="{{ device.device_update_text|default('', true) }}"
                           title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label_with_icon }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -43,7 +43,7 @@
                           data-device-type="{{ device.device_type or '' }}"
                           data-rules-enabled="{{ 'true' if device.rules_enabled|default(true) else 'false' }}"
                           data-device-update="{{ device.device_update_text|default('', true) }}"
-                          title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label }} ♻️</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
+                          title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label_with_icon }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
                     <span id="device-{{ device.device_id }}-notes"></span>
                   </td>
                   <td class="cell-room">{{ device.room_name or '—' }}</td>
@@ -152,7 +152,7 @@
                           data-fcu-temp-source-update-url="/api/v1/fcu_temp_source"
                           data-room-name="{{ device.room_name or '' }}"
                           aria-label="Edit temperature sources for {{ device.device_label }}"
-                          title="Edit temperature sources for {{ device.device_label }}">{{ device.device_label }} 🌀</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
+                          title="Edit temperature sources for {{ device.device_label }}">{{ device.device_label_with_icon }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
                     <span id="device-{{ device.device_id }}-notes"></span>
                   </td>
                   <td class="cell-disable-for" id="disable-for-{{ device.device_id }}">
@@ -375,7 +375,7 @@
                           data-device-type="{{ device.device_type or '' }}"
                           data-rules-enabled="{{ 'true' if device.rules_enabled|default(true) else 'false' }}"
                           data-device-update="{{ device.device_update_text|default('', true) }}"
-                          title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label }} 📡</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
+                          title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label_with_icon }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
                     <span id="device-{{ device.device_id }}-notes"></span>
                   </td>
                   <td class="cell-humidity{% if device.has_humidity %} cell-metric-link{% endif %}" id="humidity-{{ device.device_id }}"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -17,6 +17,7 @@
           <thead>
             <tr>
               <th class="column-unit" rowspan="2">Unit</th>
+              <th class="column-room" rowspan="2">Room</th>
               <th class="column-disable-for" rowspan="2" title="Remaining time rules are disabled for this device (H:MM)">Rules<br>disabled<br>for</th>
               <th class="column-temp" rowspan="2">Temp<br><small id="erv-temp-unit-label">°C</small></th>
               <th class="column-speed" colspan="5">Fan Speed</th>
@@ -42,9 +43,10 @@
                           data-device-type="{{ device.device_type or '' }}"
                           data-rules-enabled="{{ 'true' if device.rules_enabled|default(true) else 'false' }}"
                           data-device-update="{{ device.device_update_text|default('', true) }}"
-                          title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
+                          title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label }} ♻️</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
                     <span id="device-{{ device.device_id }}-notes"></span>
                   </td>
+                  <td class="cell-room">{{ device.room_name or '—' }}</td>
                   <td class="cell-disable-for" id="disable-for-{{ device.device_id }}">
                     <span class="disable-thermostat" role="group" aria-label="Adjust rules disable timer">
                       <button type="button"
@@ -96,7 +98,7 @@
           </tbody>
           <tfoot>
             <tr>
-              <td colspan="9" class="table-update-summary" id="oldest-update-erv">{{ table_update_summaries.erv.label if table_update_summaries.erv else '' }}</td>
+              <td colspan="10" class="table-update-summary" id="oldest-update-erv">{{ table_update_summaries.erv.label if table_update_summaries.erv else '' }}</td>
             </tr>
           </tfoot>
         </table>
@@ -105,7 +107,7 @@
         <table class="pure-table data-table fcu-table">
           <thead>
             <tr>
-              <th class="column-unit" rowspan="3">Room (Unit)</th>
+              <th class="column-unit" rowspan="3">Unit</th>
               <th class="column-disable-for" rowspan="3" title="Remaining time rules are disabled for this device (H:MM)">Rules<br>disabled<br>for</th>
               <th class="column-temp" rowspan="3">FCU Temp<br><small id="fcu-temp-unit-label">°C</small></th>
               <th class="column-computed-room" colspan="2">Computed Room</th>
@@ -135,7 +137,7 @@
                 {% set current_mode_value = current_mode|upper if current_mode else '' %}
                 <tr class="device-row" x-data-device-id="{{ device.device_id }}">
                   <td class="cell-unit">
-                    <span class="device-name-context fcu-room-editor-trigger"
+                    <span class="device-name-context fcu-temp-sources-trigger"
                           role="button"
                           tabindex="0"
                           data-device-id="{{ device.device_id }}"
@@ -146,12 +148,11 @@
                           data-device-update="{{ device.device_update_text|default('', true) }}"
                           data-device-update-url="/api/v1/devices/{{ device.device_id }}"
                           data-room-id="{{ device.room_id or '' }}"
-                          {% if device.room_id %}data-room-update-url="/api/v1/rooms/{{ device.room_id }}"{% endif %}
                           data-fcu-temp-sources-url="/api/v1/fcu_temp_sources?fcu_device_id={{ device.device_id }}"
                           data-fcu-temp-source-update-url="/api/v1/fcu_temp_source"
-                          data-fcu-temp-sources-room-name="{{ device.room_name or device.device_label }}"
-                          aria-label="Edit room settings for {{ device.room_name or device.device_label }}"
-                          title="Edit room settings for {{ device.room_name or device.device_label }}">{{ device.room_name or device.device_label }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
+                          data-room-name="{{ device.room_name or '' }}"
+                          aria-label="Edit temperature sources for {{ device.device_label }}"
+                          title="Edit temperature sources for {{ device.device_label }}">{{ device.device_label }} 🌀</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
                     <span id="device-{{ device.device_id }}-notes"></span>
                   </td>
                   <td class="cell-disable-for" id="disable-for-{{ device.device_id }}">
@@ -308,7 +309,7 @@
         </table>
 
         <!-- Section 3: Air Quality — devices without speed control that have temp -->
-        <h2>Air Quality</h2>
+        <h2>Air Quality and Room Assignments</h2>
         <table class="pure-table data-table room-matrix" id="room-matrix">
           <thead>
             <tr>
@@ -328,13 +329,15 @@
             {% for group in room_groups %}
               <tr class="room-separator"
                   data-room-id="{{ group.room_id if group.room_id is not none else '' }}"
-                  data-room-name="{{ group.room_name }}">
+                  data-room-name="{{ group.room_name }}"
+                  data-has-fcu="{{ 'true' if group.fcu_device_id else 'false' }}"
+                  data-can-delete="{{ 'true' if group.can_delete else 'false' }}">
                 <td colspan="10">
                   <button type="button"
                           class="room-name{% if group.room_id is none %} room-name-unassigned{% endif %}"
                           data-room-id="{{ group.room_id if group.room_id is not none else '' }}"
                           data-room-name="{{ group.room_name }}"
-                          {% if group.room_id is none %}disabled{% else %}aria-label="Rename {{ group.room_name }}" title="Right-click or long-press to rename"{% endif %}>{{ group.room_name }}</button>
+                          {% if group.room_id is none %}disabled{% else %}aria-label="Manage room {{ group.room_name }}" title="Right-click or long-press to manage room"{% endif %}>{{ group.room_name }}{% if group.fcu_device_id %} 🌀{% endif %}</button>
                   {% if group.room_id is not none %}
                   <span class="room-summary"
                         data-room-id="{{ group.room_id }}"
@@ -372,7 +375,7 @@
                           data-device-type="{{ device.device_type or '' }}"
                           data-rules-enabled="{{ 'true' if device.rules_enabled|default(true) else 'false' }}"
                           data-device-update="{{ device.device_update_text|default('', true) }}"
-                          title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label }}</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
+                          title="{{ device.device_update_tooltip|default(device.device_name, true) }}">{{ device.device_label }} 📡</span><span class="rules-disabled-superscript hidden" id="rules-disabled-{{ device.device_id }}" title=""></span>
                     <span id="device-{{ device.device_id }}-notes"></span>
                   </td>
                   <td class="cell-humidity{% if device.has_humidity %} cell-metric-link{% endif %}" id="humidity-{{ device.device_id }}"
@@ -406,6 +409,9 @@
             </tr>
           </tfoot>
         </table>
+        <div class="room-matrix-actions">
+          <button type="button" class="pure-button pure-button-primary" id="new-room-button">New Room</button>
+        </div>
       </form>
     </div> <!-- main-grid -->
   </div>
@@ -449,10 +455,36 @@
     <input id="room-rename-name" type="text" maxlength="120" autocomplete="off" required>
     <div class="room-rename-message" data-role="message" aria-live="polite"></div>
     <div class="room-rename-actions">
+      <button type="button" class="pure-button room-delete-choice hidden" data-action="request-room-delete">Delete…</button>
       <button type="submit" class="pure-button pure-button-primary">Rename</button>
       <button type="button" class="pure-button" data-action="cancel-room-rename">Cancel</button>
     </div>
   </form>
+</div>
+
+<div id="room-create-dialog" class="room-rename-dialog hidden" role="dialog" aria-modal="true" aria-labelledby="room-create-title">
+  <form class="room-rename-card">
+    <h3 id="room-create-title">New room</h3>
+    <label for="room-create-name">Room name</label>
+    <input id="room-create-name" type="text" maxlength="120" autocomplete="off" required>
+    <div class="room-rename-message" data-role="message" aria-live="polite"></div>
+    <div class="room-rename-actions">
+      <button type="submit" class="pure-button pure-button-primary">Create</button>
+      <button type="button" class="pure-button" data-action="cancel-room-create">Cancel</button>
+    </div>
+  </form>
+</div>
+
+<div id="room-delete-dialog" class="room-rename-dialog hidden" role="dialog" aria-modal="true" aria-labelledby="room-delete-title">
+  <div class="room-rename-card">
+    <h3 id="room-delete-title">Delete empty room</h3>
+    <p>Delete <strong data-role="room-name"></strong>? This cannot be undone.</p>
+    <div class="room-rename-message" data-role="message" aria-live="polite"></div>
+    <div class="room-rename-actions">
+      <button type="button" class="pure-button pure-button-primary" data-action="confirm-room-delete" disabled>OK (5)</button>
+      <button type="button" class="pure-button" data-action="cancel-room-delete">Cancel</button>
+    </div>
+  </div>
 </div>
 
 <div id="room-matrix-message" class="room-matrix-message hidden" role="status" aria-live="polite"></div>
@@ -460,7 +492,7 @@
 <div id="fcu-temp-sources-popup" class="fcu-temp-sources-popup hidden" role="dialog" aria-modal="true" aria-labelledby="fcu-temp-sources-title">
   <div class="fcu-temp-sources-dialog">
     <div class="fcu-temp-sources-header">
-      <h3 id="fcu-temp-sources-title" data-role="title">Room Editor</h3>
+      <h3 id="fcu-temp-sources-title" data-role="title">FCU Temperature Sources</h3>
       <div class="fcu-temp-sources-actions">
         <button type="button" class="pure-button pure-button-primary" data-action="save-fcu-temp-sources">Save</button>
         <button type="button" class="pure-button" data-action="revert-fcu-temp-sources">Revert</button>
@@ -468,8 +500,8 @@
       </div>
     </div>
     <div class="fcu-room-editor-row">
-      <label for="fcu-room-display-name">Room name</label>
-      <input id="fcu-room-display-name" class="fcu-room-display-name" type="text" autocomplete="off" data-role="display-name">
+      <span>Room</span>
+      <strong data-role="room-name">Unassigned</strong>
     </div>
     <p class="fcu-temp-sources-note">Readings older than 10 minutes are ignored.</p>
     <div class="fcu-temp-sources-message" data-role="message" aria-live="polite"></div>

--- a/doc/agent-index.md
+++ b/doc/agent-index.md
@@ -59,7 +59,9 @@ dashboard frontend work.
     values, and Hubitat/Airthings payload shapes.
 - `app/static/room_matrix.js`
   - Air Quality matrix drag assignment, sorted placement, optimistic rollback,
-    room rename, and live room summary updates.
+    room creation/rename/deletion, and live room summary updates.
+  - The Air Quality matrix is the main-page room administration surface. FCU
+    unit names remain separate from their FCU-owned room names.
 - `tests/test_room_matrix_routes.py` and `tests/test_room_matrix.js`
   - SQLite-backed grouping/rendering contracts and substantive client state
     transitions.

--- a/doc/calculated-temperatures-and-rooms.md
+++ b/doc/calculated-temperatures-and-rooms.md
@@ -175,6 +175,7 @@ Room endpoints:
 - `POST /api/v1/rooms`
 - `GET /api/v1/rooms/<room_id>`
 - `PATCH /api/v1/rooms/<room_id>`
+- `DELETE /api/v1/rooms/<room_id>`
 
 Room endpoints use separate Pydantic write contracts: `RoomCreate` requires
 `room_name`, while `RoomPatch` accepts only `room_name` and `map`. Both reject
@@ -192,6 +193,28 @@ set. Room payloads use `map` at the API boundary and `map_json` in SQLite:
   }
 }
 ```
+
+Room deletion is allowed only when the room has no FCU owner and no assigned
+device of any type. The endpoint returns `409 Conflict` when a room is occupied
+and `404 Not Found` when the room does not exist.
+
+## Main Matrix Naming And Room Administration
+
+The main page deliberately keeps physical-unit names separate from room names:
+
+- **Heating and Cooling** shows the FCU device name in its **Unit** column and
+  appends `🌀`.
+- **Energy Recovery Ventilation** appends `♻️` to the ERV device name and shows
+  its room, when present, in the adjacent **Room** column.
+- **Air Quality and Room Assignments** appends `📡` to sensor names. Its room
+  headings are the only main-page surface for creating, renaming, deleting, and
+  assigning rooms. A room owned by an FCU appends `🌀` to the room heading;
+  independent rooms have no room-heading icon.
+
+Right-clicking or long-pressing a room heading opens room management. Only
+empty, non-FCU-owned rooms expose deletion, and the confirmation button remains
+disabled for five seconds. The FCU temperature-source popup shows its room as
+read-only; it does not rename the room or FCU.
 
 Device-room assignment:
 

--- a/tests/test_room_contracts.py
+++ b/tests/test_room_contracts.py
@@ -110,6 +110,37 @@ def test_only_empty_rooms_can_be_deleted(
     assert not conn.in_transaction
 
 
+def test_deleting_empty_room_preserves_presence_history(
+    flask_test_client, test_database_conn_with_test_data
+):
+    conn, _, _ = test_database_conn_with_test_data
+    room = flask_test_client.post(
+        "/api/v1/rooms", json={"room_name": "Former Sensor Room"}
+    ).json
+    sensor_id = conn.execute(
+        "INSERT INTO devices (device_name, device_type, room_id) VALUES (?, ?, ?)",
+        ("Historical Presence Sensor", "SENSOR", room["room_id"]),
+    ).lastrowid
+    event_id = conn.execute(
+        """
+        INSERT INTO presence_events (device_id, room_id, observed_at, present)
+        VALUES (?, ?, ?, ?)
+        """,
+        (sensor_id, room["room_id"], 1_700_000_000, 1),
+    ).lastrowid
+    conn.execute("UPDATE devices SET room_id=NULL WHERE device_id=?", (sensor_id,))
+    conn.commit()
+
+    deleted = flask_test_client.delete(f"/api/v1/rooms/{room['room_id']}")
+
+    assert deleted.status_code == 204
+    event = conn.execute(
+        "SELECT room_id, present FROM presence_events WHERE presence_event_id=?",
+        (event_id,),
+    ).fetchone()
+    assert dict(event) == {"room_id": None, "present": 1}
+
+
 def test_room_assignment_rejects_unknown_and_ineligible_devices(
     flask_test_client,
     test_database_conn_with_test_data,

--- a/tests/test_room_contracts.py
+++ b/tests/test_room_contracts.py
@@ -63,6 +63,33 @@ def test_room_list_is_typed_and_alphabetized(flask_test_client):
     ]
 
 
+def test_only_empty_rooms_can_be_deleted(
+    flask_test_client, test_database_conn_with_test_data
+):
+    conn, _, _ = test_database_conn_with_test_data
+    empty = flask_test_client.post("/api/v1/rooms", json={"room_name": "Empty"})
+    occupied = flask_test_client.post(
+        "/api/v1/rooms", json={"room_name": "Occupied"}
+    )
+    sensor_id = conn.execute(
+        "INSERT INTO devices (device_name, device_type, room_id) VALUES (?, ?, ?)",
+        ("Deletion Guard Sensor", "SENSOR", occupied.json["room_id"]),
+    ).lastrowid
+    conn.commit()
+
+    rejected = flask_test_client.delete(f"/api/v1/rooms/{occupied.json['room_id']}")
+    assert rejected.status_code == 409
+    assert "without assigned devices" in rejected.json["error"]
+    assert conn.execute(
+        "SELECT room_id FROM devices WHERE device_id=?", (sensor_id,)
+    ).fetchone()["room_id"] == occupied.json["room_id"]
+
+    deleted = flask_test_client.delete(f"/api/v1/rooms/{empty.json['room_id']}")
+    assert deleted.status_code == 204
+    assert flask_test_client.get(f"/api/v1/rooms/{empty.json['room_id']}").status_code == 404
+    assert flask_test_client.delete("/api/v1/rooms/999999").status_code == 404
+
+
 def test_room_assignment_rejects_unknown_and_ineligible_devices(
     flask_test_client,
     test_database_conn_with_test_data,

--- a/tests/test_room_contracts.py
+++ b/tests/test_room_contracts.py
@@ -71,10 +71,21 @@ def test_only_empty_rooms_can_be_deleted(
     occupied = flask_test_client.post(
         "/api/v1/rooms", json={"room_name": "Occupied"}
     )
+    fcu_owned = flask_test_client.post(
+        "/api/v1/rooms", json={"room_name": "FCU Owned"}
+    )
     sensor_id = conn.execute(
         "INSERT INTO devices (device_name, device_type, room_id) VALUES (?, ?, ?)",
         ("Deletion Guard Sensor", "SENSOR", occupied.json["room_id"]),
     ).lastrowid
+    fcu_id = conn.execute(
+        "INSERT INTO devices (device_name, device_type, room_id) VALUES (?, ?, ?)",
+        ("Deletion Guard FCU", DEVICE_TYPE_FCU, fcu_owned.json["room_id"]),
+    ).lastrowid
+    conn.execute(
+        "UPDATE rooms SET fcu_device_id=? WHERE room_id=?",
+        (fcu_id, fcu_owned.json["room_id"]),
+    )
     conn.commit()
 
     rejected = flask_test_client.delete(f"/api/v1/rooms/{occupied.json['room_id']}")
@@ -84,6 +95,13 @@ def test_only_empty_rooms_can_be_deleted(
     assert conn.execute(
         "SELECT room_id FROM devices WHERE device_id=?", (sensor_id,)
     ).fetchone()["room_id"] == occupied.json["room_id"]
+
+    rejected_fcu = flask_test_client.delete(
+        f"/api/v1/rooms/{fcu_owned.json['room_id']}"
+    )
+    assert rejected_fcu.status_code == 409
+    assert rejected_fcu.json["error"] == "FCU-owned rooms cannot be deleted"
+    assert not conn.in_transaction
 
     deleted = flask_test_client.delete(f"/api/v1/rooms/{empty.json['room_id']}")
     assert deleted.status_code == 204

--- a/tests/test_room_contracts.py
+++ b/tests/test_room_contracts.py
@@ -80,6 +80,7 @@ def test_only_empty_rooms_can_be_deleted(
     rejected = flask_test_client.delete(f"/api/v1/rooms/{occupied.json['room_id']}")
     assert rejected.status_code == 409
     assert "without assigned devices" in rejected.json["error"]
+    assert not conn.in_transaction
     assert conn.execute(
         "SELECT room_id FROM devices WHERE device_id=?", (sensor_id,)
     ).fetchone()["room_id"] == occupied.json["room_id"]
@@ -88,6 +89,7 @@ def test_only_empty_rooms_can_be_deleted(
     assert deleted.status_code == 204
     assert flask_test_client.get(f"/api/v1/rooms/{empty.json['room_id']}").status_code == 404
     assert flask_test_client.delete("/api/v1/rooms/999999").status_code == 404
+    assert not conn.in_transaction
 
 
 def test_room_assignment_rejects_unknown_and_ineligible_devices(

--- a/tests/test_room_matrix.js
+++ b/tests/test_room_matrix.js
@@ -5,10 +5,14 @@ const {
   compareSensors,
   deviceRoomRequest,
   longPressTriggered,
+  persistNewRoom,
+  persistRoomDeletion,
   persistRoomName,
   persistSensorRoom,
   restoreSensorPosition,
   roomHumidityText,
+  roomDeleteCountdown,
+  roomDisplayName,
   roomIdFromValue,
   roomNameSortKey,
   roomRenameKeyTriggered,
@@ -36,6 +40,16 @@ assert.strictEqual(longPressTriggered(800, 11), false);
 assert.strictEqual(roomRenameKeyTriggered("Enter"), true);
 assert.strictEqual(roomRenameKeyTriggered(" "), true);
 assert.strictEqual(roomRenameKeyTriggered("Escape"), false);
+assert.strictEqual(roomDisplayName("Broadway North", true), "Broadway North 🌀");
+assert.strictEqual(roomDisplayName("Conference", false), "Conference");
+assert.deepStrictEqual(roomDeleteCountdown(1000, 1000), {
+  enabled: false,
+  label: "OK (5)",
+});
+assert.deepStrictEqual(roomDeleteCountdown(1000, 6000), {
+  enabled: true,
+  label: "OK",
+});
 
 const dragCloneChildren = [
   { id: "temp-1", removeAttribute: (name) => { if (name === "id") delete dragCloneChildren[0].id; } },
@@ -88,6 +102,18 @@ async function testPersistenceTransitions() {
   assert.deepStrictEqual(JSON.parse(requests[1].options.body), {
     room_name: "Bravo",
   });
+
+  const created = await persistNewRoom("Delta", successfulRequest);
+  assert.strictEqual(created.room_name, "Bravo");
+  assert.strictEqual(requests[2].url, "/api/v1/rooms");
+  assert.strictEqual(requests[2].options.method, "POST");
+  assert.deepStrictEqual(JSON.parse(requests[2].options.body), {
+    room_name: "Delta",
+  });
+
+  await persistRoomDeletion(7, successfulRequest);
+  assert.strictEqual(requests[3].url, "/api/v1/rooms/7");
+  assert.strictEqual(requests[3].options.method, "DELETE");
 
   await assert.rejects(
     persistRoomName(7, "Alpha", async () => ({

--- a/tests/test_room_matrix.js
+++ b/tests/test_room_matrix.js
@@ -47,6 +47,10 @@ assert.deepStrictEqual(roomDeleteCountdown(1000, 1000), {
   enabled: false,
   label: "OK (5)",
 });
+assert.deepStrictEqual(roomDeleteCountdown(1000, 5999), {
+  enabled: false,
+  label: "OK (1)",
+});
 assert.deepStrictEqual(roomDeleteCountdown(1000, 6000), {
   enabled: true,
   label: "OK",

--- a/tests/test_room_matrix.js
+++ b/tests/test_room_matrix.js
@@ -5,6 +5,7 @@ const {
   compareSensors,
   deviceRoomRequest,
   longPressTriggered,
+  openRoomDeleteDialog,
   persistNewRoom,
   persistRoomDeletion,
   persistRoomName,
@@ -50,6 +51,40 @@ assert.deepStrictEqual(roomDeleteCountdown(1000, 6000), {
   enabled: true,
   label: "OK",
 });
+
+const originalDocument = global.document;
+const originalSetInterval = global.setInterval;
+const originalClearInterval = global.clearInterval;
+const clearedTimers = [];
+let nextTimer = 100;
+const deleteButton = {};
+const deleteRoomName = {};
+const deleteMessage = {};
+const deleteDialog = {
+  dataset: {},
+  classList: { remove() {} },
+  querySelector(selector) {
+    return {
+      "[data-action='confirm-room-delete']": deleteButton,
+      "[data-role='room-name']": deleteRoomName,
+      "[data-role='message']": deleteMessage,
+    }[selector];
+  },
+};
+global.document = { getElementById: () => deleteDialog };
+global.setInterval = () => ++nextTimer;
+global.clearInterval = (timer) => {
+  if (timer !== undefined && timer !== null) clearedTimers.push(timer);
+};
+openRoomDeleteDialog(7, "First room");
+const firstTimer = deleteDialog._countdownTimer;
+openRoomDeleteDialog(8, "Second room");
+assert.deepStrictEqual(clearedTimers, [firstTimer]);
+assert.strictEqual(deleteDialog.dataset.roomId, "8");
+assert.notStrictEqual(deleteDialog._countdownTimer, firstTimer);
+global.document = originalDocument;
+global.setInterval = originalSetInterval;
+global.clearInterval = originalClearInterval;
 
 const dragCloneChildren = [
   { id: "temp-1", removeAttribute: (name) => { if (name === "id") delete dragCloneChildren[0].id; } },

--- a/tests/test_room_matrix_routes.py
+++ b/tests/test_room_matrix_routes.py
@@ -43,6 +43,7 @@ def test_room_matrix_groups_include_empty_rooms_and_unassigned():
             Room(room_id=2, room_name="Zulu"),
             Room(room_id=1, room_name="Alpha"),
         ],
+        {2},
     )
 
     assert [group.room_name for group in groups] == ["Alpha", "Unassigned", "Zulu"]
@@ -72,6 +73,7 @@ def test_room_matrix_groups_exclude_non_sensor_infrastructure_rows():
             )
         ],
         [Room(room_id=1, room_name="Alpha")],
+        {1},
     )
 
     assert [group.room_name for group in groups] == ["Alpha", "Unassigned"]
@@ -86,6 +88,9 @@ def test_index_renders_room_sections_and_each_sensor_once(
         "INSERT INTO rooms (room_name) VALUES ('Alpha')"
     ).lastrowid
     conn.execute("INSERT INTO rooms (room_name) VALUES ('Bravo')")
+    charlie_id = conn.execute(
+        "INSERT INTO rooms (room_name) VALUES ('Charlie')"
+    ).lastrowid
     zulu_id = conn.execute(
         "INSERT INTO rooms (room_name) VALUES ('Zulu')"
     ).lastrowid
@@ -112,6 +117,14 @@ def test_index_renders_room_sections_and_each_sensor_once(
         )
         device_ids[name] = device_id
     conn.commit()
+    conn.execute(
+        """
+        INSERT INTO devices (device_name, device_type, room_id)
+        VALUES ('New sensor without readings', 'SENSOR', ?)
+        """,
+        (charlie_id,),
+    )
+    conn.commit()
 
     response = flask_test_client.get("/")
     assert response.status_code == 200
@@ -122,13 +135,17 @@ def test_index_renders_room_sections_and_each_sensor_once(
         html,
     )
 
-    assert room_names == ["Alpha", "Bravo", "Unassigned", "Zulu"]
+    assert room_names == ["Alpha", "Bravo", "Charlie", "Unassigned", "Zulu"]
     assert re.search(
         r'data-room-name="Alpha"\s+data-has-fcu="false"\s+data-can-delete="false"',
         html,
     )
     assert re.search(
         r'data-room-name="Bravo"\s+data-has-fcu="false"\s+data-can-delete="true"',
+        html,
+    )
+    assert re.search(
+        r'data-room-name="Charlie"\s+data-has-fcu="false"\s+data-can-delete="false"',
         html,
     )
     assert re.search(

--- a/tests/test_room_matrix_routes.py
+++ b/tests/test_room_matrix_routes.py
@@ -85,6 +85,7 @@ def test_index_renders_room_sections_and_each_sensor_once(
     alpha_id = conn.execute(
         "INSERT INTO rooms (room_name) VALUES ('Alpha')"
     ).lastrowid
+    conn.execute("INSERT INTO rooms (room_name) VALUES ('Bravo')")
     zulu_id = conn.execute(
         "INSERT INTO rooms (room_name) VALUES ('Zulu')"
     ).lastrowid
@@ -117,11 +118,28 @@ def test_index_renders_room_sections_and_each_sensor_once(
     html = response.data.decode("utf-8")
     room_names = re.findall(
         r'<tr class="room-separator"\s+data-room-id="[^"]*"\s+'
-        r'data-room-name="([^"]+)">',
+        r'data-room-name="([^"]+)"[^>]*>',
         html,
     )
 
-    assert room_names == ["Alpha", "Unassigned", "Zulu"]
+    assert room_names == ["Alpha", "Bravo", "Unassigned", "Zulu"]
+    assert re.search(
+        r'data-room-name="Alpha"\s+data-has-fcu="false"\s+data-can-delete="false"',
+        html,
+    )
+    assert re.search(
+        r'data-room-name="Bravo"\s+data-has-fcu="false"\s+data-can-delete="true"',
+        html,
+    )
+    assert re.search(
+        r'data-room-name="Zulu"\s+data-has-fcu="false"\s+data-can-delete="false"',
+        html,
+    )
+    assert "Air Quality and Room Assignments" in html
+    assert 'id="new-room-button"' in html
+    assert 'id="room-create-dialog"' in html
+    assert 'id="room-delete-dialog"' in html
+    assert "Assigned Sensor 📡" in html
     assert html.count(f'x-data-device-id="{device_ids["Assigned Sensor"]}"') == 1
     assert html.count(f'x-data-device-id="{device_ids["Loose Sensor"]}"') == 1
     assert f'x-data-device-id="{device_ids["Internal Reading"]}"' not in html

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -333,7 +333,8 @@ def test_fcu_matrix_has_raw_fcu_temp_and_room_temp_columns(
     assert response.status_code == 200
     html = unescape(response.data.decode("utf-8"))
 
-    assert "Room (Unit)" in html
+    assert "Room (Unit)" not in html
+    assert "Area 51 🌀" in html
     assert "FCU Temp" in html
     assert "Computed Room" in html
     assert "column-computed-room-temp" in html
@@ -357,10 +358,10 @@ def test_fcu_matrix_has_raw_fcu_temp_and_room_temp_columns(
 
 @patch("app.routes_web.hubitat.get_name_to_label", return_value={})
 @patch("app.routes_web.db.get_device_status")
-def test_fcu_matrix_room_unit_cell_opens_room_editor(
+def test_fcu_matrix_unit_cell_opens_temperature_source_editor(
     mock_get_status, _mock_labels, flask_test_client
 ):  # noqa: F811
-    """Room (Unit) cells must expose the editor/source-weight popup contract."""
+    """FCU unit cells expose temperature weights without editing the room name."""
     mock_get_status.return_value = [
         {
             "device_id": 12,
@@ -381,19 +382,19 @@ def test_fcu_matrix_room_unit_cell_opens_room_editor(
     html = unescape(response.data.decode("utf-8"))
 
     assert 'id="fcu-temp-sources-popup"' in html
-    assert 'class="device-name-context fcu-room-editor-trigger"' in html
+    assert 'class="device-name-context fcu-temp-sources-trigger"' in html
     assert 'role="button"' in html
     assert 'tabindex="0"' in html
     assert 'data-room-id="3"' in html
-    assert 'data-room-update-url="/api/v1/rooms/3"' in html
+    assert 'data-room-name="Area 51"' in html
     assert (
         'data-fcu-temp-sources-url="/api/v1/fcu_temp_sources?fcu_device_id=12"'
         in html
     )
     assert 'data-fcu-temp-source-update-url="/api/v1/fcu_temp_source"' in html
-    assert 'data-fcu-temp-sources-room-name="Area 51"' in html
-    assert 'id="fcu-room-display-name"' in html
-    assert "Room name" in html
+    assert 'data-room-update-url=' not in html
+    assert 'id="fcu-room-display-name"' not in html
+    assert '<strong data-role="room-name">Unassigned</strong>' in html
     assert "Readings older than 10 minutes are ignored" in html
     assert 'data-action="save-fcu-temp-sources"' in html
     assert 'data-action="revert-fcu-temp-sources"' in html
@@ -428,7 +429,8 @@ def test_index_device_names_expose_rename_popup_contract(
     assert response.status_code == 200
     html = unescape(response.data.decode("utf-8"))
 
-    assert 'class="device-name-context fcu-room-editor-trigger"' in html
+    assert 'class="device-name-context fcu-temp-sources-trigger"' in html
+    assert "Server Room 🌀" in html
     assert 'data-device-id="12"' in html
     assert 'data-device-name="Area 51"' in html
     assert 'data-display-name="Server Room"' in html

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -12,6 +12,7 @@ from app.main import APP_DIR, application_metadata
 from app.routes_web import (
     _dashboard_air_quality_device_is_active,
     _dashboard_device_label,
+    _dashboard_device_label_with_icon,
     _dashboard_device_tooltip,
     _filter_speed_control_devices,
     _get_hubitat_sensors,
@@ -123,6 +124,39 @@ def test_dashboard_device_label_uses_stored_status_label():
     )
 
     assert label == "Lobby Sensor"
+
+
+def test_dashboard_device_label_icons_are_idempotent():
+    assert (
+        _dashboard_device_label_with_icon(
+            {
+                "device_name": "ERV 1",
+                "device_label": "ERV 1 ♻️",
+                "device_type": "ERV",
+            }
+        )
+        == "ERV 1 ♻️"
+    )
+    assert (
+        _dashboard_device_label_with_icon(
+            {
+                "device_name": "Area 51",
+                "device_label": "Area 51",
+                "device_type": "FCU",
+            }
+        )
+        == "Area 51 🌀"
+    )
+    assert (
+        _dashboard_device_label_with_icon(
+            {
+                "device_name": "Unknown monitor",
+                "device_label": "Unknown monitor 📡",
+                "dashboard_air_quality_active": True,
+            }
+        )
+        == "Unknown monitor 📡"
+    )
 
 
 def test_dashboard_device_tooltip_uses_device_update_time():

--- a/tests/test_unit_speed.js
+++ b/tests/test_unit_speed.js
@@ -40,7 +40,7 @@ const {
   pendingSingleSetTempUpdateDecision,
   renderDisableCell,
   renderAutoSetTempRange,
-  refreshOpenFcuRoomEditor,
+  refreshOpenFcuTempSources,
   resizeSetRangeEndpoint,
   saveAutoSetTempWidget,
   saveFcuTempSourceMultipliers,
@@ -595,7 +595,7 @@ check(
   "1,2,3,4",
 );
 check(
-  "room editor shows only sources assigned to its room",
+  "FCU temperature sources show only sources assigned to its room",
   sortedFcuTempSources(
     [
       { source_device_id: 1, room_id: 2, is_stale: false },
@@ -609,7 +609,7 @@ check(
   "1",
 );
 check(
-  "blank room id does not filter room editor sources",
+  "blank room id does not filter FCU temperature sources",
   sortedFcuTempSources(
     [
       { source_device_id: 1, room_id: null, is_stale: false },
@@ -632,25 +632,29 @@ check(
 );
 const originalDocumentForRoomRefresh = global.document;
 let refreshedTrigger = null;
-const roomEditorTrigger = { dataset: { deviceId: "12" } };
+const tempSourcesTrigger = { dataset: { deviceId: "12" } };
 global.document = {
   getElementById: () => ({
     dataset: { deviceId: "12" },
     classList: { contains: () => false },
   }),
-  querySelector: () => roomEditorTrigger,
+  querySelector: () => tempSourcesTrigger,
 };
 check(
-  "open room editor refreshes after assignment change",
-  refreshOpenFcuRoomEditor((trigger) => {
+  "open FCU temperature sources refresh after assignment change",
+  refreshOpenFcuTempSources((trigger) => {
     refreshedTrigger = trigger;
   }),
   true,
 );
-check("room editor refresh uses its FCU trigger", refreshedTrigger, roomEditorTrigger);
+check(
+  "temperature-source refresh uses its FCU trigger",
+  refreshedTrigger,
+  tempSourcesTrigger,
+);
 global.document = originalDocumentForRoomRefresh;
 
-async function testRoomEditorRefreshHandlesRejection() {
+async function testFcuTempSourcesRefreshHandlesRejection() {
   const originalDocument = global.document;
   const originalConsoleError = console.error;
   let reported = null;
@@ -659,18 +663,22 @@ async function testRoomEditorRefreshHandlesRejection() {
       dataset: { deviceId: "12" },
       classList: { contains: () => false },
     }),
-    querySelector: () => roomEditorTrigger,
+    querySelector: () => tempSourcesTrigger,
   };
   console.error = (_message, error) => { reported = error; };
   try {
     check(
-      "open room editor accepts an async refresh",
-      refreshOpenFcuRoomEditor(() => Promise.reject(new Error("refresh failed"))),
+      "open FCU temperature sources accept an async refresh",
+      refreshOpenFcuTempSources(() => Promise.reject(new Error("refresh failed"))),
       true,
     );
     await Promise.resolve();
     await Promise.resolve();
-    check("room editor refresh reports rejection", reported.message, "refresh failed");
+    check(
+      "temperature-source refresh reports rejection",
+      reported.message,
+      "refresh failed",
+    );
   } finally {
     global.document = originalDocument;
     console.error = originalConsoleError;
@@ -1297,7 +1305,7 @@ check("range set temp matching update clears state", pendingRangeWidget.dataset.
 Promise.resolve()
   .then(testPendingFanChangeOwnership)
   .then(testSingleFlightStatusRefresh)
-  .then(testRoomEditorRefreshHandlesRejection)
+  .then(testFcuTempSourcesRefreshHandlesRejection)
   .then(testEnableRulesForDevicePost)
   .then(testFcuBatchSavePost)
   .then(testAutoSetTempSavePost)

--- a/tests/test_unit_speed.js
+++ b/tests/test_unit_speed.js
@@ -8,7 +8,6 @@
 global.TemperatureUtils = require("../app/static/temperature_utils.js");
 
 const {
-  collectFcuRoomEditorDisplayNameChange,
   collectFcuTempSourceChanges,
   autoSetTempRangeForDevice,
   compactAgeFromSeconds,
@@ -16,6 +15,7 @@ const {
   createSingleFlight,
   dashboardAirQualityDeviceIsActive,
   deviceDisplayNameChanged,
+  deviceLabelWithIcon,
   deviceDisplayNamePatchBody,
   deviceRulesEnabledValue,
   deviceUpdateText,
@@ -563,15 +563,18 @@ check(
 
 // -- FCU temperature source popup behavior --
 check(
-  "room editor title includes room name",
+  "FCU source title includes unit name",
   fcuTempSourcesTitle("Area 51"),
-  "Area 51: Room Editor",
+  "Area 51: FCU Temperature Sources",
 );
 check(
-  "room editor title without room name",
+  "FCU source title without unit name",
   fcuTempSourcesTitle(""),
-  "Room Editor",
+  "FCU Temperature Sources",
 );
+check("FCU label has fan icon", deviceLabelWithIcon("Area 51", "FCU"), "Area 51 🌀");
+check("sensor label has sensor icon", deviceLabelWithIcon("Wave", "SENSOR"), "Wave 📡");
+check("ERV label has exchange icon", deviceLabelWithIcon("ERV 1", "ERV"), "ERV 1 ♻️");
 
 const unsortedSources = [
   { source_device_id: 1, is_stale: false },
@@ -1059,37 +1062,6 @@ check(
   "Weight must be a nonnegative number.",
 );
 
-const unchangedRoomName = collectFcuRoomEditorDisplayNameChange({
-  dataset: { currentDisplayName: "Area 51" },
-  querySelector: (selector) =>
-    selector === "[data-role='display-name']" ? { value: "Area 51" } : null,
-});
-check("unchanged room editor name is ignored", unchangedRoomName.changed, false);
-check("unchanged room editor name has no error", unchangedRoomName.error, "");
-
-const changedRoomName = collectFcuRoomEditorDisplayNameChange({
-  dataset: { currentDisplayName: "Area 51" },
-  querySelector: (selector) =>
-    selector === "[data-role='display-name']" ? { value: " East Lab " } : null,
-});
-check("changed room editor name is detected", changedRoomName.changed, true);
-check(
-  "changed room editor name is trimmed",
-  changedRoomName.displayName,
-  "East Lab",
-);
-
-const blankRoomName = collectFcuRoomEditorDisplayNameChange({
-  dataset: { currentDisplayName: "Area 51" },
-  querySelector: (selector) =>
-    selector === "[data-role='display-name']" ? { value: " " } : null,
-});
-check(
-  "blank room editor name is invalid",
-  blankRoomName.error,
-  "Room name is required.",
-);
-
 async function testFcuBatchSavePost() {
   const inputs = [
     {
@@ -1143,7 +1115,7 @@ async function testFcuBatchSavePost() {
       }
       if (
         selector ===
-        ".fcu-temp-source-weight, .fcu-room-display-name, .fcu-temp-sources-actions button"
+        ".fcu-temp-source-weight, .fcu-temp-sources-actions button"
       ) {
         return inputs.concat(buttons);
       }
@@ -1183,117 +1155,6 @@ async function testFcuBatchSavePost() {
       { fcu_device_id: 12, source_device_id: 22, multiplier: 0.25 },
     ]),
   );
-}
-
-async function testFcuRoomEditorNamePatch() {
-  const input = {
-    disabled: false,
-    value: "East Lab",
-    dataset: { initialDisplayName: "Area 51" },
-  };
-  const message = {
-    textContent: "",
-    classList: {
-      toggle: () => {},
-    },
-  };
-  const popup = {
-    dataset: {
-      updateUrl: "/api/v1/fcu_temp_source",
-      roomUpdateUrl: "/api/v1/rooms/3",
-      roomId: "3",
-      deviceId: "12",
-      deviceName: "Area 51",
-      currentDisplayName: "Area 51",
-    },
-    classList: {
-      hidden: false,
-      add: (name) => {
-        popup.classList.hidden = name === "hidden";
-      },
-    },
-    querySelector: (selector) => {
-      if (selector === "[data-role='message']") {
-        return message;
-      }
-      if (selector === "[data-role='display-name']") {
-        return input;
-      }
-      if (selector === "[data-role='title']") {
-        return { textContent: "" };
-      }
-      return null;
-    },
-    querySelectorAll: (selector) => {
-      if (selector === ".fcu-temp-source-weight") {
-        return [];
-      }
-      if (
-        selector ===
-        ".fcu-temp-source-weight, .fcu-room-display-name, .fcu-temp-sources-actions button"
-      ) {
-        return [input];
-      }
-      return [];
-    },
-  };
-  const label = {
-    dataset: { roomId: "3", deviceUpdate: "", deviceName: "Area 51" },
-    classList: { contains: (name) => name === "fcu-room-editor-trigger" },
-    textContent: "",
-    setAttribute(name, value) {
-      this[name] = value;
-    },
-  };
-  const requests = [];
-  const originalDocumentForSave = global.document;
-  const originalFetch = global.fetch;
-  const originalWindow = global.window;
-  const originalCustomEvent = global.CustomEvent;
-  global.document = {
-    getElementById: (id) => (id === "fcu-temp-sources-popup" ? popup : null),
-    querySelectorAll: () => [label],
-  };
-  global.fetch = async (url, options) => {
-    requests.push({ url, options });
-    return {
-      ok: true,
-      json: async () => ({
-        room_id: 3,
-        room_name: "East Lab",
-      }),
-    };
-  };
-  global.CustomEvent = class CustomEvent {
-    constructor(name, options) {
-      this.type = name;
-      this.detail = options.detail;
-    }
-  };
-  global.window = { dispatchEvent: () => {} };
-  try {
-    await saveFcuTempSourceMultipliers();
-  } finally {
-    global.document = originalDocumentForSave;
-    global.fetch = originalFetch;
-    global.window = originalWindow;
-    global.CustomEvent = originalCustomEvent;
-  }
-
-  const patchBody = JSON.parse(requests[0].options.body);
-  check("room editor name save sends one request", requests.length, 1);
-  check(
-    "room editor name save patches room URL",
-    requests[0].url,
-    "/api/v1/rooms/3",
-  );
-  check("room editor name save uses PATCH", requests[0].options.method, "PATCH");
-  check(
-    "room editor name save sends room name",
-    JSON.stringify(patchBody),
-    JSON.stringify({ room_name: "East Lab" }),
-  );
-  check("room editor name save updates label", label.textContent, "East Lab");
 }
 
 // -- FCU mode select option updates --
@@ -1439,7 +1300,6 @@ Promise.resolve()
   .then(testRoomEditorRefreshHandlesRejection)
   .then(testEnableRulesForDevicePost)
   .then(testFcuBatchSavePost)
-  .then(testFcuRoomEditorNamePatch)
   .then(testAutoSetTempSavePost)
   .catch((error) => {
     failed++;

--- a/tests/test_unit_speed.js
+++ b/tests/test_unit_speed.js
@@ -575,6 +575,16 @@ check(
 check("FCU label has fan icon", deviceLabelWithIcon("Area 51", "FCU"), "Area 51 🌀");
 check("sensor label has sensor icon", deviceLabelWithIcon("Wave", "SENSOR"), "Wave 📡");
 check(
+  "active air-quality label with unknown type has sensor icon",
+  deviceLabelWithIcon("Wave", null, true),
+  "Wave 📡",
+);
+check(
+  "inactive label with unknown type has no sensor icon",
+  deviceLabelWithIcon("Wave", null, false),
+  "Wave",
+);
+check(
   "sensor label does not duplicate its existing icon",
   deviceLabelWithIcon("Wave 📡", "SENSOR"),
   "Wave 📡",

--- a/tests/test_unit_speed.js
+++ b/tests/test_unit_speed.js
@@ -574,6 +574,11 @@ check(
 );
 check("FCU label has fan icon", deviceLabelWithIcon("Area 51", "FCU"), "Area 51 🌀");
 check("sensor label has sensor icon", deviceLabelWithIcon("Wave", "SENSOR"), "Wave 📡");
+check(
+  "sensor label does not duplicate its existing icon",
+  deviceLabelWithIcon("Wave 📡", "SENSOR"),
+  "Wave 📡",
+);
 check("ERV label has exchange icon", deviceLabelWithIcon("ERV 1", "ERV"), "ERV 1 ♻️");
 
 const unsortedSources = [


### PR DESCRIPTION
## Summary

- separate FCU device names from FCU-owned room names on the main dashboard
- label FCUs with `🌀`, air-quality sensors with `📡`, and ERVs with `♻️`
- make **Air Quality and Room Assignments** the room-administration surface
- add room creation and guarded deletion for empty, non-FCU-owned rooms
- add a read-only Room column to the ERV matrix
- document the naming, ownership, and room-management contracts

## Why

The Heating and Cooling matrix rendered an FCU-owned room name inside an element also used for live FCU device-name updates. A status refresh could therefore replace a newly renamed room with the FCU device name, making room renames appear to revert and conflating physical zones with HVAC units. This was particularly confusing for spaces such as Broadway, where two independently controlled FCUs should remain two zones even if they share one air-quality monitor.

This change keeps the concepts explicit: the Heating and Cooling matrix shows the physical FCU name, while room creation, naming, deletion, and sensor assignment happen in the Air Quality matrix.

## Behavior

- FCU temperature-source editing no longer renames the FCU or its room.
- FCU-owned room headings retain the `🌀` marker after live updates or renames.
- Independent room headings have no unit marker.
- Empty rooms can be deleted only after a five-second confirmation countdown.
- The deletion API atomically rejects FCU-owned or occupied rooms with `409 Conflict`.
- The ERV Room column is read-only; under the current contract ERVs are not assignable to rooms, so unassociated ERVs display `—`.

## Validation

- `make pytest` — 295 passed
- `make test-js` — all JavaScript suites passed
- `make check` — Ruff, Pylint 10/10, djlint, ESLint, mypy, and Flyway validation passed
- `git diff --check`

No deployment is included in this PR.

_PR prepared by Codex AI Assistant._
