### PR TITLE
Add AE-200 and network performance monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,7 @@ test-js: $(REQ) ## Run the JavaScript unit tests
 	node tests/test_room_matrix.js
 	node tests/test_room_map.js
 	node tests/test_fcu_history_chart.js
+	node tests/test_performance_monitoring.js
 test: $(REQ) ## Run both Python and JavaScript test suites
 	@python_exit=0; js_exit=0; \
 	make pytest || python_exit=$$?; \
@@ -291,7 +292,7 @@ outdated: $(REQ) ## Report outdated Python and CDN dependencies
 ## Cron targets
 ## Here mostly for testing. The actual cron entries are:
 ##
-##  * * * * * cd /home/air/temperature-bot ; DB_PATH=/var/db/temperature-bot.db .venv/bin/python -m bin.runner --loglevel INFO >> /home/air/temperature-bot.log 2>&1
+##  * * * * * cd /home/air/temperature-bot ; DB_PATH=/var/db/temperature-bot.db TEMPERATURE_BOT_INSTANCE=production PERFORMANCE_CLIENT_ID=minute-runner .venv/bin/python -m bin.runner --loglevel INFO >> /home/air/temperature-bot.log 2>&1
 ##
 ##
 ## @daily    cd /home/air/temperature-bot ; sleep 15 ; DB_PATH=/var/db/temperature-bot.db .venv/bin/python -m bin.runner --loglevel INFO --daily  >> /home/air/temperature-bot-daily.log 2>&1
@@ -300,7 +301,10 @@ outdated: $(REQ) ## Report outdated Python and CDN dependencies
 ## Question - should we just have cron do a 'make daily' and 'make every-minute' ?
 
 every-minute: $(REQ) ## Run the per-minute data collection runner
-	$(PYTHON) -m bin.runner
+	PERFORMANCE_CLIENT_ID=minute-runner $(PYTHON) -m bin.runner
+
+performance-probe: $(REQ) ## Record one AE-200 DNS, ICMP, and TCP-reject probe
+	PERFORMANCE_CLIENT_ID=network-probe $(PYTHON) -m bin.performance_monitor --once
 
 daily: $(REQ) ## Run the daily data collection runner
 	$(PYTHON) -m bin.runner --daily
@@ -308,7 +312,7 @@ daily: $(REQ) ## Run the daily data collection runner
 monthly-backup: ## Back up the production database with a dated copy
 	sudo cp /var/db/temperature-bot.db /var/db/temperature-bot.backup.$$(date -I).db
 
-.PHONY: every-minute daily monthly-backup
+.PHONY: every-minute performance-probe daily monthly-backup
 
 ################################################################
 ## Installation targets

--- a/app/ae200.py
+++ b/app/ae200.py
@@ -22,6 +22,7 @@ import xml.etree.ElementTree as ET
 import logging
 import json
 import threading
+import time
 
 import concurrent.futures
 import websockets
@@ -29,6 +30,7 @@ from websockets.extensions import permessage_deflate
 from websockets.typing import Origin, Subprotocol
 
 from app.util import env_flag_enabled, get_config
+from app import performance_monitoring
 
 logger = logging.getLogger(__name__)
 B_XMLPROC_SUBPROTOCOL = Subprotocol("b_xmlproc")
@@ -214,15 +216,30 @@ class AsyncRunner:  # pylint: disable=too-few-public-methods
     def __init__(self):
         self._command_semaphore = threading.BoundedSemaphore(value=1)
 
-    def run_async_safely(self, coro):
+    def run_async_safely(self, coro, *, sample=None):
         """Run an async coroutine safely, handling existing event loops"""
+        started_ns = time.perf_counter_ns()
         try:
             with self._command_semaphore:
                 with ae200_command_lock():
-                    return self._run_async_safely(coro)
-        except Exception:
+                    if sample is not None:
+                        sample.lock_wait_ms = performance_monitoring.elapsed_ms(
+                            started_ns
+                        )
+                    result = self._run_async_safely(coro)
+            if sample is not None:
+                sample.success = True
+                sample.outcome = "ok"
+            return result
+        except Exception as error:
             coro.close()
+            if sample is not None:
+                sample.mark_error(error)
             raise
+        finally:
+            if sample is not None:
+                sample.total_ms = performance_monitoring.elapsed_ms(started_ns)
+                performance_monitoring.record_sample_best_effort(sample)
 
     @staticmethod
     def _run_async_safely(coro):
@@ -267,75 +284,118 @@ class AE200Functions:
             address = get_config()["ae200"]["host"]
         self.address = address
 
-    async def getDevicesAsync(self):
-        if AE200_SIMULATOR:
-            raise RuntimeError("AE200_SIMULATOR not compatiable with AE200Functions")
+    async def _exchange(self, payload, sample, *, receive):
+        """Send one XML payload while timing WebSocket phases."""
+        connect_started_ns = time.perf_counter_ns()
         async with websockets.connect(
             f"ws://{self.address}/b_xmlproc/",
             extensions=[permessage_deflate.ClientPerMessageDeflateFactory()],
             origin=Origin(f"http://{self.address}"),
             subprotocols=[B_XMLPROC_SUBPROTOCOL],
         ) as websocket:
-            await websocket.send(getUnitsPayload)
-            unitsResultStr = await websocket.recv()
-            unitsResultXML = ET.fromstring(unitsResultStr)
-
-            groupList = []
-            for r in unitsResultXML.findall(
-                "./DatabaseManager/ControlGroup/MnetList/MnetRecord"
-            ):
-                # print( ET.tostring(r) )
-                groupList.append({"id": r.get("Group"), "name": r.get("GroupNameWeb")})
+            if sample is not None:
+                sample.connect_ms = performance_monitoring.elapsed_ms(
+                    connect_started_ns
+                )
+            response_started_ns = time.perf_counter_ns()
+            await websocket.send(payload)
+            response = await websocket.recv() if receive else None
+            if sample is not None:
+                sample.response_ms = performance_monitoring.elapsed_ms(
+                    response_started_ns
+                )
+                if response is not None:
+                    sample.response_bytes = len(
+                        response.encode("utf-8")
+                        if isinstance(response, str)
+                        else response
+                    )
+            close_started_ns = time.perf_counter_ns()
             await websocket.close()
-            return groupList
+            if sample is not None:
+                sample.close_ms = performance_monitoring.elapsed_ms(close_started_ns)
+            return response
+
+    async def getDevicesAsync(self, sample=None):
+        if AE200_SIMULATOR:
+            raise RuntimeError("AE200_SIMULATOR not compatiable with AE200Functions")
+        unitsResultStr = await self._exchange(
+            getUnitsPayload, sample, receive=True
+        )
+        unitsResultXML = ET.fromstring(unitsResultStr)
+
+        groupList = []
+        for r in unitsResultXML.findall(
+            "./DatabaseManager/ControlGroup/MnetList/MnetRecord"
+        ):
+            # print( ET.tostring(r) )
+            groupList.append({"id": r.get("Group"), "name": r.get("GroupNameWeb")})
+        return groupList
 
     def getDevices(self):
-        return runner.run_async_safely(self.getDevicesAsync())
+        sample = (
+            None
+            if AE200_SIMULATOR
+            else performance_monitoring.new_ae200_sample(
+                performance_monitoring.OPERATION_GET_DEVICES, self.address
+            )
+        )
+        return runner.run_async_safely(
+            self.getDevicesAsync(sample), sample=sample
+        )
 
-    async def getDeviceInfoAsync(self, deviceId, clean=True):
+    async def getDeviceInfoAsync(self, deviceId, clean=True, sample=None):
         """:param deviceId: The numeric ID of the device to get
         :param clean: if True (default), then remove keys with empty values.
         """
         if AE200_SIMULATOR:
             raise RuntimeError("AE200_SIMULATOR not compatiable with AE200Functions")
-        async with websockets.connect(
-            f"ws://{self.address}/b_xmlproc/",
-            extensions=[permessage_deflate.ClientPerMessageDeflateFactory()],
-            origin=Origin(f"http://{self.address}"),
-            subprotocols=[B_XMLPROC_SUBPROTOCOL],
-        ) as websocket:
-            getMnetDetailsPayload = getMnetDetails([deviceId])
-            await websocket.send(getMnetDetailsPayload)
-            mnetDetailsResultStr = await websocket.recv()
-            mnetDetailsResultXML = ET.fromstring(mnetDetailsResultStr)
+        getMnetDetailsPayload = getMnetDetails([deviceId])
+        mnetDetailsResultStr = await self._exchange(
+            getMnetDetailsPayload, sample, receive=True
+        )
+        mnetDetailsResultXML = ET.fromstring(mnetDetailsResultStr)
 
-            # result = {}
-            node = mnetDetailsResultXML.find("./DatabaseManager/Mnet")
-            await websocket.close()
-            if node is None:
-                raise ValueError(f"AE-200 response omitted Mnet data for device {deviceId}")
-            return cleanDeviceInfo(node.attrib) if clean else node.attrib
+        # result = {}
+        node = mnetDetailsResultXML.find("./DatabaseManager/Mnet")
+        if node is None:
+            raise ValueError(f"AE-200 response omitted Mnet data for device {deviceId}")
+        return cleanDeviceInfo(node.attrib) if clean else node.attrib
 
     def getDeviceInfo(self, deviceId, clean=True):
-        return runner.run_async_safely(self.getDeviceInfoAsync(deviceId, clean=clean))
+        sample = (
+            None
+            if AE200_SIMULATOR
+            else performance_monitoring.new_ae200_sample(
+                performance_monitoring.OPERATION_GET_DEVICE_INFO,
+                self.address,
+                deviceId,
+            )
+        )
+        return runner.run_async_safely(
+            self.getDeviceInfoAsync(deviceId, clean=clean, sample=sample),
+            sample=sample,
+        )
 
-    async def sendAsync(self, deviceId, attributes):
+    async def sendAsync(self, deviceId, attributes, sample=None):
         assert "PYTEST" not in os.environ
         if AE200_SIMULATOR:
             raise RuntimeError("AE200_SIMULATOR not compatiable with AE200Functions")
-        async with websockets.connect(
-            f"ws://{self.address}/b_xmlproc/",
-            extensions=[permessage_deflate.ClientPerMessageDeflateFactory()],
-            origin=Origin(f"http://{self.address}"),
-            subprotocols=[B_XMLPROC_SUBPROTOCOL],
-        ) as websocket:
-            attrs = " ".join([f'{key}="{attributes[key]}"' for key in attributes])
-            payload = setRequestPayload.format(deviceId=deviceId, attrs=attrs)
-            await websocket.send(payload)
-            await websocket.close()
+        attrs = " ".join([f'{key}="{attributes[key]}"' for key in attributes])
+        payload = setRequestPayload.format(deviceId=deviceId, attrs=attrs)
+        await self._exchange(payload, sample, receive=False)
 
     def send(self, deviceId, attributes):
