### PR TITLE
Prevent overlapping status polls and optimize latest-reading queries

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -95,6 +95,29 @@ FLYWAY_SCHEMA_HISTORY_TABLE = "flyway_schema_history"
 SCHEMA_UPGRADE_COMMAND = "make migrate-db"
 FCU_DEFAULT_TEMP_SOURCE_MULTIPLIER = 1.0
 
+LATEST_ROOM_METRIC_SNAPSHOTS_SQL = """
+    SELECT
+        d.device_id,
+        d.device_name,
+        d.display_name,
+        d.device_type,
+        d.room_id,
+        l.logtime,
+        l.duration,
+        l.temp10x,
+        l.status_json
+    FROM devices d
+    JOIN devlog l ON l.log_id = (
+        SELECT candidate.log_id
+        FROM devlog candidate
+        WHERE candidate.device_id = d.device_id
+          AND candidate.logtime <= ?
+        ORDER BY candidate.logtime DESC, candidate.log_id DESC
+        LIMIT 1
+    )
+    ORDER BY d.device_name
+"""
+
 
 def _chart_logtime(row: sqlite3.Row) -> int:
     """Return an integer timestamp for legacy rows that stored float times."""
@@ -959,35 +982,7 @@ def fetch_latest_room_metric_snapshots(
     """Return each device's latest raw reading at or before ``at_time``."""
     boundary = at_time if at_time is not None else float("inf")
     c = conn.cursor()
-    c.execute(
-        """
-        WITH ranked AS (
-            SELECT
-                l.*,
-                ROW_NUMBER() OVER (
-                    PARTITION BY l.device_id
-                    ORDER BY l.logtime DESC, l.log_id DESC
-                ) AS reading_rank
-            FROM devlog l
-            WHERE l.logtime <= ?
-        )
-        SELECT
-            d.device_id,
-            d.device_name,
-            d.display_name,
-            d.device_type,
-            d.room_id,
-            l.logtime,
-            l.duration,
-            l.temp10x,
-            l.status_json
-        FROM ranked l
-        JOIN devices d ON d.device_id = l.device_id
-        WHERE l.reading_rank = 1
-        ORDER BY d.device_name
-        """,
-        (boundary,),
-    )
+    c.execute(LATEST_ROOM_METRIC_SNAPSHOTS_SQL, (boundary,))
     return [
         RoomMetricSnapshot(
             device_id=row["device_id"],

--- a/app/db.py
+++ b/app/db.py
@@ -118,6 +118,33 @@ LATEST_ROOM_METRIC_SNAPSHOTS_SQL = """
     ORDER BY d.device_name
 """
 
+LATEST_DEVICE_STATUS_SQL = """
+    SELECT
+        l.*,
+        d.device_name,
+        d.display_name,
+        d.device_type,
+        d.rules_enabled,
+        d.aqi_mon,
+        d.ae200_device_id,
+        d.notes,
+        d.disabled_until,
+        d.room_id,
+        r.room_name
+    FROM devices d
+    JOIN devlog l ON l.log_id = (
+        SELECT candidate.log_id
+        FROM devlog candidate
+        WHERE candidate.device_id = d.device_id
+          AND candidate.logtime <= ?
+        ORDER BY candidate.logtime DESC, candidate.log_id DESC
+        LIMIT 1
+    )
+    LEFT JOIN rooms r ON d.room_id = r.room_id
+    WHERE ? = 0 OR d.aqi_mon = 1
+    ORDER BY d.device_name
+"""
+
 
 def _chart_logtime(row: sqlite3.Row) -> int:
     """Return an integer timestamp for legacy rows that stored float times."""
@@ -999,25 +1026,17 @@ def fetch_latest_room_metric_snapshots(
     ]
 
 
-EVERY_DEVICE=1
-AIR_MON_DEVICES=2
+EVERY_DEVICE = 1
+AIR_MON_DEVICES = 2
+
+
 def fetch_last_status(conn, flag=EVERY_DEVICE):
-    """Fetches the last status for every device. Specify where to restrict which devices are returned"""
-    if flag==AIR_MON_DEVICES:
-        where = "b.aqi_mon = 1"
-    else:
-        where = "1=1"
-    cursor = conn.cursor()
-    cursor.execute(f"""
-        SELECT a.*,b.device_name,b.display_name,b.device_type,b.rules_enabled,
-               b.aqi_mon,b.ae200_device_id,b.notes,b.disabled_until,
-               b.room_id,r.room_name
-        FROM (SELECT * FROM devlog GROUP BY device_id HAVING logtime=max(logtime)) AS a
-        JOIN devices b ON a.device_id = b.device_id
-        LEFT JOIN rooms r ON b.room_id = r.room_id
-        WHERE {where}
-        ORDER by b.device_name""")
-    return cursor.fetchall()
+    """Fetch the latest status for each device, optionally limited to AQ monitors."""
+    air_monitors_only = int(flag == AIR_MON_DEVICES)
+    return conn.execute(
+        LATEST_DEVICE_STATUS_SQL,
+        (float("inf"), air_monitors_only),
+    ).fetchall()
 
 
 def fetch_last_status_fixed(conn, flag=EVERY_DEVICE):

--- a/app/static/room_dashboard.js
+++ b/app/static/room_dashboard.js
@@ -375,14 +375,25 @@ function updateSensorTemperatures() {
     });
 }
 
-/** Create a status refresher that permits only one request at a time. */
-function createStatusRefresher(request = fetch, update = updateDeviceStatus) {
+/** Wrap an async operation so calls made while it is running are skipped. */
+function createSingleFlight(operation) {
     let inFlight = false;
-    return async function refresh() {
+    return async function runSingleFlight() {
         if (inFlight) {
             return false;
         }
         inFlight = true;
+        try {
+            return await operation();
+        } finally {
+            inFlight = false;
+        }
+    };
+}
+
+/** Create a status refresher that permits only one request at a time. */
+function createStatusRefresher(request = fetch, update = updateDeviceStatus) {
+    return createSingleFlight(async () => {
         try {
             const response = await request('/api/v1/status');
             if (!response.ok) {
@@ -397,10 +408,8 @@ function createStatusRefresher(request = fetch, update = updateDeviceStatus) {
         } catch (error) {
             console.error('Failed to refresh status:', error);
             return false;
-        } finally {
-            inFlight = false;
         }
-    };
+    });
 }
 
 const refreshStatus = createStatusRefresher();
@@ -487,15 +496,20 @@ function requestRoomStatus(endpoint, request = fetch) {
     });
 }
 
-function refreshRoomStatus(request = fetch, documentRef = document) {
-    if (!documentRef.querySelector('.room-controls-card')) {
-        return Promise.resolve(false);
-    }
-    return requestRoomStatus(roomControlEndpoint('room_status'), request)
-        .then(data => {
+function createRoomStatusRefresher(request = fetch, documentRef) {
+    const pageDocument = documentRef ?? document;
+    return createSingleFlight(async () => {
+        if (!pageDocument.querySelector('.room-controls-card')) {
+            return false;
+        }
+        try {
+            const data = await requestRoomStatus(
+                roomControlEndpoint('room_status'),
+                request,
+            );
             if (data.dimmer) {
-                const slider = documentRef.getElementById('dimmer-slider');
-                const valueEl = documentRef.getElementById('dimmer-value');
+                const slider = pageDocument.getElementById('dimmer-slider');
+                const valueEl = pageDocument.getElementById('dimmer-value');
                 if (slider && !slider.matches(':active')) {
                     slider.value = data.dimmer.level;
                 }
@@ -510,14 +524,18 @@ function refreshRoomStatus(request = fetch, documentRef = document) {
                 updateWallButton('outer', data.wall_outer.switch);
             }
             return true;
-        })
-        .catch(error => {
+        } catch (error) {
             if (DEBUG) {
                 console.error('Failed to refresh room status:', error);
             }
             return false;
-        });
+        }
+    });
 }
+
+const refreshRoomStatus = typeof document === 'undefined'
+    ? async () => false
+    : createRoomStatusRefresher();
 
 /**
  * Set up dimmer slider interaction.
@@ -764,6 +782,7 @@ if (typeof window !== 'undefined') {
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         computeFitScale,
+        createRoomStatusRefresher,
         createStatusRefresher,
         refreshRoomStatus,
         requestRoomStatus,

--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -17,7 +17,9 @@ const REFRESH_INTERVAL = 10; // seconds between refreshes
 const RUNNING_MINUTES = 10; // minutes to run before stopping
 const SHOW_REFRESH_COUNTDOWN = false;
 const DASHBOARD_AIR_QUALITY_DEVICE_EXPIRATION_SECONDS = 30 * 24 * 60 * 60;
-let lastRefreshTime = 0;
+// The HTML is server-rendered from the same status data. Wait one interval
+// before polling instead of repeating that database work immediately on load.
+let lastRefreshTime = Date.now();
 const AE200_MODE_LABELS = {
   COOL: "Cool",
   HEAT: "Heat",
@@ -2894,6 +2896,7 @@ const refreshGridRows = () => {
         console.error("Error refreshing leaderboard:", error);
         // Still update the refresh time on error to prevent rapid retries
         lastRefreshTime = now;
+        forceRefresh = false;
       }),
     );
   }

--- a/doc/calculated-temperatures-and-rooms.md
+++ b/doc/calculated-temperatures-and-rooms.md
@@ -38,8 +38,10 @@ calculation. The constant is defined once in `app/constants.py` and is currently
 10 minutes are ignored.
 
 `app/room_metrics.py` is the shared source-selection boundary for current room
-temperature and humidity. `db.fetch_latest_room_metric_snapshots()` performs
-the raw SQLite lookup and returns typed snapshots; `select_room_metric_sources()`
+temperature and humidity. `db.fetch_latest_room_metric_snapshots()` performs an
+indexed latest-row lookup per device using
+`(device_id, logtime DESC, log_id DESC)` and returns typed snapshots;
+`select_room_metric_sources()`
 then applies room membership, excludes ERV and `INTERNAL` devices, calculates
 age from `logtime + duration`, rejects stale readings, and extracts the chosen
 metric. Temperature is normalized to Celsius and humidity supports both

--- a/etc/flyway/sql/V11__devlog_latest_device_reading_index.sql
+++ b/etc/flyway/sql/V11__devlog_latest_device_reading_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_devlog_device_logtime_log_id
+ON devlog (device_id, logtime DESC, log_id DESC);

--- a/etc/schema.sql
+++ b/etc/schema.sql
@@ -91,3 +91,5 @@ CREATE INDEX IF NOT EXISTS idx_presence_events_room_observed_at
 ON presence_events(room_id, observed_at);
 CREATE INDEX IF NOT EXISTS idx_presence_events_device_observed_at
 ON presence_events(device_id, observed_at);
+CREATE INDEX IF NOT EXISTS idx_devlog_device_logtime_log_id
+ON devlog (device_id, logtime DESC, log_id DESC);

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -568,6 +568,48 @@ def test_get_device_status_includes_ae200_device_id(test_database_conn):
     assert row["rules_enabled"] is True
 
 
+def test_fetch_last_status_uses_latest_reading_index(test_database_conn):
+    """Latest status is deterministic and uses the device-first composite index."""
+    cursor = test_database_conn.execute(
+        """
+        INSERT INTO devices (device_name, device_type, aqi_mon)
+        VALUES ('Indexed latest sensor', 'SENSOR', 1)
+        """
+    )
+    assert cursor.lastrowid is not None
+    device_id = int(cursor.lastrowid)
+    test_database_conn.executemany(
+        """
+        INSERT INTO devlog (device_id, logtime, duration, temp10x, status_json)
+        VALUES (?, ?, 1, ?, '{}')
+        """,
+        [
+            (device_id, 1000, 200),
+            (device_id, 1000, 210),
+            (device_id, 999, 190),
+        ],
+    )
+    test_database_conn.commit()
+
+    latest = next(
+        row for row in db.fetch_last_status(test_database_conn)
+        if row["device_id"] == device_id
+    )
+    air_rows = db.fetch_last_status(test_database_conn, flag=db.AIR_MON_DEVICES)
+    plan = test_database_conn.execute(
+        f"EXPLAIN QUERY PLAN {db.LATEST_DEVICE_STATUS_SQL}",
+        (float("inf"), 0),
+    ).fetchall()
+    details = "\n".join(row["detail"] for row in plan)
+
+    assert latest["temp10x"] == 210
+    assert any(row["device_id"] == device_id for row in air_rows)
+    assert all(row["aqi_mon"] == 1 for row in air_rows)
+    assert "idx_devlog_device_logtime_log_id" in details
+    assert "TEMP B-TREE" not in details
+    assert "SCAN devlog" not in details
+
+
 def test_fcu_discovery_creates_and_assigns_owned_room(test_database_conn):
     """Creating a typed FCU atomically creates its canonical room."""
     device_id = db.get_or_create_device_id(

--- a/tests/test_room_metric_calculations.py
+++ b/tests/test_room_metric_calculations.py
@@ -103,7 +103,9 @@ def test_room_move_updates_temperature_and_equal_weight_humidity(
         device for device in status if device["device_id"] == fcu_id
     )
     assert fcu["calculated_humidity"] == 50.0
-    assert sum("ROW_NUMBER() OVER" in statement for statement in statements) == 1
+    assert sum(
+        "FROM devlog candidate" in statement for statement in statements
+    ) == 1
 
 
 def test_calculated_temperature_series_preserves_stale_gap(test_database_conn):

--- a/tests/test_room_metric_calculations.py
+++ b/tests/test_room_metric_calculations.py
@@ -103,9 +103,12 @@ def test_room_move_updates_temperature_and_equal_weight_humidity(
         device for device in status if device["device_id"] == fcu_id
     )
     assert fcu["calculated_humidity"] == 50.0
-    assert sum(
-        "FROM devlog candidate" in statement for statement in statements
-    ) == 1
+    metric_snapshot_statements = [
+        statement
+        for statement in statements
+        if "FROM devlog candidate" in statement and "d.aqi_mon" not in statement
+    ]
+    assert len(metric_snapshot_statements) == 1
 
 
 def test_calculated_temperature_series_preserves_stale_gap(test_database_conn):

--- a/tests/test_room_metrics.py
+++ b/tests/test_room_metrics.py
@@ -186,3 +186,43 @@ def test_shared_room_selection_handles_membership_freshness_and_payload_shapes(
     )
     assert humidity_exclusions[malformed_id] == RoomMetricExclusionReason.MISSING_METRIC
     assert humidity_exclusions[missing_id] == RoomMetricExclusionReason.MISSING_METRIC
+
+
+def test_latest_snapshot_uses_log_id_to_break_timestamp_ties(test_database_conn):
+    conn = test_database_conn
+    device_id = _device(conn, "Tied Sensor", "SENSOR", None)
+    _reading(
+        conn,
+        device_id,
+        ReadingSpec(logtime=1_000, temp10x=200, status={"humidity": 40}),
+    )
+    _reading(
+        conn,
+        device_id,
+        ReadingSpec(logtime=1_000, temp10x=210, status={"humidity": 41}),
+    )
+    _reading(
+        conn,
+        device_id,
+        ReadingSpec(logtime=1_001, temp10x=220, status={"humidity": 42}),
+    )
+    conn.commit()
+
+    snapshot = db.fetch_latest_room_metric_snapshots(conn, at_time=1_000)[0]
+
+    assert snapshot.device_id == device_id
+    assert snapshot.temp10x == 210
+    assert snapshot.status is not None
+    assert snapshot.status.humidity == 41
+
+
+def test_latest_snapshot_query_uses_bounded_composite_index(test_database_conn):
+    plan = test_database_conn.execute(
+        f"EXPLAIN QUERY PLAN {db.LATEST_ROOM_METRIC_SNAPSHOTS_SQL}",
+        (1_000,),
+    ).fetchall()
+    details = "\n".join(str(row[3]) for row in plan)
+
+    assert "idx_devlog_device_logtime_log_id" in details
+    assert "(device_id=? AND logtime<?)" in details
+    assert "CO-ROUTINE" not in details

--- a/tests/test_room_scale.js
+++ b/tests/test_room_scale.js
@@ -11,8 +11,8 @@
  */
 const {
   computeFitScale,
+  createRoomStatusRefresher,
   createStatusRefresher,
-  refreshRoomStatus,
   requestRoomStatus,
   roomControlEndpoint,
 } = require("../app/static/room_dashboard.js");
@@ -70,10 +70,11 @@ if (roomControlEndpoint("wall_light", "Hickory & East") ===
 async function testRoomStatusPolling() {
   let requests = 0;
   const unconfiguredDocument = { querySelector: () => null };
-  const refreshed = await refreshRoomStatus(
+  const refreshRoomStatus = createRoomStatusRefresher(
     () => { requests++; },
     unconfiguredDocument,
   );
+  const refreshed = await refreshRoomStatus();
   if (refreshed === false && requests === 0) {
     passed++;
   } else {
@@ -129,10 +130,67 @@ async function testDeviceStatusSingleFlight() {
     failed++;
     console.error('FAIL completed room device status must update once');
   }
+
+  let fail = true;
+  const retryingRefresh = createStatusRefresher(async () => {
+    if (fail) {
+      fail = false;
+      throw new Error('temporary failure');
+    }
+    return { ok: true, json: async () => ({ devices: [] }) };
+  }, () => {});
+  if (await retryingRefresh() === false && await retryingRefresh() === true) {
+    passed++;
+  } else {
+    failed++;
+    console.error('FAIL failed device status request must release single-flight');
+  }
+}
+
+async function testRoomControlStatusSingleFlight() {
+  let releaseRequest;
+  let requests = 0;
+  const responseReady = new Promise(resolve => { releaseRequest = resolve; });
+  const documentRef = {
+    querySelector: () => ({}),
+    getElementById: () => null,
+  };
+  const refreshRoomStatus = createRoomStatusRefresher(async () => {
+    requests++;
+    await responseReady;
+    return { ok: true, json: async () => ({}) };
+  }, documentRef);
+
+  const firstRefresh = refreshRoomStatus();
+  const overlaps = await Promise.all(Array.from({ length: 10 }, refreshRoomStatus));
+  if (overlaps.every(result => result === false) && requests === 1) {
+    passed++;
+  } else {
+    failed++;
+    console.error('FAIL room-control status requests must not overlap');
+  }
+  releaseRequest();
+  await firstRefresh;
+
+  let fail = true;
+  const retryingRefresh = createRoomStatusRefresher(async () => {
+    if (fail) {
+      fail = false;
+      throw new Error('temporary failure');
+    }
+    return { ok: true, json: async () => ({}) };
+  }, documentRef);
+  if (await retryingRefresh() === false && await retryingRefresh() === true) {
+    passed++;
+  } else {
+    failed++;
+    console.error('FAIL failed room-control request must release single-flight');
+  }
 }
 
 testRoomStatusPolling()
   .then(testDeviceStatusSingleFlight)
+  .then(testRoomControlStatusSingleFlight)
   .catch(error => {
     failed++;
     console.error(`FAIL room status polling tests: ${error.message}`);

--- a/tests/test_unit_speed.js
+++ b/tests/test_unit_speed.js
@@ -136,10 +136,14 @@ async function testSingleFlightStatusRefresh() {
     calls++;
     await firstOperation;
   });
-  const overlappingRun = await runSingleFlight(async () => {
-    calls++;
-  });
-  check("overlapping status refresh is skipped", overlappingRun, false);
+  const overlappingRuns = await Promise.all(
+    Array.from({ length: 10 }, () => runSingleFlight(async () => { calls++; })),
+  );
+  check(
+    "forced refresh attempts are skipped while status is pending",
+    overlappingRuns.every(result => result === false),
+    true,
+  );
   check("only one status refresh starts", calls, 1);
 
   releaseFirst();
@@ -152,6 +156,22 @@ async function testSingleFlightStatusRefresh() {
     true,
   );
   check("second sequential status refresh starts", calls, 2);
+
+  let failureCalls = 0;
+  try {
+    await runSingleFlight(async () => {
+      failureCalls++;
+      throw new Error("temporary failure");
+    });
+  } catch (error) {
+    check("single-flight preserves operation errors", error.message, "temporary failure");
+  }
+  check(
+    "failed status refresh releases single-flight",
+    await runSingleFlight(async () => { failureCalls++; }),
+    true,
+  );
+  check("retry runs after failed status refresh", failureCalls, 2);
 }
 
 function testPendingFanChangeOwnership() {


### PR DESCRIPTION
## Summary

- prevent overlapping `/api/v1/status` requests in both dashboard polling loops
- add Flyway V11 with the composite `(device_id, logtime DESC, log_id DESC)` index
- replace full-history latest-reading scans with deterministic indexed lookups for room metrics and device status
- add substantive JavaScript, SQL result, and SQLite query-plan regression tests
- document the latest-room-snapshot query and index contract

## Root cause

The dashboard could launch another status request while the previous request was still pending. At the same time, each status response ranked or grouped the full `devlog` history to find the latest row for each device. Slow requests therefore multiplied until synchronous Gunicorn workers and both production CPUs were saturated.

The index alone does not improve the old `GROUP BY/HAVING max(logtime)` query. The SQL must use a per-device `ORDER BY logtime DESC, log_id DESC LIMIT 1` lookup for SQLite to select the covering index.

## Performance evidence

On a disposable copy of the production-sized database:

- 736,964 `devlog` rows; 45 devices; 43 devices with readings
- old query: median 0.307223 seconds, 736,964 history rows examined, 8,932,444 VM steps
- indexed query: median 0.000093 seconds, 43 history rows returned through 45 index probes, 2,072 VM steps
- measured query speedup: approximately 3,300x
- index build: 0.357 seconds
- index size: approximately 13.8 MiB
- all query variants returned the same 43 device IDs

The planner regression tests require `idx_devlog_device_logtime_log_id`, reject a temporary B-tree sort, and reject a full `devlog` scan.

## Validation

- `make check`
- `SKIP_BROWSER_TEST=1 make test`
  - 296 Python tests passed
  - 4 browser tests intentionally skipped
  - all JavaScript tests passed
- Flyway validation replayed all 11 migrations successfully

## Human deployment and verification

1. Back up the SQLite database.
2. Apply Flyway V11 before starting the new application code.
3. Deploy to a non-production environment first.
4. Confirm `/api/v1/status` latency remains low with several dashboard tabs open.
5. In browser DevTools, verify there is never more than one pending status request per polling loop.
6. Confirm forced refresh, failed requests, and recovery do not create overlapping polls.
7. Run `EXPLAIN QUERY PLAN` against the deployed database and verify the composite index is selected.
8. Exercise room temperature, humidity, FCU status, and air-quality displays to confirm latest readings and timestamp tie-breaking remain correct.
9. Deploy to production only after human review and staging verification.

No deployment is performed by this PR.

Closes #192.
Addresses the query and polling portions of #177.
