### PR TITLE
Harden room and FCU rename completion

### DIFF
--- a/app/static/room_matrix.js
+++ b/app/static/room_matrix.js
@@ -310,7 +310,35 @@ function applyRoomMetrics(roomId, temp10x, humidity) {
 }
 
 function closeRoomRenameDialog() {
-  document.getElementById("room-rename-dialog")?.classList.add("hidden");
+  const dialog = document.getElementById("room-rename-dialog");
+  if (!dialog) return;
+  setRoomRenameSaving(dialog, false);
+  dialog.classList.add("hidden");
+}
+
+function roomRenameIsSaving(dialog) {
+  return dialog?.dataset.saving === "true";
+}
+
+function setRoomRenameSaving(dialog, saving) {
+  if (!dialog) return;
+  if (saving) {
+    dialog.dataset.saving = "true";
+    dialog.setAttribute("aria-busy", "true");
+  } else {
+    delete dialog.dataset.saving;
+    dialog.removeAttribute("aria-busy");
+  }
+  dialog.querySelectorAll("input, button").forEach((control) => {
+    control.disabled = saving;
+  });
+}
+
+function cancelRoomRenameDialog() {
+  const dialog = document.getElementById("room-rename-dialog");
+  if (!dialog || roomRenameIsSaving(dialog)) return false;
+  closeRoomRenameDialog();
+  return true;
 }
 
 function openRoomRenameDialog(button) {
@@ -320,6 +348,7 @@ function openRoomRenameDialog(button) {
   if (!dialog || !input) return;
   dialog.dataset.roomId = button.dataset.roomId;
   dialog.dataset.roomName = button.dataset.roomName || button.textContent.trim();
+  setRoomRenameSaving(dialog, false);
   input.value = button.dataset.roomName || button.textContent.trim();
   dialog.querySelector("[data-role='message']").textContent = "";
   dialog
@@ -334,28 +363,51 @@ function openRoomRenameDialog(button) {
 }
 
 async function renameRoom(dialog) {
+  if (roomRenameIsSaving(dialog)) return false;
   const roomId = roomIdFromValue(dialog.dataset.roomId);
   const input = document.getElementById("room-rename-name");
   const message = dialog.querySelector("[data-role='message']");
   const roomName = String(input?.value || "").trim();
   if (roomId === null || !roomName) {
     message.textContent = "Room name is required.";
-    return;
+    return false;
   }
+  setRoomRenameSaving(dialog, true);
+  message.textContent = "Saving…";
+  let data;
   try {
-    const data = await persistRoomName(roomId, roomName);
-    const savedRoomName = data.room_name || roomName;
+    data = await persistRoomName(roomId, roomName);
+  } catch (error) {
+    message.textContent = error.message || "Unable to rename room.";
+    setRoomRenameSaving(dialog, false);
+    input?.focus();
+    return false;
+  }
+
+  const savedRoomName = data.room_name || roomName;
+  let presentationFailed = false;
+  try {
     applyMatrixRoomName(roomId, savedRoomName);
     document
       .querySelectorAll(`.fcu-temp-sources-trigger[data-room-id="${roomId}"]`)
       .forEach((trigger) => {
         trigger.dataset.roomName = savedRoomName;
       });
-    closeRoomRenameDialog();
-    showRoomMatrixMessage(`Renamed room to ${data.room_name || roomName}.`);
   } catch (error) {
-    message.textContent = error.message || "Unable to rename room.";
+    presentationFailed = true;
+    console.error("Room rename was saved, but the page update failed:", error);
   }
+  closeRoomRenameDialog();
+  if (presentationFailed) {
+    if (typeof window !== "undefined") window.location.reload();
+    return true;
+  }
+  try {
+    showRoomMatrixMessage(`Renamed room to ${savedRoomName}.`);
+  } catch (error) {
+    console.error("Room rename was saved, but the confirmation failed:", error);
+  }
+  return true;
 }
 
 function closeRoomCreateDialog() {
@@ -476,7 +528,7 @@ function setupRoomRename() {
   });
   dialog?.querySelector("[data-action='cancel-room-rename']")?.addEventListener(
     "click",
-    closeRoomRenameDialog,
+    cancelRoomRenameDialog,
   );
   dialog?.querySelector("[data-action='request-room-delete']")?.addEventListener(
     "click",
@@ -508,6 +560,9 @@ function setupRoomRename() {
   deleteDialog
     ?.querySelector("[data-action='cancel-room-delete']")
     ?.addEventListener("click", closeRoomDeleteDialog);
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") cancelRoomRenameDialog();
+  });
 }
 
 function setupRoomDragging() {
@@ -600,6 +655,7 @@ if (typeof window !== "undefined") {
 if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     compareSensors,
+    cancelRoomRenameDialog,
     deviceRoomRequest,
     longPressTriggered,
     openRoomDeleteDialog,
@@ -608,6 +664,8 @@ if (typeof module !== "undefined" && module.exports) {
     persistRoomName,
     persistSensorRoom,
     restoreSensorPosition,
+    renameRoom,
+    roomRenameIsSaving,
     roomRenameKeyTriggered,
     roomHumidityText,
     roomDeleteCountdown,

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -923,6 +923,11 @@ table.rules-table th  {
     justify-content: flex-end;
 }
 
+.device-rename-message {
+    min-height: 1.2rem;
+    color: #b42318;
+}
+
 .fcu-temp-sources-popup {
     position: fixed;
     inset: 0;

--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -1308,11 +1308,27 @@ function setDeviceRenameControlsDisabled(popup, disabled) {
   }
 }
 
+function deviceRenameIsSaving(popup) {
+  return popup?.dataset.saving === "true";
+}
+
+function setDeviceRenameSaving(popup, saving) {
+  if (saving) {
+    popup.dataset.saving = "true";
+    popup.setAttribute("aria-busy", "true");
+  } else {
+    delete popup.dataset.saving;
+    popup.removeAttribute("aria-busy");
+  }
+  setDeviceRenameControlsDisabled(popup, saving);
+}
+
 function closeDeviceRenamePopup() {
   const popup = document.getElementById("device-rename-popup");
   if (!popup) {
     return;
   }
+  setDeviceRenameSaving(popup, false);
   popup.classList.add("hidden");
   popup.removeAttribute("style");
   delete popup.dataset.deviceId;
@@ -1321,6 +1337,13 @@ function closeDeviceRenamePopup() {
   delete popup.dataset.rulesEnabled;
   delete popup.dataset.deviceUpdate;
   delete popup.dataset.currentDisplayName;
+}
+
+function cancelDeviceRenamePopup() {
+  const popup = document.getElementById("device-rename-popup");
+  if (!popup || deviceRenameIsSaving(popup)) return false;
+  closeDeviceRenamePopup();
+  return true;
 }
 
 function setDeviceReadonlyMetadata(popup, deviceType, rulesEnabled) {
@@ -1387,9 +1410,11 @@ function openDeviceRenamePopup(target, event) {
     lastUpdateInput.value = deviceUpdate || "--";
   }
   setDeviceReadonlyMetadata(popup, deviceType, rulesEnabled);
+  setDeviceRenameSaving(popup, false);
+  const message = popup.querySelector("[data-role='message']");
+  if (message) message.textContent = "";
 
   popup.classList.remove("hidden");
-  setDeviceRenameControlsDisabled(popup, false);
   positionDeviceRenamePopup(popup, event.clientX, event.clientY);
   displayNameInput.focus();
   displayNameInput.select();
@@ -1471,19 +1496,33 @@ function applyDeviceDisplayName(
 async function submitDeviceDisplayName(displayName) {
   const popup = document.getElementById("device-rename-popup");
   if (!popup) {
-    return;
+    return false;
   }
+  if (deviceRenameIsSaving(popup)) return false;
   const deviceId = parseInt(popup.dataset.deviceId, 10);
   const deviceName = popup.dataset.deviceName || "";
   if (!Number.isInteger(deviceId) || !deviceName) {
     closeDeviceRenamePopup();
-    return;
+    return false;
   }
 
-  setDeviceRenameControlsDisabled(popup, true);
+  const message = popup.querySelector("[data-role='message']");
+  setDeviceRenameSaving(popup, true);
+  if (message) message.textContent = "Saving…";
+  let data;
   try {
-    const data = await patchDeviceDisplayName(deviceId, displayName);
-    const savedDisplayName = data.display_name || displayName || deviceName;
+    data = await patchDeviceDisplayName(deviceId, displayName);
+  } catch (error) {
+    console.error("Failed to update device display name:", error);
+    if (message) message.textContent = error.message || "Unable to rename unit.";
+    setDeviceRenameSaving(popup, false);
+    document.getElementById("device-rename-display-name")?.focus();
+    return false;
+  }
+
+  const savedDisplayName = data.display_name || displayName || deviceName;
+  forceRefresh = true;
+  try {
     applyDeviceDisplayName(
       deviceId,
       deviceName,
@@ -1491,17 +1530,11 @@ async function submitDeviceDisplayName(displayName) {
       data.device_type ?? popup.dataset.deviceType,
       data.rules_enabled ?? popup.dataset.rulesEnabled,
     );
-    forceRefresh = true;
-    closeDeviceRenamePopup();
   } catch (error) {
-    console.error("Failed to update device display name:", error);
-    alert(`Error ${error.message}`);
-    closeDeviceRenamePopup();
-  } finally {
-    if (!popup.classList.contains("hidden")) {
-      setDeviceRenameControlsDisabled(popup, false);
-    }
+    console.error("Device rename was saved, but the page update failed:", error);
   }
+  closeDeviceRenamePopup();
+  return true;
 }
 
 function setupDeviceRenamePopupControls() {
@@ -1558,17 +1591,17 @@ function setupDeviceRenamePopupControls() {
 
   const cancelButton = popup.querySelector("[data-action='cancel-device-rename']");
   if (cancelButton) {
-    cancelButton.addEventListener("click", closeDeviceRenamePopup);
+    cancelButton.addEventListener("click", cancelDeviceRenamePopup);
   }
 
   document.addEventListener("click", (event) => {
     if (!popup.classList.contains("hidden") && !popup.contains(event.target)) {
-      closeDeviceRenamePopup();
+      cancelDeviceRenamePopup();
     }
   });
   document.addEventListener("keydown", (event) => {
     if (event.key === "Escape") {
-      closeDeviceRenamePopup();
+      cancelDeviceRenamePopup();
     }
   });
 }
@@ -3205,9 +3238,11 @@ if (typeof module !== "undefined" && module.exports) {
     autoSetTempRangeForDevice,
     compactAgeFromSeconds,
     clearPendingFanChange,
+    cancelDeviceRenamePopup,
     createSingleFlight,
     dashboardAirQualityDeviceIsActive,
     deviceDisplayNameChanged,
+    deviceRenameIsSaving,
     deviceLabelWithIcon,
     deviceDisplayNamePatchBody,
     deviceRulesEnabledValue,
@@ -3242,6 +3277,7 @@ if (typeof module !== "undefined" && module.exports) {
     setAutoSetTempUnavailable,
     updateSetRangeModeState,
     sortedFcuTempSources,
+    submitDeviceDisplayName,
     tableUpdateSummaryText,
     updateSetTempForDevice,
     updateTemperatureCell,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -431,6 +431,7 @@
     <input id="device-rename-display-name" type="text" autocomplete="off">
     <button type="button" class="pure-button pure-button-primary" data-action="rename-device" disabled>rename</button>
   </div>
+  <div class="device-rename-message" data-role="message" aria-live="polite"></div>
   <div class="device-rename-row">
     <label for="device-rename-device-type">device type</label>
     <input id="device-rename-device-type" type="text" readonly>

--- a/tests/test_device_metadata.py
+++ b/tests/test_device_metadata.py
@@ -5,6 +5,8 @@ import sqlite3
 
 from conftest import flask_test_client  # noqa: F401  # pylint: disable=unused-import
 
+from app import db
+
 
 def _first_device_id() -> int:
     test_db_path = os.environ.get("TEST_DB_NAME")
@@ -89,6 +91,48 @@ def test_device_metadata_empty_patch_preserves_fields(flask_test_client):  # noq
     assert row["device_type"] == "ERV"
     assert row["rules_enabled"] == 0
     assert row["notes"] == "keep this note"
+
+
+def test_fcu_display_name_and_room_name_are_independent(
+    flask_test_client, test_database_conn_with_test_data
+):  # noqa: F811
+    """FCU labels and room names must remain separate persisted properties."""
+    conn, _, _ = test_database_conn_with_test_data
+    device_id = db.get_or_create_device_id(
+        conn, "Independent FCU", device_type="FCU"
+    )
+    room_id = conn.execute(
+        "SELECT room_id FROM devices WHERE device_id=?", (device_id,)
+    ).fetchone()[0]
+    original_room_name = conn.execute(
+        "SELECT room_name FROM rooms WHERE room_id=?", (room_id,)
+    ).fetchone()[0]
+
+    device_response = flask_test_client.patch(
+        f"/api/v1/devices/{device_id}", json={"display_name": "Independent Unit"}
+    )
+    assert device_response.status_code == 200
+    assert conn.execute(
+        "SELECT room_name FROM rooms WHERE room_id=?", (room_id,)
+    ).fetchone()[0] == original_room_name
+
+    room_response = flask_test_client.patch(
+        f"/api/v1/rooms/{room_id}", json={"room_name": "Independent Room"}
+    )
+    assert room_response.status_code == 200
+    row = conn.execute(
+        """
+        SELECT devices.display_name, rooms.room_name
+        FROM devices
+        JOIN rooms ON rooms.room_id=devices.room_id
+        WHERE devices.device_id=?
+        """,
+        (device_id,),
+    ).fetchone()
+    assert dict(row) == {
+        "display_name": "Independent Unit",
+        "room_name": "Independent Room",
+    }
 
 
 def test_devices_route(flask_test_client):  # noqa: F811

--- a/tests/test_room_matrix.js
+++ b/tests/test_room_matrix.js
@@ -2,6 +2,7 @@
 
 const assert = require("assert");
 const {
+  cancelRoomRenameDialog,
   compareSensors,
   deviceRoomRequest,
   longPressTriggered,
@@ -11,6 +12,8 @@ const {
   persistRoomName,
   persistSensorRoom,
   restoreSensorPosition,
+  renameRoom,
+  roomRenameIsSaving,
   roomHumidityText,
   roomDeleteCountdown,
   roomDisplayName,
@@ -177,7 +180,123 @@ async function testPersistenceTransitions() {
   assert.strictEqual(row.dataset.roomId, "3");
 }
 
+function fakeClassList(initial = []) {
+  const classes = new Set(initial);
+  return {
+    add: (...names) => names.forEach((name) => classes.add(name)),
+    contains: (name) => classes.has(name),
+    remove: (...names) => names.forEach((name) => classes.delete(name)),
+  };
+}
+
+function fakeRenameDialog(roomName = "Bravo") {
+  const controls = [{ disabled: false }, { disabled: false }, { disabled: false }];
+  const message = { textContent: "" };
+  return {
+    attributes: {},
+    classList: fakeClassList(),
+    controls,
+    dataset: { roomId: "7", roomName: "Alpha" },
+    input: { focusCount: 0, value: roomName, focus() { this.focusCount++; } },
+    message,
+    querySelector: (selector) =>
+      selector === "[data-role='message']" ? message : null,
+    querySelectorAll: () => controls,
+    removeAttribute(name) { delete this.attributes[name]; },
+    setAttribute(name, value) { this.attributes[name] = String(value); },
+  };
+}
+
+async function testRoomRenameCompletion() {
+  const originalDocument = global.document;
+  const originalFetch = global.fetch;
+  const originalWindow = global.window;
+  const originalConsoleError = console.error;
+  let releaseRequest;
+  let requestCount = 0;
+  const dialog = fakeRenameDialog();
+  const errors = [];
+  let reloadCount = 0;
+  global.document = {
+    getElementById(id) {
+      if (id === "room-rename-dialog") return dialog;
+      if (id === "room-rename-name") return dialog.input;
+      return null;
+    },
+    querySelector() {
+      throw new Error("simulated rendering failure");
+    },
+  };
+  global.fetch = async () => {
+    requestCount++;
+    await new Promise((resolve) => { releaseRequest = resolve; });
+    return { ok: true, json: async () => ({ room_name: "Bravo" }) };
+  };
+  global.window = { location: { reload: () => { reloadCount++; } } };
+  console.error = (...args) => errors.push(args.join(" "));
+
+  try {
+    const first = renameRoom(dialog);
+    assert.strictEqual(roomRenameIsSaving(dialog), true);
+    assert.strictEqual(dialog.attributes["aria-busy"], "true");
+    assert.ok(dialog.controls.every((control) => control.disabled));
+    assert.strictEqual(dialog.message.textContent, "Saving…");
+    assert.strictEqual(cancelRoomRenameDialog(), false);
+    assert.strictEqual(await renameRoom(dialog), false);
+    assert.strictEqual(requestCount, 1);
+
+    releaseRequest();
+    assert.strictEqual(await first, true);
+    assert.strictEqual(dialog.classList.contains("hidden"), true);
+    assert.strictEqual(roomRenameIsSaving(dialog), false);
+    assert.ok(dialog.controls.every((control) => !control.disabled));
+    assert.ok(errors.some((message) => message.includes("rename was saved")));
+    assert.strictEqual(reloadCount, 1);
+
+    dialog.classList.remove("hidden");
+    assert.strictEqual(cancelRoomRenameDialog(), true);
+    assert.strictEqual(dialog.classList.contains("hidden"), true);
+  } finally {
+    global.document = originalDocument;
+    global.fetch = originalFetch;
+    global.window = originalWindow;
+    console.error = originalConsoleError;
+  }
+}
+
+async function testRoomRenameErrorRecovery() {
+  const originalDocument = global.document;
+  const originalFetch = global.fetch;
+  const dialog = fakeRenameDialog("Duplicate");
+  global.document = {
+    getElementById(id) {
+      if (id === "room-rename-dialog") return dialog;
+      if (id === "room-rename-name") return dialog.input;
+      return null;
+    },
+  };
+  global.fetch = async () => ({
+    ok: false,
+    json: async () => ({ error: "Room name already exists" }),
+  });
+
+  try {
+    assert.strictEqual(await renameRoom(dialog), false);
+    assert.strictEqual(dialog.classList.contains("hidden"), false);
+    assert.strictEqual(roomRenameIsSaving(dialog), false);
+    assert.ok(dialog.controls.every((control) => !control.disabled));
+    assert.strictEqual(dialog.input.value, "Duplicate");
+    assert.strictEqual(dialog.input.focusCount, 1);
+    assert.strictEqual(dialog.message.textContent, "Room name already exists");
+  } finally {
+    global.document = originalDocument;
+    global.fetch = originalFetch;
+  }
+}
+
 testPersistenceTransitions()
+  .then(testRoomRenameCompletion)
+  .then(testRoomRenameErrorRecovery)
   .then(() => console.log("room_matrix tests passed"))
   .catch((error) => {
     console.error(error);

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -479,6 +479,7 @@ def test_index_device_names_expose_rename_popup_contract(
     assert 'data-action="reset-device-name"' in html
     assert 'data-action="rename-device"' in html
     assert 'data-action="cancel-device-rename"' in html
+    assert 'class="device-rename-message" data-role="message" aria-live="polite"' in html
 
 
 def test_temperature_chart_page_has_raw_calculated_mode_switch(

--- a/tests/test_unit_speed.js
+++ b/tests/test_unit_speed.js
@@ -12,9 +12,11 @@ const {
   autoSetTempRangeForDevice,
   compactAgeFromSeconds,
   clearPendingFanChange,
+  cancelDeviceRenamePopup,
   createSingleFlight,
   dashboardAirQualityDeviceIsActive,
   deviceDisplayNameChanged,
+  deviceRenameIsSaving,
   deviceLabelWithIcon,
   deviceDisplayNamePatchBody,
   deviceRulesEnabledValue,
@@ -48,6 +50,7 @@ const {
   setAutoSetTempUnavailable,
   setRangePartFromPointerTarget,
   sortedFcuTempSources,
+  submitDeviceDisplayName,
   tableUpdateSummaryText,
   updateSetTempForDevice,
   updateTemperatureCell,
@@ -1071,6 +1074,158 @@ check("rules-enabled false string parses", deviceRulesEnabledValue("false"), fal
 check("rules-enabled one parses", deviceRulesEnabledValue(1), true);
 check("rules-enabled zero parses", deviceRulesEnabledValue(0), false);
 
+function fakeDeviceRenamePopup(displayName = "East Lab") {
+  const message = { textContent: "" };
+  const renameButton = { disabled: false };
+  const inputs = {
+    "device-rename-device-name": { disabled: false, readOnly: true },
+    "device-rename-display-name": {
+      disabled: false,
+      focusCount: 0,
+      value: displayName,
+      focus() { this.focusCount++; },
+    },
+    "device-rename-device-type": { disabled: false, readOnly: true },
+    "device-rename-rules-enabled": { checked: true, disabled: true },
+    "device-rename-last-update": { disabled: false, readOnly: true },
+  };
+  const controls = [...Object.values(inputs), renameButton, { disabled: false }];
+  const popup = {
+    attributes: {},
+    classList: fakeClassList(),
+    controls,
+    dataset: {
+      currentDisplayName: "West Lab",
+      deviceId: "12",
+      deviceName: "FCU-12",
+      deviceType: "FCU",
+      rulesEnabled: "true",
+    },
+    inputs,
+    message,
+    querySelector(selector) {
+      if (selector === "[data-role='message']") return message;
+      if (selector === "[data-action='rename-device']") return renameButton;
+      return null;
+    },
+    querySelectorAll: () => controls,
+    removeAttribute(name) { delete this.attributes[name]; },
+    setAttribute(name, value) { this.attributes[name] = String(value); },
+  };
+  return popup;
+}
+
+function installDeviceRenameDocument(popup, renderFailure = false) {
+  return {
+    getElementById(id) {
+      if (id === "device-rename-popup") return popup;
+      return popup.inputs[id] || null;
+    },
+    querySelectorAll() {
+      if (renderFailure) throw new Error("simulated rendering failure");
+      return [];
+    },
+  };
+}
+
+async function testDeviceRenameCompletion() {
+  const originalDocument = global.document;
+  const originalFetch = global.fetch;
+  const originalConsoleError = console.error;
+  const popup = fakeDeviceRenamePopup();
+  const errors = [];
+  let releaseRequest;
+  let requestCount = 0;
+  global.document = installDeviceRenameDocument(popup, true);
+  global.fetch = async () => {
+    requestCount++;
+    await new Promise((resolve) => { releaseRequest = resolve; });
+    return {
+      ok: true,
+      json: async () => ({ display_name: "East Lab", device_type: "FCU" }),
+    };
+  };
+  console.error = (...args) => errors.push(args.join(" "));
+
+  try {
+    const first = submitDeviceDisplayName("East Lab");
+    check("device rename enters saving state", deviceRenameIsSaving(popup), true);
+    check("device rename marks dialog busy", popup.attributes["aria-busy"], "true");
+    check(
+      "device rename disables controls",
+      popup.controls.every((control) => control.disabled),
+      true,
+    );
+    check("device rename reports pending state", popup.message.textContent, "Saving…");
+    check("Escape cannot close pending device rename", cancelDeviceRenamePopup(), false);
+    check("duplicate device rename is ignored", await submitDeviceDisplayName("East Lab"), false);
+    check("device rename sends one request", requestCount, 1);
+
+    releaseRequest();
+    check("device rename succeeds", await first, true);
+    check("successful device rename closes popup", popup.classList.contains("hidden"), true);
+    check("successful device rename clears saving state", deviceRenameIsSaving(popup), false);
+    check(
+      "saved device rename distinguishes rendering failure",
+      errors.some((message) => message.includes("rename was saved")),
+      true,
+    );
+
+    popup.classList.remove("hidden");
+    check("Escape closes idle device rename", cancelDeviceRenamePopup(), true);
+    check("idle device rename is closed", popup.classList.contains("hidden"), true);
+  } finally {
+    global.document = originalDocument;
+    global.fetch = originalFetch;
+    console.error = originalConsoleError;
+  }
+}
+
+async function testDeviceRenameErrorRecovery() {
+  const originalDocument = global.document;
+  const originalFetch = global.fetch;
+  const originalConsoleError = console.error;
+  const popup = fakeDeviceRenamePopup("Duplicate");
+  global.document = installDeviceRenameDocument(popup);
+  global.fetch = async () => ({
+    ok: false,
+    status: 409,
+    statusText: "Conflict",
+    json: async () => ({ error: "Display name already exists" }),
+  });
+  console.error = () => {};
+
+  try {
+    check("failed device rename returns false", await submitDeviceDisplayName("Duplicate"), false);
+    check("failed device rename stays open", popup.classList.contains("hidden"), false);
+    check("failed device rename clears saving state", deviceRenameIsSaving(popup), false);
+    check(
+      "failed device rename restores editable input",
+      popup.inputs["device-rename-display-name"].disabled,
+      false,
+    );
+    check(
+      "failed device rename preserves entered name",
+      popup.inputs["device-rename-display-name"].value,
+      "Duplicate",
+    );
+    check(
+      "failed device rename restores focus",
+      popup.inputs["device-rename-display-name"].focusCount,
+      1,
+    );
+    check(
+      "failed device rename shows persistence error",
+      popup.message.textContent,
+      "409 Display name already exists",
+    );
+  } finally {
+    global.document = originalDocument;
+    global.fetch = originalFetch;
+    console.error = originalConsoleError;
+  }
+}
+
 const popupWithChangedSource = {
   querySelectorAll: () => [
     {
@@ -1361,6 +1516,8 @@ Promise.resolve()
   .then(testEnableRulesForDevicePost)
   .then(testFcuBatchSavePost)
   .then(testAutoSetTempSavePost)
+  .then(testDeviceRenameCompletion)
+  .then(testDeviceRenameErrorRecovery)
   .catch((error) => {
     failed++;
     console.error(error);


### PR DESCRIPTION
## Summary

- prevent duplicate Air Quality room-rename and Heating and Cooling FCU display-name PATCH requests
- disable and mark rename dialogs busy while persistence is pending
- close successful saves independently of later DOM presentation work
- preserve the entered value and restore controls after API errors
- make Escape, Cancel, and outside-click close idle dialogs without implying that an in-flight request was cancelled
- preserve the distinction between room names and FCU display names with a SQLite-backed contract test

## Root cause

Both rename paths coupled persistence completion to subsequent DOM updates. A presentation exception could therefore make a successful PATCH look unsuccessful or leave the room dialog open. The room path had no in-flight guard, and the FCU path disabled controls without an explicit guard against queued or programmatic duplicate submissions.

The revised flows use dialog-owned `saving` state. A confirmed PATCH is authoritative; local presentation is best-effort. A room presentation failure reloads persisted server state, while an FCU presentation failure forces the next normal status refresh.

## User impact

- one PATCH is sent per rename action, including under delayed responses
- successful saves close reliably
- failed saves remain editable and retryable with an inline error
- room renames affect only rooms, while FCU renames affect only device display names

## Validation

- `make test-js`
- focused Makefile pytest run: 74 passed
- `make check`
- `SKIP_BROWSER_TEST=1 make test`: 360 passed, 4 browser tests skipped; all JavaScript suites passed

An unskipped full run reached 359 passing tests before four existing Playwright tests failed because the Codex desktop sandbox denied Chromium's Mach port registration. No application assertion failed in those tests.

## Tracking

Refs #195 (`hvac-2xr`). The issue remains open pending maintainer review and human browser verification under network throttling.

No deployment is included in this PR.