-        return runner.run_async_safely(self.sendAsync(deviceId, attributes))
+        sample = (
+            None
+            if AE200_SIMULATOR
+            else performance_monitoring.new_ae200_sample(
+                performance_monitoring.OPERATION_SET, self.address, deviceId
+            )
+        )
+        return runner.run_async_safely(
+            self.sendAsync(deviceId, attributes, sample=sample), sample=sample
+        )
 
 
 ################################################################

--- a/app/ae200.py
+++ b/app/ae200.py
@@ -318,7 +318,7 @@ class AE200Functions:
 
     async def getDevicesAsync(self, sample=None):
         if AE200_SIMULATOR:
-            raise RuntimeError("AE200_SIMULATOR not compatiable with AE200Functions")
+            raise RuntimeError("AE200_SIMULATOR not compatible with AE200Functions")
         unitsResultStr = await self._exchange(
             getUnitsPayload, sample, receive=True
         )
@@ -349,7 +349,7 @@ class AE200Functions:
         :param clean: if True (default), then remove keys with empty values.
         """
         if AE200_SIMULATOR:
-            raise RuntimeError("AE200_SIMULATOR not compatiable with AE200Functions")
+            raise RuntimeError("AE200_SIMULATOR not compatible with AE200Functions")
         getMnetDetailsPayload = getMnetDetails([deviceId])
         mnetDetailsResultStr = await self._exchange(
             getMnetDetailsPayload, sample, receive=True
@@ -380,7 +380,7 @@ class AE200Functions:
     async def sendAsync(self, deviceId, attributes, sample=None):
         assert "PYTEST" not in os.environ
         if AE200_SIMULATOR:
-            raise RuntimeError("AE200_SIMULATOR not compatiable with AE200Functions")
+            raise RuntimeError("AE200_SIMULATOR not compatible with AE200Functions")
         attrs = " ".join([f'{key}="{attributes[key]}"' for key in attributes])
         payload = setRequestPayload.format(deviceId=deviceId, attrs=attrs)
         await self._exchange(payload, sample, receive=False)

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from . import ae200
 from . import db
 from . import routes_api
 from . import routes_web
+from .performance_routes import performance_routes
 from .models import ApplicationMetadata, json_ready
 from .version import __version__, git_branch, git_sha
 
@@ -104,6 +105,7 @@ def create_app():
 
     # Register blueprints
     app.register_blueprint(routes_api.api_v1, url_prefix="/api/v1")
+    app.register_blueprint(performance_routes)
 
     # Register web routes
     routes_web.create_web_routes(app)

--- a/app/performance_monitoring.py
+++ b/app/performance_monitoring.py
@@ -1,0 +1,391 @@
+"""Persist and query AE-200 and network performance samples."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+import re
+import socket
+import sqlite3
+import statistics
+import subprocess
+import sys
+import time
+
+from pydantic import BaseModel, Field
+
+from .constants import DB_PATH, TEST_DB_NAME
+
+logger = logging.getLogger(__name__)
+
+PERFORMANCE_TABLE = "performance_samples"
+PERFORMANCE_INSTANCE_ENV = "TEMPERATURE_BOT_INSTANCE"
+PERFORMANCE_CLIENT_ENV = "PERFORMANCE_CLIENT_ID"
+PERFORMANCE_EXPERIMENT_ENV = "PERFORMANCE_EXPERIMENT_ID"
+PERFORMANCE_RETENTION_DAYS_ENV = "PERFORMANCE_RETENTION_DAYS"
+AE200_REJECT_PORT_ENV = "AE200_REJECT_PORT"
+
+SAMPLE_TYPE_AE200 = "ae200_request"
+SAMPLE_TYPE_DNS = "dns"
+SAMPLE_TYPE_ICMP = "icmp_ping"
+SAMPLE_TYPE_TCP_REJECT = "tcp_reject"
+
+OPERATION_GET_DEVICES = "get_devices"
+OPERATION_GET_DEVICE_INFO = "get_device_info"
+OPERATION_SET = "set"
+OPERATION_RESOLVE = "resolve"
+OPERATION_ECHO = "echo"
+OPERATION_REJECT = "reject"
+
+DEFAULT_REJECT_PORT = 1
+DEFAULT_RETENTION_DAYS = 90
+DEFAULT_QUERY_LIMIT = 50_000
+MAX_QUERY_LIMIT = 100_000
+MAX_ERROR_MESSAGE_LENGTH = 500
+AE200_WEBSOCKET_PORT = 80
+
+PING_TIME_RE = re.compile(r"\btime[=<]([0-9]+(?:\.[0-9]+)?)\s*ms\b")
+PACKET_LOSS_RE = re.compile(r"([0-9]+(?:\.[0-9]+)?)%\s+packet loss")
+
+
+def _default_instance_id() -> str:
+    return os.getenv(PERFORMANCE_INSTANCE_ENV) or socket.gethostname()
+
+
+def _default_client_id() -> str:
+    configured = os.getenv(PERFORMANCE_CLIENT_ENV)
+    if configured:
+        return configured
+    return Path(sys.argv[0]).stem or "unknown"
+
+
+def _default_experiment_id() -> str | None:
+    return os.getenv(PERFORMANCE_EXPERIMENT_ENV) or None
+
+
+def elapsed_ms(start_ns: int) -> float:
+    """Return milliseconds elapsed since a monotonic nanosecond timestamp."""
+    return (time.perf_counter_ns() - start_ns) / 1_000_000
+
+
+class PerformanceSample(BaseModel):  # pylint: disable=too-many-instance-attributes
+    """One application or network performance observation."""
+
+    observed_at_ms: int = Field(default_factory=lambda: time.time_ns() // 1_000_000)
+    instance_id: str = Field(default_factory=_default_instance_id)
+    client_id: str = Field(default_factory=_default_client_id)
+    sample_type: str
+    operation: str
+    target_host: str
+    target_port: int | None = None
+    resolved_ip: str | None = None
+    ae200_device_id: str | None = None
+    dns_ms: float | None = None
+    icmp_min_ms: float | None = None
+    icmp_median_ms: float | None = None
+    icmp_max_ms: float | None = None
+    packet_loss_pct: float | None = None
+    lock_wait_ms: float | None = None
+    connect_ms: float | None = None
+    response_ms: float | None = None
+    close_ms: float | None = None
+    total_ms: float = 0
+    success: bool = False
+    outcome: str = "pending"
+    error_type: str | None = None
+    error_message: str | None = None
+    response_bytes: int | None = None
+    experiment_id: str | None = Field(default_factory=_default_experiment_id)
+
+    def mark_error(self, error: BaseException) -> None:
+        """Attach a normalized error without changing the original exception."""
+        self.success = False
+        self.outcome = "error"
+        self.error_type = type(error).__name__
+        self.error_message = str(error)[:MAX_ERROR_MESSAGE_LENGTH]
+
+
+class PingSummary(BaseModel):
+    """Parsed aggregate values from the system ping command."""
+
+    minimum_ms: float | None = None
+    median_ms: float | None = None
+    maximum_ms: float | None = None
+    packet_loss_pct: float
+    replies: int
+
+
+class PerformanceQuery(BaseModel):
+    """Validated filters for the performance sample API."""
+
+    start_ms: int
+    end_ms: int
+    instance_id: str | None = None
+    client_id: str | None = None
+    sample_type: str | None = None
+    operation: str | None = None
+    limit: int = Field(default=DEFAULT_QUERY_LIMIT, ge=1, le=MAX_QUERY_LIMIT)
+
+
+class PerformanceSamplePage(BaseModel):
+    """Bounded performance query response with truncation state."""
+
+    samples: list[PerformanceSample]
+    truncated: bool
+
+
+def configured_database_path() -> str | None:
+    """Return the test or runtime SQLite path, if configured."""
+    return os.getenv(TEST_DB_NAME) or os.getenv(DB_PATH)
+
+
+def new_ae200_sample(
+    operation: str, target_host: str, ae200_device_id: object | None = None
+) -> PerformanceSample:
+    """Build a request sample with common AE-200 fields."""
+    return PerformanceSample(
+        sample_type=SAMPLE_TYPE_AE200,
+        operation=operation,
+        target_host=target_host,
+        target_port=AE200_WEBSOCKET_PORT,
+        ae200_device_id=(
+            None if ae200_device_id is None else str(ae200_device_id)
+        ),
+    )
+
+
+def insert_sample(conn: sqlite3.Connection, sample: PerformanceSample) -> int:
+    """Insert one sample with the caller's SQLite connection."""
+    fields = sample.model_dump()
+    columns = tuple(fields)
+    placeholders = ", ".join("?" for _column in columns)
+    cursor = conn.execute(
+        f"INSERT INTO {PERFORMANCE_TABLE} ({', '.join(columns)}) "
+        f"VALUES ({placeholders})",
+        tuple(fields[column] for column in columns),
+    )
+    if cursor.lastrowid is None:
+        raise sqlite3.DatabaseError("performance sample insert returned no row id")
+    return cursor.lastrowid
+
+
+def record_sample(sample: PerformanceSample, db_path: str | None = None) -> int:
+    """Persist one sample in a short independent transaction."""
+    path = db_path or configured_database_path()
+    if not path:
+        raise RuntimeError(f"{DB_PATH} is not configured")
+    with sqlite3.connect(path, timeout=2) as conn:
+        sample_id = insert_sample(conn, sample)
+        conn.commit()
+        return sample_id
+
+
+def record_sample_best_effort(sample: PerformanceSample) -> None:
+    """Record instrumentation without affecting the instrumented operation."""
+    try:
+        record_sample(sample)
+    except (OSError, RuntimeError, sqlite3.Error) as error:
+        logger.warning(
+            "Could not record %s performance sample: %s",
+            sample.sample_type,
+            error,
+        )
+
+
+def fetch_sample_page(
+    conn: sqlite3.Connection, query: PerformanceQuery
+) -> PerformanceSamplePage:
+    """Return ordered samples and whether the bounded query was truncated."""
+    clauses = ["observed_at_ms >= ?", "observed_at_ms <= ?"]
+    values: list[object] = [query.start_ms, query.end_ms]
+    for column in ("instance_id", "client_id", "sample_type", "operation"):
+        value = getattr(query, column)
+        if value is not None:
+            clauses.append(f"{column} = ?")
+            values.append(value)
+    values.append(query.limit + 1)
+    rows = conn.execute(
+        f"SELECT * FROM {PERFORMANCE_TABLE} "
+        f"WHERE {' AND '.join(clauses)} "
+        "ORDER BY observed_at_ms, sample_id LIMIT ?",
+        values,
+    ).fetchall()
+    samples = [
+        PerformanceSample.model_validate(
+            {key: row[key] for key in row.keys() if key != "sample_id"}
+        )
+        for row in rows[: query.limit]
+    ]
+    return PerformanceSamplePage(samples=samples, truncated=len(rows) > query.limit)
+
+
+def fetch_samples(
+    conn: sqlite3.Connection, query: PerformanceQuery
+) -> list[PerformanceSample]:
+    """Return the sample rows from a bounded query."""
+    return fetch_sample_page(conn, query).samples
+
+
+def delete_expired_samples(
+    conn: sqlite3.Connection,
+    *,
+    now_ms: int | None = None,
+    retention_days: int | None = None,
+) -> int:
+    """Delete raw samples older than the configured retention period."""
+    days = retention_days
+    if days is None:
+        days = int(
+            os.getenv(
+                PERFORMANCE_RETENTION_DAYS_ENV, str(DEFAULT_RETENTION_DAYS)
+            )
+        )
+    if days < 1:
+        raise ValueError("performance retention must be at least one day")
+    current_ms = time.time_ns() // 1_000_000 if now_ms is None else now_ms
+    cutoff_ms = current_ms - days * 24 * 60 * 60 * 1000
+    cursor = conn.execute(
+        f"DELETE FROM {PERFORMANCE_TABLE} WHERE observed_at_ms < ?", (cutoff_ms,)
+    )
+    return cursor.rowcount
+
+
+def parse_ping_output(output: str) -> PingSummary:
+    """Parse Linux or macOS ping output without relying on summary wording."""
+    values = [float(value) for value in PING_TIME_RE.findall(output)]
+    loss_match = PACKET_LOSS_RE.search(output)
+    if loss_match is None:
+        raise ValueError("ping output did not include packet loss")
+    return PingSummary(
+        minimum_ms=min(values) if values else None,
+        median_ms=statistics.median(values) if values else None,
+        maximum_ms=max(values) if values else None,
+        packet_loss_pct=float(loss_match.group(1)),
+        replies=len(values),
+    )
+
+
+def resolve_target(host: str) -> tuple[str, float]:
+    """Resolve a target and return the first stream-capable address and time."""
+    started_ns = time.perf_counter_ns()
+    addresses = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    dns_ms = elapsed_ms(started_ns)
+    if not addresses:
+        raise OSError(f"DNS returned no addresses for {host}")
+    return str(addresses[0][4][0]), dns_ms
+
+
+def run_ping(host: str, count: int = 3, timeout_seconds: float = 10) -> tuple[PingSummary, float]:
+    """Run the platform ping command and return its parsed output and duration."""
+    started_ns = time.perf_counter_ns()
+    completed = subprocess.run(
+        ["ping", "-n", "-c", str(count), host],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=timeout_seconds,
+    )
+    total_ms = elapsed_ms(started_ns)
+    output = "\n".join((completed.stdout, completed.stderr))
+    summary = parse_ping_output(output)
+    return summary, total_ms
+
+
+def probe_tcp_reject(
+    host: str,
+    port: int,
+    *,
+    resolved_ip: str | None = None,
+    timeout_seconds: float = 3,
+) -> PerformanceSample:
+    """Measure a TCP connection attempt to a port expected to reject it."""
+    sample = PerformanceSample(
+        sample_type=SAMPLE_TYPE_TCP_REJECT,
+        operation=OPERATION_REJECT,
+        target_host=host,
+        target_port=port,
+        resolved_ip=resolved_ip,
+    )
+    started_ns = time.perf_counter_ns()
+    try:
+        with socket.create_connection(
+            (resolved_ip or host, port), timeout=timeout_seconds
+        ):
+            sample.connect_ms = elapsed_ms(started_ns)
+            sample.success = True
+            sample.outcome = "connected"
+    except ConnectionRefusedError:
+        sample.connect_ms = elapsed_ms(started_ns)
+        sample.success = True
+        sample.outcome = "refused"
+    except OSError as error:
+        sample.connect_ms = elapsed_ms(started_ns)
+        sample.mark_error(error)
+    sample.total_ms = elapsed_ms(started_ns)
+    return sample
+
+
+def collect_network_samples(
+    host: str,
+    *,
+    reject_port: int = DEFAULT_REJECT_PORT,
+    ping_count: int = 3,
+) -> list[PerformanceSample]:
+    """Collect DNS, ICMP, and TCP-reject samples for one target."""
+    samples: list[PerformanceSample] = []
+    resolved_ip: str | None = None
+    dns_sample = PerformanceSample(
+        sample_type=SAMPLE_TYPE_DNS,
+        operation=OPERATION_RESOLVE,
+        target_host=host,
+    )
+    dns_started_ns = time.perf_counter_ns()
+    try:
+        resolved_ip, dns_sample.dns_ms = resolve_target(host)
+        dns_sample.resolved_ip = resolved_ip
+        dns_sample.success = True
+        dns_sample.outcome = "resolved"
+    except OSError as error:
+        dns_sample.mark_error(error)
+    dns_sample.total_ms = elapsed_ms(dns_started_ns)
+    samples.append(dns_sample)
+
+    ping_sample = PerformanceSample(
+        sample_type=SAMPLE_TYPE_ICMP,
+        operation=OPERATION_ECHO,
+        target_host=host,
+        resolved_ip=resolved_ip,
+    )
+    ping_started_ns = time.perf_counter_ns()
+    try:
+        ping, ping_sample.total_ms = run_ping(
+            resolved_ip or host, count=ping_count
+        )
+        ping_sample.icmp_min_ms = ping.minimum_ms
+        ping_sample.icmp_median_ms = ping.median_ms
+        ping_sample.icmp_max_ms = ping.maximum_ms
+        ping_sample.packet_loss_pct = ping.packet_loss_pct
+        ping_sample.success = ping.replies > 0
+        ping_sample.outcome = "reply" if ping.replies > 0 else "no_reply"
+    except (OSError, subprocess.SubprocessError, ValueError) as error:
+        ping_sample.total_ms = elapsed_ms(ping_started_ns)
+        ping_sample.mark_error(error)
+    samples.append(ping_sample)
+
+    samples.append(
+        probe_tcp_reject(host, reject_port, resolved_ip=resolved_ip)
+        if resolved_ip is not None
+        else PerformanceSample(
+            sample_type=SAMPLE_TYPE_TCP_REJECT,
+            operation=OPERATION_REJECT,
+            target_host=host,
+            target_port=reject_port,
+            total_ms=0,
+            success=False,
+            outcome="dns_failed",
+            error_type="DNSFailure",
+            error_message="TCP probe skipped because DNS resolution failed",
+        )
+    )
+    return samples

--- a/app/performance_monitoring.py
+++ b/app/performance_monitoring.py
@@ -44,6 +44,7 @@ DEFAULT_QUERY_LIMIT = 50_000
 MAX_QUERY_LIMIT = 100_000
 MAX_ERROR_MESSAGE_LENGTH = 500
 AE200_WEBSOCKET_PORT = 80
+BEST_EFFORT_SQLITE_TIMEOUT_SECONDS = 0
 
 PING_TIME_RE = re.compile(r"\btime[=<]([0-9]+(?:\.[0-9]+)?)\s*ms\b")
 PACKET_LOSS_RE = re.compile(r"([0-9]+(?:\.[0-9]+)?)%\s+packet loss")
@@ -170,12 +171,17 @@ def insert_sample(conn: sqlite3.Connection, sample: PerformanceSample) -> int:
     return cursor.lastrowid
 
 
-def record_sample(sample: PerformanceSample, db_path: str | None = None) -> int:
+def record_sample(
+    sample: PerformanceSample,
+    db_path: str | None = None,
+    *,
+    timeout_seconds: float = 2,
+) -> int:
     """Persist one sample in a short independent transaction."""
     path = db_path or configured_database_path()
     if not path:
         raise RuntimeError(f"{DB_PATH} is not configured")
-    with sqlite3.connect(path, timeout=2) as conn:
+    with sqlite3.connect(path, timeout=timeout_seconds) as conn:
         sample_id = insert_sample(conn, sample)
         conn.commit()
         return sample_id
@@ -184,7 +190,9 @@ def record_sample(sample: PerformanceSample, db_path: str | None = None) -> int:
 def record_sample_best_effort(sample: PerformanceSample) -> None:
     """Record instrumentation without affecting the instrumented operation."""
     try:
-        record_sample(sample)
+        record_sample(
+            sample, timeout_seconds=BEST_EFFORT_SQLITE_TIMEOUT_SECONDS
+        )
     except (OSError, RuntimeError, sqlite3.Error) as error:
         logger.warning(
             "Could not record %s performance sample: %s",
@@ -266,14 +274,24 @@ def parse_ping_output(output: str) -> PingSummary:
     )
 
 
+def preferred_stream_address(addresses: list[tuple]) -> str:
+    """Prefer IPv4 so the resolved literal works with macOS `ping`."""
+    if not addresses:
+        raise OSError("DNS returned no addresses")
+    for address in addresses:
+        if address[0] == socket.AF_INET:
+            return str(address[4][0])
+    return str(addresses[0][4][0])
+
+
 def resolve_target(host: str) -> tuple[str, float]:
-    """Resolve a target and return the first stream-capable address and time."""
+    """Resolve a target, preferring IPv4, and return its lookup time."""
     started_ns = time.perf_counter_ns()
     addresses = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
     dns_ms = elapsed_ms(started_ns)
     if not addresses:
         raise OSError(f"DNS returned no addresses for {host}")
-    return str(addresses[0][4][0]), dns_ms
+    return preferred_stream_address(addresses), dns_ms
 
 
 def run_ping(host: str, count: int = 3, timeout_seconds: float = 10) -> tuple[PingSummary, float]:

--- a/app/performance_routes.py
+++ b/app/performance_routes.py
@@ -1,0 +1,58 @@
+"""Web and JSON routes for integration performance monitoring."""
+
+import time
+
+from flask import Blueprint, jsonify, render_template, request
+from pydantic import ValidationError
+
+from . import performance_monitoring
+from .utils.db_utils import with_db_connection
+
+performance_routes = Blueprint("performance_monitoring", __name__)
+
+
+def _integer_query_arg(name: str, default: int) -> int:
+    raw_value = request.args.get(name)
+    return default if raw_value is None else int(raw_value)
+
+
+@performance_routes.get("/performance-monitoring")
+def performance_page():
+    """Render the integration and network performance chart."""
+    return render_template(
+        "performance-monitoring.html", current_page="performance-monitoring"
+    )
+
+
+@performance_routes.get("/api/v1/performance_samples")
+@with_db_connection
+def performance_samples(conn):
+    """Return a bounded time range of typed performance samples."""
+    now_ms = time.time_ns() // 1_000_000
+    try:
+        query = performance_monitoring.PerformanceQuery(
+            start_ms=_integer_query_arg(
+                "start_ms", now_ms - 24 * 60 * 60 * 1000
+            ),
+            end_ms=_integer_query_arg("end_ms", now_ms),
+            instance_id=request.args.get("instance_id") or None,
+            client_id=request.args.get("client_id") or None,
+            sample_type=request.args.get("sample_type") or None,
+            operation=request.args.get("operation") or None,
+            limit=_integer_query_arg(
+                "limit", performance_monitoring.DEFAULT_QUERY_LIMIT
+            ),
+        )
+    except (ValidationError, ValueError) as error:
+        details = (
+            error.errors(include_context=False)
+            if isinstance(error, ValidationError)
+            else [{"msg": str(error)}]
+        )
+        return jsonify(
+            {"error": "validation error", "details": details}
+        ), 400
+    if query.end_ms < query.start_ms:
+        return jsonify({"error": "end_ms must not precede start_ms"}), 400
+    page = performance_monitoring.fetch_sample_page(conn, query)
+    return jsonify(page.model_dump(mode="json"))

--- a/app/static/performance_monitoring.js
+++ b/app/static/performance_monitoring.js
@@ -1,0 +1,220 @@
+// AE-200 and independent network performance chart.
+
+let performanceChart = null;
+let performanceSamples = [];
+let performanceStartMs = null;
+let performanceEndMs = null;
+let performanceTruncated = false;
+
+const PERFORMANCE_ENDPOINT = "/api/v1/performance_samples";
+const FILTER_COLUMNS = {
+  "performance-instance": "instance_id",
+  "performance-client": "client_id",
+  "performance-type": "sample_type",
+  "performance-operation": "operation",
+};
+
+function localDateValue(milliseconds) {
+  const date = new Date(milliseconds);
+  const offset = date.getTimezoneOffset() * 60 * 1000;
+  return new Date(milliseconds - offset).toISOString().slice(0, 10);
+}
+
+function updateDateInputs() {
+  document.getElementById("performance-start").value =
+    localDateValue(performanceStartMs);
+  document.getElementById("performance-end").value =
+    localDateValue(performanceEndMs);
+}
+
+function setRange(days) {
+  performanceEndMs = Date.now();
+  performanceStartMs = performanceEndMs - days * 24 * 60 * 60 * 1000;
+  updateDateInputs();
+  loadPerformanceSamples();
+}
+
+function selectedFilters() {
+  return Object.fromEntries(
+    Object.entries(FILTER_COLUMNS).map(([elementId, column]) => [
+      column,
+      document.getElementById(elementId).value,
+    ]),
+  );
+}
+
+function filteredSamples() {
+  const filters = selectedFilters();
+  return performanceSamples.filter((sample) =>
+    Object.entries(filters).every(
+      ([column, value]) => !value || sample[column] === value,
+    ),
+  );
+}
+
+function fillFilter(elementId, column) {
+  const select = document.getElementById(elementId);
+  const selected = select.value;
+  const values = [...new Set(performanceSamples.map((row) => row[column]))]
+    .filter(Boolean)
+    .sort();
+  select.replaceChildren(new Option("all", ""));
+  values.forEach((value) => select.add(new Option(value, value)));
+  if (values.includes(selected)) select.value = selected;
+}
+
+function refreshFilters() {
+  Object.entries(FILTER_COLUMNS).forEach(([elementId, column]) =>
+    fillFilter(elementId, column),
+  );
+}
+
+function points(samples, predicate, column) {
+  return samples
+    .filter((sample) => predicate(sample) && sample[column] !== null)
+    .map((sample) => [sample.observed_at_ms, sample[column]]);
+}
+
+function percentile(values, fraction) {
+  if (!values.length) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const position = (sorted.length - 1) * fraction;
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  if (lower === upper) return sorted[lower];
+  return (
+    sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower)
+  );
+}
+
+function rollingPercentile(samples, column, fraction, windowSize = 60) {
+  const numeric = samples
+    .filter((sample) => Number.isFinite(sample[column]))
+    .sort((left, right) => left.observed_at_ms - right.observed_at_ms);
+  return numeric.map((sample, index) => {
+    const start = Math.max(0, index - windowSize + 1);
+    const values = numeric.slice(start, index + 1).map((row) => row[column]);
+    return [sample.observed_at_ms, percentile(values, fraction)];
+  });
+}
+
+function series(name, data) {
+  return {
+    name,
+    type: "line",
+    showSymbol: data.length < 200,
+    connectNulls: false,
+    data,
+  };
+}
+
+function renderPerformanceChart() {
+  if (!performanceChart) return;
+  const samples = filteredSamples();
+  const ae200 = (sample) => sample.sample_type === "ae200_request";
+  const icmp = (sample) => sample.sample_type === "icmp_ping";
+  const tcp = (sample) => sample.sample_type === "tcp_reject";
+  const failures = samples.filter((sample) => !sample.success).length;
+  const accepted = samples.filter(
+    (sample) => sample.sample_type === "tcp_reject" && sample.outcome === "connected",
+  ).length;
+  document.getElementById("performance-summary").textContent =
+    `${samples.length} samples; ${failures} failures; ` +
+    `${accepted} unexpected accepted TCP connections` +
+    `${performanceTruncated ? "; result limit reached." : "."}`;
+
+  const ae200Samples = samples.filter(ae200);
+
+  performanceChart.setOption(
+    {
+      tooltip: { trigger: "axis" },
+      legend: { top: 0 },
+      grid: { top: 80, left: 75, right: 30, bottom: 80 },
+      xAxis: { type: "time" },
+      yAxis: { type: "value", name: "milliseconds", min: 0 },
+      dataZoom: [{ type: "inside" }, { type: "slider" }],
+      series: [
+        series("AE-200 total", points(samples, ae200, "total_ms")),
+        series(
+          "AE-200 total p50 (60 samples)",
+          rollingPercentile(ae200Samples, "total_ms", 0.5),
+        ),
+        series(
+          "AE-200 total p95 (60 samples)",
+          rollingPercentile(ae200Samples, "total_ms", 0.95),
+        ),
+        series("AE-200 lock wait", points(samples, ae200, "lock_wait_ms")),
+        series("WebSocket connect", points(samples, ae200, "connect_ms")),
+        series("AE-200 response", points(samples, ae200, "response_ms")),
+        series("ICMP median", points(samples, icmp, "icmp_median_ms")),
+        series("TCP reject", points(samples, tcp, "connect_ms")),
+      ],
+    },
+    { notMerge: true },
+  );
+}
+
+function loadPerformanceSamples() {
+  const query = new URLSearchParams({
+    start_ms: Math.floor(performanceStartMs),
+    end_ms: Math.floor(performanceEndMs),
+  });
+  fetch(`${PERFORMANCE_ENDPOINT}?${query}`)
+    .then((response) => {
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return response.json();
+    })
+    .then((page) => {
+      performanceSamples = page.samples;
+      performanceTruncated = page.truncated;
+      refreshFilters();
+      renderPerformanceChart();
+    })
+    .catch((error) => {
+      document.getElementById("performance-summary").textContent =
+        `Unable to load performance samples: ${error}`;
+    });
+}
+
+function datesChanged() {
+  const start = document.getElementById("performance-start").value;
+  const end = document.getElementById("performance-end").value;
+  if (!start || !end) return;
+  performanceStartMs = new Date(`${start}T00:00:00`).getTime();
+  performanceEndMs = new Date(`${end}T23:59:59.999`).getTime();
+  loadPerformanceSamples();
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", () => {
+    performanceChart = echarts.init(
+      document.getElementById("performance-chart"),
+    );
+    document
+      .getElementById("performance-day")
+      .addEventListener("click", () => setRange(1));
+    document
+      .getElementById("performance-week")
+      .addEventListener("click", () => setRange(7));
+    document
+      .getElementById("performance-month")
+      .addEventListener("click", () => setRange(31));
+    document
+      .getElementById("performance-start")
+      .addEventListener("change", datesChanged);
+    document
+      .getElementById("performance-end")
+      .addEventListener("change", datesChanged);
+    Object.keys(FILTER_COLUMNS).forEach((elementId) =>
+      document
+        .getElementById(elementId)
+        .addEventListener("change", renderPerformanceChart),
+    );
+    window.addEventListener("resize", () => performanceChart.resize());
+    setRange(1);
+  });
+}
+
+if (typeof module !== "undefined") {
+  module.exports = { percentile, rollingPercentile };
+}

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1728,6 +1728,23 @@ li.pure-menu-item > .rules-master-toggle {
     margin-top: 16px;
 }
 
