### PR TITLE
Refresh dashboard status immediately on load

### DIFF
--- a/app/ae200.py
+++ b/app/ae200.py
@@ -3,7 +3,7 @@ ae200 controller.
 Originally from https://github.com/natevoci/ae200.
 Includes both async routines and synchronous covers.
 
-Simulator if AE200_SIMULATOR is set
+Simulator if AE200_SIMULATOR contains an explicit true value
 
 """
 
@@ -28,7 +28,7 @@ import websockets
 from websockets.extensions import permessage_deflate
 from websockets.typing import Origin, Subprotocol
 
-from app.util import get_config
+from app.util import env_flag_enabled, get_config
 
 logger = logging.getLogger(__name__)
 B_XMLPROC_SUBPROTOCOL = Subprotocol("b_xmlproc")
@@ -83,7 +83,15 @@ def friendly_fan_speed_label(device_name, raw_fan_speed):
     labels = _ERV_SPEED_LABELS if is_erv else _FAN_SPEED_LABELS
     return labels.get(speed, str(raw_fan_speed))
 
-AE200_SIMULATOR = os.getenv('AE200_SIMULATOR')
+AE200_SIMULATOR_ENV = "AE200_SIMULATOR"
+
+
+def ae200_simulator_enabled() -> bool:
+    """Return True when AE-200 simulator mode is explicitly enabled."""
+    return env_flag_enabled(AE200_SIMULATOR_ENV)
+
+
+AE200_SIMULATOR = ae200_simulator_enabled()
 SIMULATOR_DIR = Path(join(dirname(__file__), "test_data"))
 
 getUnitsPayload = """<?xml version="1.0" encoding="UTF-8" ?>

--- a/app/airquality.py
+++ b/app/airquality.py
@@ -5,11 +5,10 @@ You need an API key
 
 import logging
 import json
-import os
 from typing import Any
 
 import requests
-from app.util import get_config, get_secret
+from app.util import env_flag_enabled, get_config, get_secret
 from app.paths import TIMEOUT_SECONDS
 
 AIRNOW_URL = "https://www.airnowapi.org/aq/observation/zipCode/current/?format=application/json&zipCode={zipcode}&distance=15&API_KEY={API_KEY}"
@@ -17,7 +16,6 @@ GOOGLE_URL = "https://airquality.googleapis.com/v1/history:lookup?key={API_KEY}"
 
 logger = logging.getLogger(__name__)
 AQICN_SIMULATOR_ENV = "AQICN_SIMULATOR"
-TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 AQICN_SIMULATOR_DATA = {
     "aqi": 45,
     "iaqi": {
@@ -50,7 +48,7 @@ class AQIError(Exception):
 
 def aqicn_simulator_enabled() -> bool:
     """Return True when AQICN simulator mode is explicitly enabled."""
-    return os.getenv(AQICN_SIMULATOR_ENV, "").strip().lower() in TRUE_ENV_VALUES
+    return env_flag_enabled(AQICN_SIMULATOR_ENV)
 
 def aqi_decode(aqi):
     aqi = int(aqi)

--- a/app/airthings.py
+++ b/app/airthings.py
@@ -2,11 +2,10 @@
 Interface to the airthings api
 """
 
-import os
 import json
 from pathlib import Path
 import requests
-from app.util import get_secret
+from app.util import env_flag_enabled, get_secret
 from app.paths import TIMEOUT_SECONDS
 
 
@@ -15,7 +14,15 @@ ACCOUNTS_URL = "https://consumer-api.airthings.com/v1/accounts"
 DEVICES_URL = "https://consumer-api.airthings.com/v1/accounts/{accountId}/devices"
 SENSORS_URL = "https://consumer-api.airthings.com/v1/accounts/{accountId}/sensors?{sn_param}"
 
-AIRTHINGS_SIMULATOR = os.getenv('AIRTHINGS_SIMULATOR')
+AIRTHINGS_SIMULATOR_ENV = "AIRTHINGS_SIMULATOR"
+
+
+def airthings_simulator_enabled() -> bool:
+    """Return True when Airthings simulator mode is explicitly enabled."""
+    return env_flag_enabled(AIRTHINGS_SIMULATOR_ENV)
+
+
+AIRTHINGS_SIMULATOR = airthings_simulator_enabled()
 if AIRTHINGS_SIMULATOR:
     AIRTHINGS_SAMPLE_FILE     = Path(__file__).parent.parent / 'etc' / 'airthings_sample.json'
     CLIENT_ID     = None

--- a/app/hubitat.py
+++ b/app/hubitat.py
@@ -3,18 +3,16 @@ Hubitat implementation
 """
 
 import json
-import os
 from pathlib import Path
 
 import requests
-from app.util import get_config,get_secret
+from app.util import env_flag_enabled, get_config, get_secret
 from app.paths import TIMEOUT_SECONDS
 
 OFFLINE = 'OFFLINE - '
 HUBITAT_SIMULATOR_ENV = "HUBITAT_SIMULATOR"
 SIMULATOR_DIR = Path(__file__).resolve().parent / "test_data"
 SIMULATOR_DEVICES_FILE = SIMULATOR_DIR / "hubitat_get_devices.json"
-TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
 
 HUBITAT_GET_ALL_DEVICES_FULL_DETAILS = "http://{host}/apps/api/{appId}/devices/all?access_token={access_token}"
 HUBITAT_GET_DEVICE_INFO = "http://{host}/apps/api/{appId}/devices/{device_id}?access_token={access_token}"
@@ -33,7 +31,7 @@ HUBITAT_SEND_DEVICE_COMMAND="http://{host}/apps/api/{appId}/devices/{device_id}/
 
 def hubitat_simulator_enabled() -> bool:
     """Return True when Hubitat simulator mode is explicitly enabled."""
-    return os.getenv(HUBITAT_SIMULATOR_ENV, "").strip().lower() in TRUE_ENV_VALUES
+    return env_flag_enabled(HUBITAT_SIMULATOR_ENV)
 
 
 def _simulated_devices():

--- a/app/models.py
+++ b/app/models.py
@@ -4,7 +4,8 @@ This module is the home for structured application data that crosses module
 boundaries:
 
 - Request models are populated by ``flask_pydantic`` route validation and are
-  passed into ``rules_engine`` command functions.
+  passed into ``rules_engine`` command functions. Control requests reject
+  unknown fields so client typos cannot silently change hardware commands.
 - Response models validate data assembled from SQLite rows or external
   services before routes/templates receive JSON-ready dictionaries.
 
@@ -347,7 +348,11 @@ class WeatherStation(BaseModel):
 
 
 class WeatherData(BaseModel):
-    """Weather payload returned by the app weather endpoint."""
+    """Application-assembled weather payload returned by the weather endpoint.
+
+    The weather service reduces upstream responses to this internal shape before
+    validation, so rejecting unexpected top-level fields catches contract drift.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -376,7 +381,13 @@ class AqiWeatherResponse(BaseModel):
     weather: WeatherData | Dict[str, Any]
 
 
-class SpeedControl(BaseModel):
+class ControlRequest(BaseModel):
+    """Strict base for request bodies that control devices or configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class SpeedControl(ControlRequest):
     """Request body for changing an AE-200 fan speed.
 
     Used by ``POST /api/v1/set_fan_speed`` and by rules that command fan speed
@@ -393,7 +404,7 @@ class SpeedControl(BaseModel):
         return _rule_code(value, ae200.FAN_SPEED_NAMES, "fan_speed")
 
 
-class DriveControl(BaseModel):
+class DriveControl(ControlRequest):
     """Request body for changing an AE-200 drive state.
 
     Used by ``POST /api/v1/set_drive`` and by rules that command drive state
@@ -412,7 +423,7 @@ class DriveControl(BaseModel):
         return _rule_code(value, ae200.DRIVE_NAMES, "drive")
 
 
-class ModeControl(BaseModel):
+class ModeControl(ControlRequest):
     """Request body for changing an AE-200 operation mode."""
 
     device_id: int = Field(description="Local device id from the devices table.")
@@ -421,14 +432,14 @@ class ModeControl(BaseModel):
     )
 
 
-class NoteControl(BaseModel):
+class NoteControl(ControlRequest):
     """Request body for updating the operator note attached to a device."""
 
     device_id: int = Field(description="Local device id from the devices table.")
     notes: str | None = Field(description="Replacement note text, or null to clear it.")
 
 
-class DeviceMetadataControl(BaseModel):
+class DeviceMetadataControl(ControlRequest):
     """Editable metadata stored on the devices table."""
 
     device_id: int = Field(description="Local device id from the devices table.")
@@ -460,7 +471,7 @@ class DeviceMetadataControl(BaseModel):
         return _optional_upper(value)
 
 
-class SetTempControl(BaseModel):
+class SetTempControl(ControlRequest):
     """Request body for changing an AE-200 set temperature.
 
     ``set_temp_c`` is always Celsius. Browser code can display Fahrenheit, but
@@ -471,7 +482,7 @@ class SetTempControl(BaseModel):
     set_temp_c: float = Field(description="Requested set point in degrees Celsius.")
 
 
-class AutoSetTempControl(BaseModel):
+class AutoSetTempControl(ControlRequest):
     """Request body for changing AE-200 Auto Heat/Cool setpoints."""
 
     device_id: int = Field(description="Local device id from the devices table.")
@@ -485,7 +496,7 @@ class AutoSetTempControl(BaseModel):
         return self
 
 
-class SetRangeControl(BaseModel):
+class SetRangeControl(ControlRequest):
     """Request body for changing an FCU temperature set range."""
 
     device_id: int = Field(description="Local device id from the devices table.")
@@ -503,16 +514,14 @@ class FcuSetRange(BaseModel):
     updated_at: int | None = None
 
 
-class DeviceRoomControl(BaseModel):
+class DeviceRoomControl(ControlRequest):
     """Request body for assigning a device to a room."""
-
-    model_config = ConfigDict(extra="forbid")
 
     device_id: int = Field(description="Local device id from the devices table.")
     room_id: int | None = Field(description="Room id, or null to clear assignment.")
 
 
-class FcuTempSourceControl(BaseModel):
+class FcuTempSourceControl(ControlRequest):
     """Request body for one FCU temperature source multiplier."""
 
     fcu_device_id: int = Field(description="FCU device id from the devices table.")

--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -17,9 +17,7 @@ const REFRESH_INTERVAL = 10; // seconds between refreshes
 const RUNNING_MINUTES = 10; // minutes to run before stopping
 const SHOW_REFRESH_COUNTDOWN = false;
 const DASHBOARD_AIR_QUALITY_DEVICE_EXPIRATION_SECONDS = 30 * 24 * 60 * 60;
-// The HTML is server-rendered from the same status data. Wait one interval
-// before polling instead of repeating that database work immediately on load.
-let lastRefreshTime = Date.now();
+let lastRefreshTime = 0;
 const AE200_MODE_LABELS = {
   COOL: "Cool",
   HEAT: "Heat",
@@ -2643,10 +2641,11 @@ function setupNoteInputHandlers(input, noteElement, deviceId, originalText) {
 // Refresh the rows in the fan control and temperature panel grid.
 const refreshGridRows = () => {
   const now = Date.now();
-  const secondsSinceRefresh = Math.floor((now - lastRefreshTime) / 1000);
-  const secondsUntilRefresh = forceRefresh
-    ? 0
-    : REFRESH_INTERVAL - secondsSinceRefresh;
+  const secondsUntilRefresh = secondsUntilStatusRefresh(
+    now,
+    lastRefreshTime,
+    forceRefresh,
+  );
 
   // Check if total runtime exceeded
   if (now - start > RUNNING_MINUTES * 60 * 1000) {
@@ -2902,6 +2901,11 @@ const refreshGridRows = () => {
   }
   setTimeout(refreshGridRows, 1000); // Schedule next check in 1 second
 };
+
+function secondsUntilStatusRefresh(now, refreshedAt, forced) {
+  if (forced || refreshedAt === 0) return 0;
+  return REFRESH_INTERVAL - Math.floor((now - refreshedAt) / 1000);
+}
 
 /* This loads weather and starts the refresh cycle. */
 async function loadWeatherAndStartRefresh() {
@@ -3233,6 +3237,7 @@ if (typeof module !== "undefined" && module.exports) {
     resizeSetRangeEndpoint,
     saveAutoSetTempWidget,
     saveFcuTempSourceMultipliers,
+    secondsUntilStatusRefresh,
     setRangePartFromPointerTarget,
     setAutoSetTempUnavailable,
     updateSetRangeModeState,

--- a/app/util.py
+++ b/app/util.py
@@ -11,6 +11,13 @@ import yaml
 from app.paths import CONFIG_YAML_PATH
 
 logger = logging.getLogger(__name__)
+TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def env_flag_enabled(name: str) -> bool:
+    """Return whether an environment flag contains an explicit true value."""
+    return os.getenv(name, "").strip().lower() in TRUE_ENV_VALUES
+
 
 @functools.lru_cache(maxsize=1)
 def get_config():

--- a/doc/tech-debt.md
+++ b/doc/tech-debt.md
@@ -187,9 +187,9 @@ plan.
 
 Current state:
 
-- `etc/air_basistech_net.service`, `etc/slg1_basistech_net.service`, and
-  `etc/deg1_basistech_net.service` still contain Gunicorn `--reload` even though
-  it was manually removed from the live process after the July CPU incident.
+- The checked-in Gunicorn service units now omit `--reload`, matching the
+  manually corrected live production process. A repository test prevents the
+  reloader from being reintroduced into those units.
 - `etc/air_basistech_net.service` still runs as `User=simsong` and `Group=simsong`
   while using `/home/air/temperature-bot`.
 - `etc/slg1_basistech_net.service` uses `/home/simsong/temperature-bot`.

--- a/etc/air_basistech_net.service
+++ b/etc/air_basistech_net.service
@@ -9,7 +9,7 @@ Group=simsong
 WorkingDirectory=/home/air/temperature-bot
 Environment="PATH=/home/air/temperature-bot/.venv/bin"
 Environment="DB_PATH=/var/db/temperature-bot.db"
-ExecStart=/bin/bash -c 'gunicorn app.main:app --reload --bind 127.0.0.1:8100 --workers $((2 * $(/usr/bin/nproc) + 1))'
+ExecStart=/bin/bash -c 'gunicorn app.main:app --bind 127.0.0.1:8100 --workers $((2 * $(/usr/bin/nproc) + 1))'
 Restart=always
 RestartSec=2
 

--- a/etc/deg1_basistech_net.service
+++ b/etc/deg1_basistech_net.service
@@ -10,7 +10,7 @@ WorkingDirectory=/home/deg/temperature-bot
 Environment="PATH=/home/deg/temperature-bot/.venv/bin"
 Environment="DB_PATH=/home/deg/temperature-bot/temperature-bot.db"
 Environment="LOG_LEVEL=DEBUG"
-ExecStart=/bin/bash -c 'LOG_LEVEL=DEBUG gunicorn app.main:app --log-level debug --reload --bind 127.0.0.1:8004 --workers $((2 * $(/usr/bin/nproc) + 1)) --access-logfile /home/deg/access.log --error-logfile /home/deg/error.log'
+ExecStart=/bin/bash -c 'LOG_LEVEL=DEBUG gunicorn app.main:app --log-level debug --bind 127.0.0.1:8004 --workers $((2 * $(/usr/bin/nproc) + 1)) --access-logfile /home/deg/access.log --error-logfile /home/deg/error.log'
 Restart=always
 RestartSec=1
 

--- a/etc/slg1_basistech_net.service
+++ b/etc/slg1_basistech_net.service
@@ -10,7 +10,7 @@ WorkingDirectory=/home/simsong/temperature-bot
 Environment="PATH=/home/simsong/temperature-bot/.venv/bin"
 Environment="DB_PATH=/var/db/temperature-bot.db"
 Environment="LOG_LEVEL=DEBUG"
-ExecStart=/bin/bash -c 'LOG_LEVEL=DEBUG gunicorn app.main:app --log-level debug --reload --bind 127.0.0.1:8003 --workers $((2 * $(/usr/bin/nproc) + 1)) --access-logfile /home/simsong/access.log --error-logfile /home/simsong/error.log'
+ExecStart=/bin/bash -c 'LOG_LEVEL=DEBUG gunicorn app.main:app --log-level debug --bind 127.0.0.1:8003 --workers $((2 * $(/usr/bin/nproc) + 1)) --access-logfile /home/simsong/access.log --error-logfile /home/simsong/error.log'
 Restart=always
 RestartSec=1
 

--- a/tests/test_bin_tools.py
+++ b/tests/test_bin_tools.py
@@ -105,6 +105,16 @@ def test_makefile_local_targets_control_sensor_simulators():
     )
 
 
+def test_production_gunicorn_services_disable_reloader():
+    """Production service definitions must never run Gunicorn's dev reloader."""
+    etc_dir = Path(__file__).resolve().parents[1] / "etc"
+    service_files = sorted(etc_dir.glob("*_basistech_net.service"))
+
+    assert service_files
+    for service_file in service_files:
+        assert "--reload" not in service_file.read_text(encoding="utf-8"), service_file
+
+
 def test_update_from_airthings_persists_sensor_status(monkeypatch, test_database_conn):
     """Airthings updater should write both temperature and rich air-quality payloads."""
     monkeypatch.setattr(

--- a/tests/test_control_contracts.py
+++ b/tests/test_control_contracts.py
@@ -1,0 +1,46 @@
+"""Strict validation tests for hardware and configuration control requests."""
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    (
+        ("POST", "/api/v1/set_fan_speed", {"device_id": 1, "fan_speed": 1}),
+        ("POST", "/api/v1/set_drive", {"device_id": 1, "drive": 1}),
+        ("POST", "/api/v1/set_mode", {"device_id": 1, "mode": "COOL"}),
+        ("POST", "/api/v1/set_temp", {"device_id": 1, "set_temp_c": 21}),
+        (
+            "POST",
+            "/api/v1/set_auto_temp",
+            {"device_id": 1, "heat_set_temp_c": 19, "cool_set_temp_c": 24},
+        ),
+        (
+            "POST",
+            "/api/v1/set_range",
+            {"device_id": 1, "set_range_low_c": 19, "set_range_high_c": 24},
+        ),
+        ("POST", "/api/v1/update_note", {"device_id": 1, "notes": "note"}),
+        (
+            "POST",
+            "/api/v1/update_device_room",
+            {"device_id": 1, "room_id": None},
+        ),
+        (
+            "POST",
+            "/api/v1/fcu_temp_source",
+            {"fcu_device_id": 1, "source_device_id": 2, "multiplier": 1},
+        ),
+        ("PATCH", "/api/v1/devices/1", {"display_name": "Unit"}),
+    ),
+)
+def test_control_endpoints_reject_unknown_fields(
+    flask_test_client, method, path, payload
+):
+    response = flask_test_client.open(
+        path,
+        method=method,
+        json={**payload, "unexpected": True},
+    )
+
+    assert response.status_code == 400

--- a/tests/test_simulator_flags.py
+++ b/tests/test_simulator_flags.py
@@ -1,0 +1,37 @@
+"""Simulator environment flags require explicit true values."""
+
+import pytest
+
+from app import ae200, airquality, airthings, hubitat
+
+
+SIMULATOR_FLAGS = (
+    (ae200.ae200_simulator_enabled, ae200.AE200_SIMULATOR_ENV),
+    (airthings.airthings_simulator_enabled, airthings.AIRTHINGS_SIMULATOR_ENV),
+    (hubitat.hubitat_simulator_enabled, hubitat.HUBITAT_SIMULATOR_ENV),
+    (airquality.aqicn_simulator_enabled, airquality.AQICN_SIMULATOR_ENV),
+)
+
+
+@pytest.mark.parametrize(("enabled", "env_name"), SIMULATOR_FLAGS)
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    (
+        ("1", True),
+        ("true", True),
+        ("TRUE", True),
+        ("yes", True),
+        ("on", True),
+        (" On ", True),
+        ("0", False),
+        ("false", False),
+        ("False", False),
+        ("no", False),
+        ("off", False),
+        ("", False),
+        ("random", False),
+    ),
+)
+def test_simulator_flag_values(monkeypatch, value, expected, enabled, env_name):
+    monkeypatch.setenv(env_name, value)
+    assert enabled() is expected

--- a/tests/test_unit_speed.js
+++ b/tests/test_unit_speed.js
@@ -44,6 +44,7 @@ const {
   resizeSetRangeEndpoint,
   saveAutoSetTempWidget,
   saveFcuTempSourceMultipliers,
+  secondsUntilStatusRefresh,
   setAutoSetTempUnavailable,
   setRangePartFromPointerTarget,
   sortedFcuTempSources,
@@ -173,6 +174,22 @@ async function testSingleFlightStatusRefresh() {
   );
   check("retry runs after failed status refresh", failureCalls, 2);
 }
+
+check(
+  "initial status refresh is immediate",
+  secondsUntilStatusRefresh(20_000, 0, false),
+  0,
+);
+check(
+  "completed status refresh waits one interval",
+  secondsUntilStatusRefresh(20_000, 20_000, false),
+  10,
+);
+check(
+  "forced status refresh is immediate",
+  secondsUntilStatusRefresh(20_000, 20_000, true),
+  0,
+);
 
 function testPendingFanChangeOwnership() {
   const pendingChanges = new Map();


### PR DESCRIPTION
Treat an unset last-refresh timestamp as immediately due while retaining the ten-second interval after completed requests and the existing single-flight protection. Add direct scheduling regression coverage.