+#performance-chart {
+    height: 620px;
+    width: 100%;
+    margin-top: 16px;
+}
+
+.performance-monitoring-page {
+    padding: 0 1em;
+}
+
+.performance-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75em;
+    margin-top: 0.75em;
+}
+
 /* About page */
 .about-content {
     max-width: 800px;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -60,12 +60,13 @@
       <li class="pure-menu-item{% if current_page == 'weather' %} pure-menu-selected{% endif %}">
         <a href="/weather" class="pure-menu-link">Weather</a>
       </li>
-      <li class="pure-menu-item{% if current_page in ['temperature_chart', 'lighting_chart', 'chart_aqi', 'alerts', 'rules', 'logs_today', 'devices', 'all_devices'] %} pure-menu-selected{% endif %}">
+      <li class="pure-menu-item{% if current_page in ['temperature_chart', 'lighting_chart', 'chart_aqi', 'performance-monitoring', 'alerts', 'rules', 'logs_today', 'devices', 'all_devices'] %} pure-menu-selected{% endif %}">
         <a href="#" id="deep-dive-menu-link" class="pure-menu-link">Deep Dive ▾</a>
         <div id="deep-dive-popup" class="github-popup">
           <a href="/chart"{% if current_page == 'temperature_chart' %} class="pure-menu-selected"{% endif %}>Temperature Chart</a>
           <a href="/lighting_chart"{% if current_page == 'lighting_chart' %} class="pure-menu-selected"{% endif %}>Lighting Chart</a>
           <a href="/chart_aqi"{% if current_page == 'chart_aqi' %} class="pure-menu-selected"{% endif %}>Air Quality Chart</a>
+          <a href="/performance-monitoring"{% if current_page == 'performance-monitoring' %} class="pure-menu-selected"{% endif %}>Performance Monitoring</a>
           <a href="/alerts"{% if current_page == 'alerts' %} class="pure-menu-selected"{% endif %}>Alerts</a>
           <a href="/presence"{% if current_page == 'presence' %} class="pure-menu-selected"{% endif %}>Presence</a>
           <a href="/rules"{% if current_page == 'rules' %} class="pure-menu-selected"{% endif %}>Rules</a>

--- a/app/templates/performance-monitoring.html
+++ b/app/templates/performance-monitoring.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block title %} Performance Monitoring {% endblock %}
+{% block head %}
+{% if dist %}
+  <script src="https://cdn.jsdelivr.net/npm/echarts@{{ echarts_version }}"></script>
+{% else %}
+  <script src="/static/echarts@5"></script>
+{% endif %}
+<script src="/static/performance_monitoring.js"></script>
+{% endblock %}
+{% block body %}
+<main class="performance-monitoring-page">
+  <h1>Performance Monitoring</h1>
+  <p>AE-200 application timing and independent DNS, ICMP, and TCP-reject probes.</p>
+  <div id="performance-controls">
+    <div class="temporal-buttons">
+      <button id="performance-day">day</button>
+      <button id="performance-week">week</button>
+      <button id="performance-month">month</button>
+      <label>Start <input type="date" id="performance-start"></label>
+      <label>End <input type="date" id="performance-end"></label>
+    </div>
+    <div class="performance-filters">
+      <label>Instance <select id="performance-instance"><option value="">all</option></select></label>
+      <label>Client <select id="performance-client"><option value="">all</option></select></label>
+      <label>Type <select id="performance-type"><option value="">all</option></select></label>
+      <label>Operation <select id="performance-operation"><option value="">all</option></select></label>
+    </div>
+  </div>
+  <p id="performance-summary" role="status"></p>
+  <div id="performance-chart" aria-label="Performance latency time series"></div>
+</main>
+{% endblock %}

--- a/bin/performance_monitor.py
+++ b/bin/performance_monitor.py
@@ -1,0 +1,73 @@
+"""One-shot AE-200 DNS, ICMP, and TCP-reject performance probe."""
+
+import argparse
+import logging
+import os
+
+from app import db
+from app import performance_monitoring
+from app.util import get_config
+
+logger = logging.getLogger(__name__)
+
+
+def setup_parser() -> argparse.ArgumentParser:
+    """Return the command-line parser for the one-shot probe."""
+    parser = argparse.ArgumentParser(
+        description="Record independent network measurements to the AE-200."
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="collect one set of probes and exit (required)",
+    )
+    parser.add_argument("--host", help="AE-200 hostname; defaults to config")
+    parser.add_argument(
+        "--reject-port",
+        type=int,
+        default=int(
+            os.getenv(
+                performance_monitoring.AE200_REJECT_PORT_ENV,
+                str(performance_monitoring.DEFAULT_REJECT_PORT),
+            )
+        ),
+        help="TCP port expected to reject connections",
+    )
+    parser.add_argument("--ping-count", type=int, default=3)
+    parser.add_argument("--loglevel", default="INFO")
+    return parser
+
+
+def main() -> int:
+    """Collect and persist one set of independent network samples."""
+    args = setup_parser().parse_args()
+    if not args.once:
+        raise SystemExit("--once is required; schedule this command once per minute")
+    if not 1 <= args.reject_port <= 65535:
+        raise SystemExit("--reject-port must be between 1 and 65535")
+    if not 1 <= args.ping_count <= 10:
+        raise SystemExit("--ping-count must be between 1 and 10")
+
+    logging.basicConfig(level=args.loglevel.upper())
+    db.validate_database_schema_on_startup()
+    host = args.host or get_config()["ae200"]["host"]
+    samples = performance_monitoring.collect_network_samples(
+        host,
+        reject_port=args.reject_port,
+        ping_count=args.ping_count,
+    )
+    for sample in samples:
+        performance_monitoring.record_sample(sample)
+        logger.info(
+            "%s %s success=%s outcome=%s total_ms=%.3f",
+            sample.sample_type,
+            sample.operation,
+            sample.success,
+            sample.outcome,
+            sample.total_ms,
+        )
+    return 0 if any(sample.success for sample in samples) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/render_web_ui_pages.py
+++ b/bin/render_web_ui_pages.py
@@ -419,6 +419,7 @@ def prepare_output_dir(output_dir: Path) -> None:
 
 
 def create_database(db_path: Path) -> dict[str, int]:
+    from app import performance_monitoring
     from app.paths import SCHEMA_FILE_PATH
 
     conn = sqlite3.connect(db_path)
@@ -578,6 +579,70 @@ def create_database(db_path: Path) -> dict[str, int]:
                 ),
             )
 
+        now_ms = now * 1000
+        for index in range(24):
+            observed_at_ms = now_ms - (23 - index) * 60 * 60 * 1000
+            lock_wait_ms = 1.0 + index % 4
+            connect_ms = 18.0 + index % 6
+            response_ms = 85.0 + index * 2.5
+            performance_monitoring.insert_sample(
+                conn,
+                performance_monitoring.PerformanceSample(
+                    observed_at_ms=observed_at_ms,
+                    instance_id="production",
+                    client_id="minute-runner",
+                    sample_type=performance_monitoring.SAMPLE_TYPE_AE200,
+                    operation=performance_monitoring.OPERATION_GET_DEVICES,
+                    target_host="ae200.example",
+                    target_port=80,
+                    lock_wait_ms=lock_wait_ms,
+                    connect_ms=connect_ms,
+                    response_ms=response_ms,
+                    close_ms=2.0,
+                    total_ms=lock_wait_ms + connect_ms + response_ms + 2.0,
+                    success=True,
+                    outcome="ok",
+                    response_bytes=2048,
+                ),
+            )
+            if index % 2 == 0:
+                performance_monitoring.insert_sample(
+                    conn,
+                    performance_monitoring.PerformanceSample(
+                        observed_at_ms=observed_at_ms + 30_000,
+                        instance_id="production",
+                        client_id="network-probe",
+                        sample_type=performance_monitoring.SAMPLE_TYPE_ICMP,
+                        operation=performance_monitoring.OPERATION_ECHO,
+                        target_host="ae200.example",
+                        resolved_ip="192.0.2.10",
+                        icmp_min_ms=11.0 + index / 10,
+                        icmp_median_ms=12.0 + index / 10,
+                        icmp_max_ms=13.5 + index / 10,
+                        packet_loss_pct=0,
+                        total_ms=2010,
+                        success=True,
+                        outcome="reply",
+                    ),
+                )
+                performance_monitoring.insert_sample(
+                    conn,
+                    performance_monitoring.PerformanceSample(
+                        observed_at_ms=observed_at_ms + 31_000,
+                        instance_id="production",
+                        client_id="network-probe",
+                        sample_type=performance_monitoring.SAMPLE_TYPE_TCP_REJECT,
+                        operation=performance_monitoring.OPERATION_REJECT,
+                        target_host="ae200.example",
+                        target_port=1,
+                        resolved_ip="192.0.2.10",
+                        connect_ms=17.0 + index / 8,
+                        total_ms=17.0 + index / 8,
+                        success=True,
+                        outcome="refused",
+                    ),
+                )
+
         conn.commit()
         return device_ids
     finally:
@@ -662,6 +727,13 @@ def page_specs(device_ids: dict[str, int]) -> list[PageSpec]:
         PageSpec(slug="lighting-chart", title="Lighting Chart", path="/lighting_chart", wait_selector="#lighting-chart canvas"),
         *metric_pages,
         PageSpec(slug="aqi-chart", title="Air Quality Chart", path="/chart_aqi", wait_selector="#aqi-chart canvas"),
+        PageSpec(
+            slug="performance-monitoring",
+            title="Performance Monitoring",
+            path="/performance-monitoring",
+            wait_selector="#performance-chart canvas",
+            settle_ms=900,
+        ),
         PageSpec(slug="alerts", title="Alerts", path="/alerts", wait_selector="#active-alerts-table"),
         PageSpec(slug="rules", title="Rules", path="/rules?run_rules=0", wait_selector=".suspend-rules-buttons"),
         PageSpec(slug="logs-today", title="Activity Log", path="/logs_today", wait_selector="#log-table"),

--- a/bin/runner.py
+++ b/bin/runner.py
@@ -26,6 +26,7 @@ from app import airthings
 from app import db
 from app import db_alerts
 from app import hubitat
+from app import performance_monitoring
 from app.device_types import (
     DEVICE_TYPE_SENSOR,
     HubitatDevice,
@@ -223,6 +224,11 @@ def daily_cleanup(conn, when):
     """
     print("Daily cleanup")
     c = conn.cursor()
+    deleted_performance_samples = performance_monitoring.delete_expired_samples(conn)
+    conn.commit()
+    logger.info(
+        "Deleted %d expired performance samples", deleted_performance_samples
+    )
 
     # See if there are any in the previous week that need to be
     prev_week_start = (when - datetime.timedelta(weeks=2)).timestamp()

--- a/doc/agent-index.md
+++ b/doc/agent-index.md
@@ -14,6 +14,8 @@ surface quickly.
   Makefile targets, and migration rules.
 - `doc/frontend-rendering-strategy.md`: frontend architecture and where SSR,
   JSON APIs, and static JavaScript belong.
+- `doc/performance-monitoring.md`: AE-200 request timing, independent network
+  probes, storage, charting, deployment, and staging-load experiments.
 - `doc/rooms-implementation-review.md`: room dashboard debt, open room issues,
   and Hickory/Kitchen dashboard generalization notes.
 - `doc/rooms-implementation-plan.md`: approved FCU-owned room model, grouped

--- a/doc/performance-monitoring.md
+++ b/doc/performance-monitoring.md
@@ -35,7 +35,11 @@ The row also records the operation, AE-200 device id when applicable, response
 size, success or failure, normalized error type, instance/client identity, and
 an optional experiment id. Recording happens after releasing the AE-200 file
 lock. A monitoring write failure is logged but never replaces the application
-request's return value or exception.
+request's return value or exception. Inline request instrumentation uses a
+zero-wait SQLite transaction: if another writer holds the database, the sample
+is dropped and a warning is logged instead of delaying AE-200 work. Scheduled
+network probes may use SQLite's normal bounded wait because they are not on a
+control-request path.
 
 Simulator operations are not recorded as AE-200 performance samples because
 they do not exercise the controller or network.
@@ -50,6 +54,11 @@ an AE-200 XML command:
    loss.
 3. One TCP connection attempt to a configurable port expected to have no
    listener.
+
+When DNS supplies both address families, the probe prefers IPv4. This keeps the
+resolved literal compatible with the `ping` executable on both Linux and
+macOS; an IPv6-only target is retained, but may require platform-specific
+`ping6` support in a future extension.
 
 The TCP probe intentionally measures a reject path. `ECONNREFUSED` means the
 target was reached and promptly returned a TCP RST, so the sample is successful

--- a/doc/performance-monitoring.md
+++ b/doc/performance-monitoring.md
@@ -1,0 +1,177 @@
+# Performance monitoring
+
+## Purpose
+
+The AE-200 does not expose controller CPU or queue utilization through the
+interface used by Temperature Bot. This design records request latency and
+failures as indirect controller-load signals and records independent network
+measurements so WAN changes are not mistaken for AE-200 saturation.
+
+Monitoring is observational. Production and staging keep their normal ability
+to read and write the AE-200. No read-only application mode is introduced.
+
+## Signals
+
+### Application requests
+
+Every real AE-200 operation records one sample:
+
+- `get_devices`: enumerate controller units;
+- `get_device_info`: fetch one unit's state;
+- `set`: send a control command.
+
+Durations use `time.perf_counter_ns()`, a monotonic clock, and are stored in
+milliseconds:
+
+- `lock_wait_ms`: wait for the in-process semaphore and cross-process file
+  lock;
+- `connect_ms`: WebSocket TCP connection and HTTP upgrade;
+- `response_ms`: XML send/receive time, or XML send time for a command with no
+  response body;
+- `close_ms`: WebSocket close time;
+- `total_ms`: the complete synchronous operation, including local queueing.
+
+The row also records the operation, AE-200 device id when applicable, response
+size, success or failure, normalized error type, instance/client identity, and
+an optional experiment id. Recording happens after releasing the AE-200 file
+lock. A monitoring write failure is logged but never replaces the application
+request's return value or exception.
+
+Simulator operations are not recorded as AE-200 performance samples because
+they do not exercise the controller or network.
+
+### Independent network probe
+
+`python -m bin.performance_monitor --once` records three probes without issuing
+an AE-200 XML command:
+
+1. DNS resolution of the configured AE-200 hostname.
+2. Three ICMP echo requests, summarized as minimum, median, maximum, and packet
+   loss.
+3. One TCP connection attempt to a configurable port expected to have no
+   listener.
+
+The TCP probe intentionally measures a reject path. `ECONNREFUSED` means the
+target was reached and promptly returned a TCP RST, so the sample is successful
+with outcome `refused`. A timeout or unreachable error is a failed network
+sample. If the supposedly closed port accepts the connection, the probe records
+outcome `connected` and closes immediately; the operator should choose a
+different port. This is not an HTTP probe: an HTTP measurement would require a
+request and response, while an "empty HTTP connect" is only a TCP connection.
+
+The default closed port is TCP/1 and is configurable with
+`AE200_REJECT_PORT`. Network firewalls may silently drop that port instead of
+rejecting it, so deployment must confirm the expected `refused` outcome.
+
+The probe is a separate short-lived process, intended to run once per minute:
+
+```cron
+* * * * * cd /home/air/temperature-bot && \
+  DB_PATH=/var/db/temperature-bot.db \
+  TEMPERATURE_BOT_INSTANCE=production \
+  PERFORMANCE_CLIENT_ID=network-probe \
+  .venv/bin/python -m bin.performance_monitor --once \
+  >> /home/air/temperature-bot-performance.log 2>&1
+```
+
+Offsetting it by about 30 seconds is useful when comparing the probe with the
+minute collector. The process is independent of the HVAC Rules master switch.
+The checked-in `etc/temperature-bot-performance-monitor.service` and `.timer`
+run the production probe at 30 seconds past each minute. Install them in
+`/etc/systemd/system`, run `systemctl daemon-reload`, and enable the timer with
+`systemctl enable --now temperature-bot-performance-monitor.timer`. Use either
+the timer or the example cron entry, not both. A staging installation needs a
+copy or override with the staging working directory, database, and instance id.
+
+## Storage
+
+Samples live in the append-only `performance_samples` table. They are not
+added to AE-200 `status_json`: latency changes on nearly every request and
+would defeat `devlog` run-length compression.
+
+The schema is installed by the repeatable Flyway migration
+`R__performance_samples.sql`. A repeatable migration is used deliberately
+because this work branches from `main` at V11 while the independent AQI/alerts
+branch owns V12 through V15. Flyway applies repeatable migrations after pending
+versioned migrations, so this PR can deploy before or after that branch without
+reusing a version number. Future changes after the branches converge should use
+the next normal versioned migration.
+
+The default retention period is 90 days. The daily runner deletes older rows;
+`PERFORMANCE_RETENTION_DAYS` can tune the period. At the present baseline of 13
+AE-200 WebSocket requests per minute, application samples contribute about
+18,720 rows per day. The independent probe contributes three rows per minute,
+or 4,320 rows per day.
+
+## Identity and experiments
+
+Set these environment variables on each deployment:
+
+- `TEMPERATURE_BOT_INSTANCE`: stable environment name, such as `production` or
+  `staging`; defaults to the hostname.
+- `PERFORMANCE_CLIENT_ID`: process role, such as `minute-runner`, `web`, or
+  `network-probe`; defaults to the executable name.
+- `PERFORMANCE_EXPERIMENT_ID`: optional label shared by samples during a
+  controlled test.
+- `AE200_REJECT_PORT`: expected-closed TCP port; defaults to `1`.
+- `PERFORMANCE_RETENTION_DAYS`: raw-sample retention; defaults to `90`.
+
+Production and staging write to their own SQLite databases. Each chart therefore
+shows samples generated by that deployment. To compare the same interval across
+both databases, export the query results or point a reporting tool at copies of
+both databases; the application must not make staging write into production's
+database.
+
+## Chart and API
+
+`/performance-monitoring` defaults to the last day and can select a week,
+month, or custom date range. It plots raw latency for:
+
+- AE-200 lock wait, connect, command/response, and total time;
+- ICMP median latency;
+- TCP reject latency.
+
+Filters distinguish instance, client, sample type, and operation. Failures and
+unexpected outcomes remain in the API response and summary rather than being
+dropped from the graph. `/api/v1/performance_samples` returns a typed
+`{"samples": [...], "truncated": false}` page for the selected range, capped to
+protect the web process from unbounded queries. The chart shows rolling p50 and
+p95 AE-200 total latency over the latest 60 displayed request samples.
+The 50,000-row default limit accommodates a full day at the expected load.
+Broader ranges can reach the cap; the page reports truncation rather than
+silently presenting the result as complete.
+
+## Interpretation
+
+No single latency value proves controller CPU saturation:
+
+| Observation | Likely area to investigate |
+|---|---|
+| DNS, ICMP, TCP, and AE-200 all rise | WAN path or remote-site network |
+| ICMP is stable; TCP and AE-200 rise | TCP path, firewall, or target host stack |
+| DNS/ICMP/TCP are stable; AE-200 response rises | AE-200 application/controller |
+| Only `lock_wait_ms` rises | local process contention |
+| `connect_ms` is stable; `response_ms` rises | AE-200 XML processing |
+| Probe is stable; only one client slows | client-specific queueing or code path |
+
+Cross-data-center ICMP can be deprioritized, and a closed TCP port can be
+filtered. Trends and correlated signals are more useful than a single sample.
+
+## Controlled staging-load experiment
+
+Staging remains writable so a maintainer can make a change and verify that the
+AE-200 accepted it. To measure the cost of a second collector:
+
+1. Establish at least one day of production baseline data.
+2. Confirm the network probe normally reports `refused`, not timeouts.
+3. Set a unique `PERFORMANCE_EXPERIMENT_ID` on the staging collector.
+4. Start only the staging AE-200 collection loop at the normal one-minute rate;
+   do not duplicate Hubitat, Airthings, weather, or automatic HVAC rules unless
+   those systems are part of the test.
+5. Keep staging web controls enabled for manual read/write validation.
+6. Stop the experiment if error rate rises or p95 AE-200 response time degrades
+   materially and stays elevated.
+7. Compare before/during/after p50, p95, p99, failures, and network probes.
+
+The experiment measures capacity indirectly. It does not establish AE-200 CPU
+utilization unless Mitsubishi exposes a separate supported metric.

--- a/doc/sql-migrations.md
+++ b/doc/sql-migrations.md
@@ -14,6 +14,9 @@ Temperature Bot now tracks SQL schema versions with Flyway.
   for FCU ownership and assignment.
 - `etc/flyway/sql/V10__room_presence.sql` stores room-at-observation presence
   events and indexes current and historical room queries.
+- `etc/flyway/sql/R__performance_samples.sql` adds integration and network
+  timing samples. It is repeatable so it can be deployed before or after the
+  independent branch that owns V12-V15; see `doc/performance-monitoring.md`.
 - Flyway creates and manages `flyway_schema_history`; do not add that table to a versioned migration or to `etc/schema.sql`.
 - Existing populated databases are baselined at V1 by `make migrate-db` and `make deploy`, then any later migrations are applied.
 - `etc/schema.sql` is generated from the Flyway migration history for tests and compatibility. Do not hand-edit it for schema changes.
@@ -59,7 +62,9 @@ flyway \
 
 ## Adding a new migration
 
-1. Add a new SQL file in `etc/flyway/sql/`.
+1. Add a new SQL file in `etc/flyway/sql/`. Normally use the next versioned
+   migration. Use a repeatable migration only when the change is idempotent and
+   branch-order compatibility requires it; document that decision in the SQL.
 2. Use a Flyway versioned filename, for example:
    - `V3__add_new_table.sql`
    - `V4__add_alert_indexes.sql`

--- a/etc/air-stage_basistech_net.service
+++ b/etc/air-stage_basistech_net.service
@@ -9,6 +9,8 @@ Group=simsong
 WorkingDirectory=/home/air-stage/temperature-bot
 Environment="PATH=/home/air-stage/temperature-bot/.venv/bin"
 Environment="DB_PATH=/home/air-stage/var/db/temperature-bot.db"
+Environment="TEMPERATURE_BOT_INSTANCE=staging"
+Environment="PERFORMANCE_CLIENT_ID=web"
 ExecStart=/bin/bash -c 'gunicorn app.main:app --bind 127.0.0.1:8101 --workers $((2 * $(/usr/bin/nproc) + 1))'
 Restart=always
 RestartSec=2

--- a/etc/air_basistech_net.service
+++ b/etc/air_basistech_net.service
@@ -9,6 +9,8 @@ Group=simsong
 WorkingDirectory=/home/air/temperature-bot
 Environment="PATH=/home/air/temperature-bot/.venv/bin"
 Environment="DB_PATH=/var/db/temperature-bot.db"
+Environment="TEMPERATURE_BOT_INSTANCE=production"
+Environment="PERFORMANCE_CLIENT_ID=web"
 ExecStart=/bin/bash -c 'gunicorn app.main:app --bind 127.0.0.1:8100 --workers $((2 * $(/usr/bin/nproc) + 1))'
 Restart=always
 RestartSec=2

--- a/etc/flyway/sql/R__performance_samples.sql
+++ b/etc/flyway/sql/R__performance_samples.sql
@@ -1,0 +1,43 @@
+-- Repeatable rather than versioned so this PR remains migration-order
+-- compatible with the independent AQI/alerts branch, which owns V12-V15.
+-- Flyway runs repeatable migrations after all pending versioned migrations.
+CREATE TABLE IF NOT EXISTS performance_samples (
+    sample_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    observed_at_ms INTEGER NOT NULL,
+    instance_id TEXT NOT NULL,
+    client_id TEXT NOT NULL,
+    sample_type TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    target_host TEXT NOT NULL,
+    target_port INTEGER,
+    resolved_ip TEXT,
+    ae200_device_id TEXT,
+    dns_ms REAL CHECK (dns_ms IS NULL OR dns_ms >= 0),
+    icmp_min_ms REAL CHECK (icmp_min_ms IS NULL OR icmp_min_ms >= 0),
+    icmp_median_ms REAL CHECK (icmp_median_ms IS NULL OR icmp_median_ms >= 0),
+    icmp_max_ms REAL CHECK (icmp_max_ms IS NULL OR icmp_max_ms >= 0),
+    packet_loss_pct REAL CHECK (
+        packet_loss_pct IS NULL OR
+        (packet_loss_pct >= 0 AND packet_loss_pct <= 100)
+    ),
+    lock_wait_ms REAL CHECK (lock_wait_ms IS NULL OR lock_wait_ms >= 0),
+    connect_ms REAL CHECK (connect_ms IS NULL OR connect_ms >= 0),
+    response_ms REAL CHECK (response_ms IS NULL OR response_ms >= 0),
+    close_ms REAL CHECK (close_ms IS NULL OR close_ms >= 0),
+    total_ms REAL NOT NULL CHECK (total_ms >= 0),
+    success INTEGER NOT NULL CHECK (success IN (0, 1)),
+    outcome TEXT NOT NULL,
+    error_type TEXT,
+    error_message TEXT,
+    response_bytes INTEGER CHECK (response_bytes IS NULL OR response_bytes >= 0),
+    experiment_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_performance_samples_observed_at
+ON performance_samples(observed_at_ms);
+
+CREATE INDEX IF NOT EXISTS idx_performance_samples_instance_type_time
+ON performance_samples(instance_id, sample_type, observed_at_ms);
+
+CREATE INDEX IF NOT EXISTS idx_performance_samples_operation_time
+ON performance_samples(operation, observed_at_ms);

--- a/etc/schema.sql
+++ b/etc/schema.sql
@@ -93,3 +93,40 @@ CREATE INDEX IF NOT EXISTS idx_presence_events_device_observed_at
 ON presence_events(device_id, observed_at);
 CREATE INDEX IF NOT EXISTS idx_devlog_device_logtime_log_id
 ON devlog (device_id, logtime DESC, log_id DESC);
+CREATE TABLE IF NOT EXISTS performance_samples (
+    sample_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    observed_at_ms INTEGER NOT NULL,
+    instance_id TEXT NOT NULL,
+    client_id TEXT NOT NULL,
+    sample_type TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    target_host TEXT NOT NULL,
+    target_port INTEGER,
+    resolved_ip TEXT,
+    ae200_device_id TEXT,
+    dns_ms REAL CHECK (dns_ms IS NULL OR dns_ms >= 0),
+    icmp_min_ms REAL CHECK (icmp_min_ms IS NULL OR icmp_min_ms >= 0),
+    icmp_median_ms REAL CHECK (icmp_median_ms IS NULL OR icmp_median_ms >= 0),
+    icmp_max_ms REAL CHECK (icmp_max_ms IS NULL OR icmp_max_ms >= 0),
+    packet_loss_pct REAL CHECK (
+        packet_loss_pct IS NULL OR
+        (packet_loss_pct >= 0 AND packet_loss_pct <= 100)
+    ),
+    lock_wait_ms REAL CHECK (lock_wait_ms IS NULL OR lock_wait_ms >= 0),
+    connect_ms REAL CHECK (connect_ms IS NULL OR connect_ms >= 0),
+    response_ms REAL CHECK (response_ms IS NULL OR response_ms >= 0),
+    close_ms REAL CHECK (close_ms IS NULL OR close_ms >= 0),
+    total_ms REAL NOT NULL CHECK (total_ms >= 0),
+    success INTEGER NOT NULL CHECK (success IN (0, 1)),
+    outcome TEXT NOT NULL,
+    error_type TEXT,
+    error_message TEXT,
+    response_bytes INTEGER CHECK (response_bytes IS NULL OR response_bytes >= 0),
+    experiment_id TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_performance_samples_observed_at
+ON performance_samples(observed_at_ms);
+CREATE INDEX IF NOT EXISTS idx_performance_samples_instance_type_time
+ON performance_samples(instance_id, sample_type, observed_at_ms);
+CREATE INDEX IF NOT EXISTS idx_performance_samples_operation_time
+ON performance_samples(operation, observed_at_ms);

--- a/etc/temperature-bot-performance-monitor.service
+++ b/etc/temperature-bot-performance-monitor.service
@@ -1,0 +1,16 @@
+### /etc/systemd/system/temperature-bot-performance-monitor.service ###
+[Unit]
+Description=Record AE-200 network performance probes
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=simsong
+Group=simsong
+WorkingDirectory=/home/air/temperature-bot
+Environment="PATH=/home/air/temperature-bot/.venv/bin:/usr/bin:/bin"
+Environment="DB_PATH=/var/db/temperature-bot.db"
+Environment="TEMPERATURE_BOT_INSTANCE=production"
+Environment="PERFORMANCE_CLIENT_ID=network-probe"
+ExecStart=/home/air/temperature-bot/.venv/bin/python -m bin.performance_monitor --once

--- a/etc/temperature-bot-performance-monitor.timer
+++ b/etc/temperature-bot-performance-monitor.timer
@@ -1,0 +1,12 @@
+### /etc/systemd/system/temperature-bot-performance-monitor.timer ###
+[Unit]
+Description=Run the AE-200 network performance probe once per minute
+
+[Timer]
+OnCalendar=*-*-* *:*:30
+AccuracySec=1s
+Persistent=true
+Unit=temperature-bot-performance-monitor.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_performance_monitoring.js
+++ b/tests/test_performance_monitoring.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const assert = require("assert");
+const {
+  percentile,
+  rollingPercentile,
+} = require("../app/static/performance_monitoring.js");
+
+assert.strictEqual(percentile([], 0.5), null);
+assert.strictEqual(percentile([30, 10, 20], 0.5), 20);
+assert.strictEqual(percentile([10, 20], 0.95), 19.5);
+
+const samples = [
+  { observed_at_ms: 3000, total_ms: 30 },
+  { observed_at_ms: 1000, total_ms: 10 },
+  { observed_at_ms: 2000, total_ms: 20 },
+  { observed_at_ms: 4000, total_ms: null },
+];
+assert.deepStrictEqual(rollingPercentile(samples, "total_ms", 0.5, 2), [
+  [1000, 10],
+  [2000, 15],
+  [3000, 25],
+]);
+
+console.log("performance_monitoring.js tests passed");

--- a/tests/test_performance_monitoring.py
+++ b/tests/test_performance_monitoring.py
@@ -1,0 +1,238 @@
+"""Substantive SQLite, timing, parser, and loopback probe tests."""
+
+import asyncio
+import socket
+
+import pytest
+import websockets
+
+from app import ae200
+from app import performance_monitoring
+from bin import performance_monitor as performance_monitor_cli
+
+
+LINUX_PING_OUTPUT = """PING ae200 (192.0.2.10) 56(84) bytes of data.
+64 bytes from 192.0.2.10: icmp_seq=1 ttl=63 time=12.4 ms
+64 bytes from 192.0.2.10: icmp_seq=2 ttl=63 time=14.8 ms
+64 bytes from 192.0.2.10: icmp_seq=3 ttl=63 time=13.1 ms
+
+--- ae200 ping statistics ---
+3 packets transmitted, 3 received, 0% packet loss, time 2003ms
+"""
+
+MACOS_PING_WITH_LOSS_OUTPUT = """PING ae200 (192.0.2.10): 56 data bytes
+64 bytes from 192.0.2.10: icmp_seq=0 ttl=63 time=21.250 ms
+64 bytes from 192.0.2.10: icmp_seq=2 ttl=63 time=19.750 ms
+
+--- ae200 ping statistics ---
+3 packets transmitted, 2 packets received, 33.3% packet loss
+"""
+
+
+def _sample(observed_at_ms: int, *, operation: str = "get_devices"):
+    return performance_monitoring.PerformanceSample(
+        observed_at_ms=observed_at_ms,
+        instance_id="test",
+        client_id="pytest",
+        sample_type=performance_monitoring.SAMPLE_TYPE_AE200,
+        operation=operation,
+        target_host="ae200.example",
+        target_port=80,
+        lock_wait_ms=1.25,
+        connect_ms=2.5,
+        response_ms=3.75,
+        total_ms=8.0,
+        success=True,
+        outcome="ok",
+    )
+
+
+def test_ping_parser_handles_linux_and_macos_loss():
+    """Individual replies determine median even when one macOS packet is lost."""
+    linux = performance_monitoring.parse_ping_output(LINUX_PING_OUTPUT)
+    macos = performance_monitoring.parse_ping_output(MACOS_PING_WITH_LOSS_OUTPUT)
+
+    assert linux.model_dump() == {
+        "minimum_ms": 12.4,
+        "median_ms": 13.1,
+        "maximum_ms": 14.8,
+        "packet_loss_pct": 0.0,
+        "replies": 3,
+    }
+    assert macos.minimum_ms == 19.75
+    assert macos.median_ms == 20.5
+    assert macos.maximum_ms == 21.25
+    assert macos.packet_loss_pct == 33.3
+    assert macos.replies == 2
+
+
+def test_tcp_reject_probe_treats_loopback_refusal_as_reachable():
+    """A closed local port produces the probe's expected successful outcome."""
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    closed_port = listener.getsockname()[1]
+    listener.close()
+
+    sample = performance_monitoring.probe_tcp_reject(
+        "localhost", closed_port, resolved_ip="127.0.0.1"
+    )
+
+    assert sample.success is True
+    assert sample.outcome == "refused"
+    assert sample.connect_ms is not None
+    assert sample.total_ms >= sample.connect_ms
+
+
+def test_performance_samples_persist_filter_and_expire(test_database_conn):
+    """Persistence keeps filters precise and retention deletes only old rows."""
+    performance_monitoring.insert_sample(test_database_conn, _sample(1_000))
+    performance_monitoring.insert_sample(
+        test_database_conn, _sample(2_000, operation="get_device_info")
+    )
+    performance_monitoring.insert_sample(
+        test_database_conn,
+        performance_monitoring.PerformanceSample(
+            observed_at_ms=2_500,
+            instance_id="other",
+            client_id="probe",
+            sample_type=performance_monitoring.SAMPLE_TYPE_TCP_REJECT,
+            operation=performance_monitoring.OPERATION_REJECT,
+            target_host="ae200.example",
+            target_port=1,
+            connect_ms=4,
+            total_ms=4,
+            success=True,
+            outcome="refused",
+        ),
+    )
+    test_database_conn.commit()
+
+    rows = performance_monitoring.fetch_samples(
+        test_database_conn,
+        performance_monitoring.PerformanceQuery(
+            start_ms=1_500,
+            end_ms=3_000,
+            instance_id="test",
+            operation="get_device_info",
+        ),
+    )
+    assert len(rows) == 1
+    assert rows[0].observed_at_ms == 2_000
+
+    deleted = performance_monitoring.delete_expired_samples(
+        test_database_conn, now_ms=3_000, retention_days=1
+    )
+    assert deleted == 0
+    deleted = performance_monitoring.delete_expired_samples(
+        test_database_conn,
+        now_ms=2 * 24 * 60 * 60 * 1000,
+        retention_days=1,
+    )
+    assert deleted == 3
+
+
+def test_async_runner_records_success_and_original_failure(
+    test_database_conn, monkeypatch, tmp_path
+):
+    """Instrumentation records both outcomes without replacing exceptions."""
+    test_database_conn.commit()
+    monkeypatch.setattr(ae200, "AE200_COMMAND_LOCK_PATH", str(tmp_path / "ae200.lock"))
+    runner = ae200.AsyncRunner()
+
+    async def succeed():
+        await asyncio.sleep(0)
+        return "done"
+
+    success = _sample(10_000)
+    success.success = False
+    success.outcome = "pending"
+    assert runner.run_async_safely(succeed(), sample=success) == "done"
+
+    async def fail():
+        await asyncio.sleep(0)
+        raise ValueError("controller rejected payload")
+
+    failure = _sample(11_000, operation="set")
+    with pytest.raises(ValueError, match="controller rejected payload"):
+        runner.run_async_safely(fail(), sample=failure)
+
+    rows = test_database_conn.execute(
+        """
+        SELECT observed_at_ms, success, outcome, error_type, lock_wait_ms
+        FROM performance_samples
+        WHERE observed_at_ms IN (10000, 11000)
+        ORDER BY observed_at_ms
+        """
+    ).fetchall()
+    assert [tuple(row[:4]) for row in rows] == [
+        (10_000, 1, "ok", None),
+        (11_000, 0, "error", "ValueError"),
+    ]
+    assert all(row[4] >= 0 for row in rows)
+
+
+def test_ae200_exchange_times_real_local_websocket(monkeypatch):
+    """Phase timing wraps an actual WebSocket upgrade and XML round trip."""
+    response_xml = """<Packet><DatabaseManager><ControlGroup><MnetList>
+    <MnetRecord Group="10" GroupNameWeb="Office"/>
+    </MnetList></ControlGroup></DatabaseManager></Packet>"""
+
+    async def exercise():
+        async def handler(websocket):
+            assert await websocket.recv() == ae200.getUnitsPayload
+            await websocket.send(response_xml)
+
+        async with websockets.serve(
+            handler, "127.0.0.1", 0, subprotocols=["b_xmlproc"]
+        ) as server:
+            port = server.sockets[0].getsockname()[1]
+            controller = ae200.AE200Functions(f"127.0.0.1:{port}")
+            sample = performance_monitoring.new_ae200_sample(
+                performance_monitoring.OPERATION_GET_DEVICES,
+                controller.address,
+            )
+            devices = await controller.getDevicesAsync(sample)
+            return devices, sample
+
+    monkeypatch.setattr(ae200, "AE200_SIMULATOR", False)
+    devices, sample = asyncio.run(exercise())
+
+    assert devices == [{"id": "10", "name": "Office"}]
+    assert sample.connect_ms is not None
+    assert sample.response_ms is not None
+    assert sample.close_ms is not None
+    assert sample.response_bytes == len(response_xml.encode("utf-8"))
+
+
+def test_performance_api_and_page(flask_test_client, test_database_conn):
+    """The page is linked to a bounded API that returns persisted samples."""
+    performance_monitoring.insert_sample(test_database_conn, _sample(20_000))
+    performance_monitoring.insert_sample(test_database_conn, _sample(20_001))
+    test_database_conn.commit()
+
+    page = flask_test_client.get("/performance-monitoring")
+    response = flask_test_client.get(
+        "/api/v1/performance_samples?start_ms=19000&end_ms=21000&limit=1"
+    )
+
+    assert page.status_code == 200
+    assert b"Performance Monitoring" in page.data
+    assert b"performance_monitoring.js" in page.data
+    assert response.status_code == 200
+    assert response.get_json()["samples"][0]["operation"] == "get_devices"
+    assert response.get_json()["truncated"] is True
+    invalid = flask_test_client.get(
+        "/api/v1/performance_samples?start_ms=21000&end_ms=19000"
+    )
+    assert invalid.status_code == 400
+    malformed = flask_test_client.get(
+        "/api/v1/performance_samples?start_ms=not-a-number"
+    )
+    assert malformed.status_code == 400
+
+
+def test_performance_probe_cli_refuses_unscheduled_loop_mode(monkeypatch):
+    """The probe cannot accidentally become an unsupervised internal loop."""
+    monkeypatch.setattr("sys.argv", ["performance_monitor"])
+    with pytest.raises(SystemExit, match="--once is required"):
+        performance_monitor_cli.main()

--- a/tests/test_performance_monitoring.py
+++ b/tests/test_performance_monitoring.py
@@ -1,7 +1,9 @@
 """Substantive SQLite, timing, parser, and loopback probe tests."""
 
 import asyncio
+import logging
 import socket
+import time
 
 import pytest
 import websockets
@@ -81,6 +83,37 @@ def test_tcp_reject_probe_treats_loopback_refusal_as_reachable():
     assert sample.outcome == "refused"
     assert sample.connect_ms is not None
     assert sample.total_ms >= sample.connect_ms
+
+
+def test_dns_address_selection_prefers_ipv4_for_portable_ping():
+    """An IPv4 result wins even when DNS returns IPv6 first."""
+    addresses = [
+        (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2001:db8::10", 0, 0, 0)),
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.0.2.10", 0)),
+    ]
+
+    assert performance_monitoring.preferred_stream_address(addresses) == "192.0.2.10"
+
+
+def test_best_effort_record_does_not_wait_for_sqlite_writer(
+    test_database_conn, caplog
+):
+    """Inline telemetry abandons a locked database without delaying AE-200 work."""
+    test_database_conn.execute("BEGIN EXCLUSIVE")
+    started = time.perf_counter()
+    with caplog.at_level(logging.WARNING):
+        performance_monitoring.record_sample_best_effort(_sample(9_000))
+    elapsed = time.perf_counter() - started
+    test_database_conn.rollback()
+
+    assert elapsed < 0.5
+    assert "database is locked" in caplog.text
+    assert (
+        test_database_conn.execute(
+            "SELECT count(*) FROM performance_samples WHERE observed_at_ms = 9000"
+        ).fetchone()[0]
+        == 0
+    )
 
 
 def test_performance_samples_persist_filter_and_expire(test_database_conn):

--- a/tests/test_performance_monitoring.py
+++ b/tests/test_performance_monitoring.py
@@ -85,6 +85,50 @@ def test_tcp_reject_probe_treats_loopback_refusal_as_reachable():
     assert sample.total_ms >= sample.connect_ms
 
 
+def test_tcp_reject_probe_flags_unexpected_listener():
+    """An open port is reachable but violates the closed-port probe contract."""
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    try:
+        sample = performance_monitoring.probe_tcp_reject(
+            "localhost",
+            listener.getsockname()[1],
+            resolved_ip="127.0.0.1",
+        )
+    finally:
+        listener.close()
+
+    assert sample.success is True
+    assert sample.outcome == "connected"
+
+
+def test_collect_network_samples_loopback_end_to_end():
+    """One collection performs real DNS, ICMP, and TCP-reject probes."""
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    closed_port = listener.getsockname()[1]
+    listener.close()
+
+    samples = performance_monitoring.collect_network_samples(
+        "localhost", reject_port=closed_port, ping_count=1
+    )
+
+    assert [sample.sample_type for sample in samples] == [
+        performance_monitoring.SAMPLE_TYPE_DNS,
+        performance_monitoring.SAMPLE_TYPE_ICMP,
+        performance_monitoring.SAMPLE_TYPE_TCP_REJECT,
+    ]
+    assert [sample.outcome for sample in samples] == [
+        "resolved",
+        "reply",
+        "refused",
+    ]
+    assert all(sample.success for sample in samples)
+    assert samples[0].resolved_ip == "127.0.0.1"
+    assert samples[1].icmp_median_ms is not None
+
+
 def test_dns_address_selection_prefers_ipv4_for_portable_ping():
     """An IPv4 result wins even when DNS returns IPv6 first."""
     addresses = [

--- a/tests/test_schema_flyway.py
+++ b/tests/test_schema_flyway.py
@@ -16,11 +16,13 @@ MIGRATED_APP_TABLES = BASELINE_APP_TABLES | {
     "rooms",
     "fcu_temp_sources",
     "fcu_set_ranges",
+    "performance_samples",
 }
 BASELINE_MIGRATION_PATH = (
     Path(ROOT_DIR) / "etc" / "flyway" / "sql" / "V1__baseline_schema.sql"
 )
 MIGRATION_DIR = Path(ROOT_DIR) / "etc" / "flyway" / "sql"
+PERFORMANCE_MIGRATION_PATH = MIGRATION_DIR / "R__performance_samples.sql"
 
 
 def table_names_created_by(sql_path):
@@ -59,6 +61,31 @@ def test_schema_file_can_be_applied_twice():
         schema_sql = Path(SCHEMA_FILE_PATH).read_text(encoding="utf-8")
         conn.executescript(schema_sql)
         conn.executescript(schema_sql)
+
+
+def test_performance_repeatable_migration_is_idempotent_and_indexed():
+    """The conflict-safe repeatable migration can be reapplied by Flyway."""
+    with closing(sqlite3.connect(":memory:")) as conn:
+        migration_sql = PERFORMANCE_MIGRATION_PATH.read_text(encoding="utf-8")
+        conn.executescript(migration_sql)
+        conn.executescript(migration_sql)
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(performance_samples)")
+        }
+        indexes = {
+            row[1] for row in conn.execute("PRAGMA index_list(performance_samples)")
+        }
+
+    assert {
+        "observed_at_ms",
+        "sample_type",
+        "lock_wait_ms",
+        "connect_ms",
+        "response_ms",
+        "total_ms",
+        "outcome",
+    } <= columns
+    assert "idx_performance_samples_instance_type_time" in indexes
 
 
 def test_baseline_migration_does_not_create_flyway_history_table():


### PR DESCRIPTION
> Created by Codex at the maintainer's request. The complete design is in `doc/performance-monitoring.md` and GitHub issue #206.

## What changed

- instrument every real AE-200 list, detail, and set operation with monotonic lock-wait, WebSocket connect, command/response, close, and total timing;
- persist typed success/failure samples without changing AE-200 `status_json` or defeating `devlog` run-length compression;
- add an independent one-shot DNS, three-packet ICMP, and TCP-reject probe plus a once-per-minute systemd timer;
- add a bounded performance API and Deep Dive chart with filters, failures, raw phase timing, and rolling p50/p95 AE-200 latency;
- retain raw samples for 90 days by default through the existing daily runner;
- identify production, staging, web, runner, probe, and optional experiment samples without making staging read-only;
- document interpretation, deployment, and a controlled writable-staging load experiment.

The TCP probe deliberately targets a configurable port expected to have no listener. `ECONNREFUSED` is a successful `refused` observation because it measures the RST path. Timeouts and unreachable errors are failures; an unexpected accepted connection is recorded and highlighted before immediately closing.

Inline AE-200 telemetry fails immediately on SQLite write contention so monitoring cannot delay a control request. DNS probes prefer IPv4 when both families are returned, keeping the resolved literal portable across the Linux and macOS `ping` commands.

## Migration compatibility

The table is created by `R__performance_samples.sql`, an idempotent repeatable migration. This branch starts from main at V11 while PR #203 owns V12-V15. Flyway applies repeatable migrations after versioned migrations, avoiding a version collision whether this PR deploys before or after #203. A synthetic merge-tree check against `origin/new-rules` is clean.

## Deployment note

The application code and migration deploy normally. To start independent probes, install the checked-in `temperature-bot-performance-monitor.service` and `.timer` in `/etc/systemd/system`, reload systemd, and enable the timer. Confirm the configured closed port reports `refused`; use either the timer or the documented cron entry, not both.

## Validation

- `make check`
- `SKIP_BROWSER_TEST=1 make test` — 370 passed, 5 expected browser/hardware skips; all JavaScript tests passed
- real loopback end-to-end DNS, ICMP, TCP-refusal, and unexpected-listener coverage satisfies the patch coverage gate
- substantive tests use real SQLite contention, a real loopback TCP refusal, and a real local WebSocket/XML round trip
- visual regression workflow renders 23 pages, including a populated Performance Monitoring chart
- all five Copilot inline comments were fixed, replied to, and resolved

Closes #206
