### PR TITLE
Task/deg 12 aug broadway

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -873,6 +873,21 @@ def get_rooms(conn) -> list[Room]:
     return [_room_from_row(row) for row in c.fetchall()]
 
 
+def get_room_fcu_names(conn) -> dict[int, str]:
+    """Return the device name of each room's owning FCU, keyed by room id.
+
+    Resolving room keys one at a time meant a per-room lookup for every
+    candidate; one join answers the whole question. Rooms with no FCU (Garage,
+    Data Closet) are simply absent.
+    """
+    c = conn.cursor()
+    c.execute(
+        "SELECT r.room_id, d.device_name FROM rooms r "
+        "JOIN devices d ON d.device_id = r.fcu_device_id"
+    )
+    return {int(row["room_id"]): str(row["device_name"] or "") for row in c.fetchall()}
+
+
 def get_assigned_room_ids(conn) -> set[int]:
     """Return room ids referenced by any device, including devices without logs."""
     c = conn.cursor()

--- a/app/device_types.py
+++ b/app/device_types.py
@@ -32,11 +32,17 @@ class HubitatDevice(BaseModel):
 
 
 class HubitatControlAttributes(BaseModel):
-    """Control attributes returned by the Maker API single-device endpoint."""
+    """Control attributes returned by the Maker API single-device endpoint.
+
+    ``speed`` is reported by ``FanControl`` devices and is deliberately untyped:
+    Hubitat drivers publish their own vocabularies (``medium-low``, ``auto``,
+    ``on``), and rejecting an unfamiliar one would lose the whole reading.
+    """
 
     model_config = ConfigDict(extra="ignore")
     level: int | None = Field(default=None, ge=0, le=100)
     switch: Literal["on", "off"] | None = None
+    speed: str | None = None
 
 
 class HubitatControlDevice(BaseModel):

--- a/app/device_types.py
+++ b/app/device_types.py
@@ -2,7 +2,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 DEVICE_TYPE_SENSOR = "SENSOR"
 DEVICE_TYPE_FAN = "FAN"
@@ -50,6 +50,30 @@ class HubitatControlDevice(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
     attributes: HubitatControlAttributes = Field(default_factory=HubitatControlAttributes)
+
+    @field_validator("attributes", mode="before")
+    @classmethod
+    def _accept_either_attribute_shape(cls, value):
+        """Normalize the two shapes Maker API uses for ``attributes``.
+
+        ``/devices/all`` returns a mapping of name to value, but
+        ``/devices/<id>`` -- the endpoint room control status reads -- returns a
+        list of ``{name, currentValue, dataType}`` records. Only the mapping was
+        accepted, so every live control read failed validation and every room
+        dashboard reported its controls unreadable.
+
+        Where a device lists an attribute twice, as the Hue group driver does
+        for ``switch`` and ``colorName``, the last entry wins. Both entries
+        carried the same value in the observed payloads, so this picks an order
+        rather than resolving a real conflict.
+        """
+        if not isinstance(value, list):
+            return value
+        return {
+            entry["name"]: entry.get("currentValue")
+            for entry in value
+            if isinstance(entry, dict) and entry.get("name")
+        }
 
 
 FAN_CAPABILITIES = frozenset({"FanControl"})

--- a/app/device_types.py
+++ b/app/device_types.py
@@ -63,17 +63,21 @@ class HubitatControlDevice(BaseModel):
         dashboard reported its controls unreadable.
 
         Where a device lists an attribute twice, as the Hue group driver does
-        for ``switch`` and ``colorName``, the last entry wins. Both entries
-        carried the same value in the observed payloads, so this picks an order
-        rather than resolving a real conflict.
+        for ``switch`` and ``colorName``, the last entry that carries a value
+        wins. Preferring the last entry outright would let a trailing null
+        discard a real reading from an earlier one.
         """
         if not isinstance(value, list):
             return value
-        return {
-            entry["name"]: entry.get("currentValue")
-            for entry in value
-            if isinstance(entry, dict) and entry.get("name")
-        }
+        normalized: dict[str, object] = {}
+        for entry in value:
+            if not isinstance(entry, dict) or not entry.get("name"):
+                continue
+            current = entry.get("currentValue")
+            if current is None and entry["name"] in normalized:
+                continue
+            normalized[entry["name"]] = current
+        return normalized
 
 
 FAN_CAPABILITIES = frozenset({"FanControl"})

--- a/app/hubitat.py
+++ b/app/hubitat.py
@@ -242,6 +242,18 @@ def set_switch(device_id, state):
     return send_device_command(device_id, state)
 
 
+def set_fan_speed(device_id, speed):
+    """Set a Hubitat ``FanControl`` device's speed.
+
+    speed: one of ``off``, ``low``, ``medium``, ``high``
+
+    Sent through ``setSpeed`` rather than on/off so the device keeps reporting a
+    speed. Hubitat drivers accept more speeds than we offer; the narrower set is
+    a UI choice, not a driver limit.
+    """
+    return send_device_command(device_id, "setSpeed", str(speed))
+
+
 def _find_device_by_label(label):
     """Find a device by its Hubitat label. Raises RuntimeError if not found."""
     devices = get_all_devices()

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from . import ae200
 from . import db
+from . import room_config
 from . import routes_api
 from . import routes_web
 from .performance_routes import performance_routes
@@ -103,6 +104,9 @@ def create_app():
     def simulator_context():
         return {
             "ae200_simulator": bool(ae200.AE200_SIMULATOR),
+            "room_dashboards": sorted(
+                room_config.ROOM_CONFIGS.values(), key=lambda config: config.label
+            ),
             **json_ready(application_metadata()),
         }
 

--- a/app/models.py
+++ b/app/models.py
@@ -1136,11 +1136,17 @@ class RoomControlState(BaseModel):
     Only the fields a kind actually has are populated: ``level`` for dimmers,
     ``speed`` for fans. Unreadable devices are omitted from the response rather
     than reported with a guessed state.
+
+    Every field is optional for the same reason the whole control is omitted
+    when unreadable: a device that answers without an attribute has not told us
+    that attribute's value. Defaulting a missing ``switch`` to ``off`` would
+    show a running fan as stopped, and a missing ``level`` as ``0`` would show a
+    lit dimmer at zero percent.
     """
 
     key: str
     kind: RoomControlKind
-    switch: Literal["on", "off"]
+    switch: Literal["on", "off"] | None = None
     level: int | None = Field(default=None, ge=0, le=100)
     speed: str | None = None
 

--- a/app/models.py
+++ b/app/models.py
@@ -385,6 +385,13 @@ class RoomControl(BaseModel):
     )
     up_label: str | None = Field(default=None, description="TV-up component label.")
     down_label: str | None = Field(default=None, description="TV-down component label.")
+    unavailable_note: str | None = Field(
+        default=None,
+        description=(
+            "Why this control has no reachable device. Set it to render the "
+            "tile permanently unavailable instead of omitting the control."
+        ),
+    )
 
     @model_validator(mode="after")
     def _check_addressing(self) -> "RoomControl":
@@ -392,7 +399,18 @@ class RoomControl(BaseModel):
 
         A TV lift is driven through two Hubitat component switches addressed by
         label; every other kind is driven by device id.
+
+        A control with an ``unavailable_note`` is exempt and must carry no
+        device id. That combination is how a control we cannot reach yet stays
+        visible on the page: the alternative, a placeholder id, is how three of
+        these came to name unrelated devices on the wrong hub.
         """
+        if self.unavailable_note:
+            if self.device_id:
+                raise ValueError(
+                    f"control {self.key!r} has both a device_id and an unavailable_note"
+                )
+            return self
         if self.kind is RoomControlKind.TV:
             if not (self.up_label and self.down_label):
                 raise ValueError(f"TV control {self.key!r} needs up_label and down_label")
@@ -443,9 +461,15 @@ class RoomConfig(BaseModel):
         """Return the only control of a kind, for bodies that omit ``control``.
 
         Rooms with a single dimmer predate per-control addressing, so their
-        request bodies carry no control key.
+        request bodies carry no control key. Controls with no reachable device
+        do not count towards being the only one: Broadway has two unavailable
+        switches, which must not make a third switch ambiguous or absent.
         """
-        matches = [control for control in self.controls if control.kind is kind]
+        matches = [
+            control
+            for control in self.controls
+            if control.kind is kind and not control.unavailable_note
+        ]
         return matches[0] if len(matches) == 1 else None
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -447,7 +447,12 @@ class RoomConfig(BaseModel):
     )
 
     def find_control(self, key: str, kind: RoomControlKind) -> RoomControl | None:
-        """Return the configured control with this key and kind, if any."""
+        """Return the configured control with this key and kind, if any.
+
+        Unlike :meth:`sole_control` this returns controls with no reachable
+        device: they are configured, and a caller naming one deserves to be told
+        that its device is missing rather than that the key does not exist.
+        """
         return next(
             (
                 control

--- a/app/models.py
+++ b/app/models.py
@@ -1075,12 +1075,20 @@ class RoomDashboardSensorAttributes(BaseModel):
 
 
 class RoomDashboardSensor(BaseModel):
-    """One assigned sensor rendered by a canonical room dashboard."""
+    """One assigned sensor rendered by a canonical room dashboard.
+
+    ``stale_for`` carries the age of the last reading when it is too old to
+    trust, and is ``None`` while the reading is current. It replaces an earlier
+    ``offline`` flag: what we actually know is that we have not heard from the
+    device recently, not that the device is off. The runner or the hub could be
+    the thing that stopped, and saying how long ago lets a reader tell a brief
+    hiccup from a sensor that has been silent for days.
+    """
 
     id: int
     name: str
     display_name: str
-    offline: bool = False
+    stale_for: str | None = None
     attributes: RoomDashboardSensorAttributes
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -21,6 +21,7 @@ from enum import StrEnum
 from collections.abc import Callable
 from typing import Annotated, Any, Dict, Iterable, Literal
 from pydantic import (
+    AliasChoices,
     BaseModel,
     ConfigDict,
     Field,
@@ -357,21 +358,95 @@ class AlertHistoryEntry(BaseModel):
     )
 
 
+class RoomControlKind(StrEnum):
+    """How one configured room actuator is driven and rendered."""
+
+    SWITCH = "switch"
+    DIMMER = "dimmer"
+    FAN = "fan"
+    TV = "tv"
+
+
+class RoomControl(BaseModel):
+    """One actuator offered by a room dashboard.
+
+    ``key`` is the room-stable identifier used in control request bodies and in
+    the rendered DOM. It is chosen by configuration rather than derived from the
+    Hubitat device id, so a device can be replaced without changing the API.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    key: str = Field(min_length=1, description="Room-stable control identifier.")
+    kind: RoomControlKind = Field(description="How the control is driven.")
+    label: str = Field(min_length=1, description="Caption shown on the tile.")
+    device_id: str | None = Field(
+        default=None, description="Hubitat device id; unused by TV lifts."
+    )
+    up_label: str | None = Field(default=None, description="TV-up component label.")
+    down_label: str | None = Field(default=None, description="TV-down component label.")
+
+    @model_validator(mode="after")
+    def _check_addressing(self) -> "RoomControl":
+        """Require whichever addressing the control kind actually uses.
+
+        A TV lift is driven through two Hubitat component switches addressed by
+        label; every other kind is driven by device id.
+        """
+        if self.kind is RoomControlKind.TV:
+            if not (self.up_label and self.down_label):
+                raise ValueError(f"TV control {self.key!r} needs up_label and down_label")
+        elif not self.device_id:
+            raise ValueError(f"{self.kind} control {self.key!r} needs a device_id")
+        return self
+
+
 class RoomConfig(BaseModel):
-    """Static dashboard configuration for one room."""
+    """Static dashboard configuration for one room dashboard.
+
+    Sensor tiles are never configured here; they come from canonical
+    ``devices.room_id`` membership. ``members`` selects which rooms' sensors the
+    dashboard shows, and the remaining fields are deliberate presentation
+    choices about which actuators to offer.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     url: str = Field(description="Dashboard route for the room.")
+    label: str = Field(default="", description="Name shown in the Rooms menu.")
+    members: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Member room keys, each matched against a room name or the device "
+            "name of the FCU that owns the room. Empty means the dashboard "
+            "shows only the room it was addressed by."
+        ),
+    )
     ervs: list[str] = Field(default_factory=list, description="AE-200 ERV names.")
     fans: list[str] = Field(default_factory=list, description="AE-200 fan names.")
-    sensors: list[str] = Field(default_factory=list, description="Hubitat sensor names.")
-    tv_control: bool = Field(default=False, description="Whether to render TV controls.")
-    tv_up_label: str | None = Field(default=None, description="Hubitat TV-up label.")
-    tv_down_label: str | None = Field(default=None, description="Hubitat TV-down label.")
-    dimmer_id: str | None = Field(default=None, description="Hubitat dimmer device id.")
-    wall_inner_id: str | None = Field(default=None, description="Inner wall light device id.")
-    wall_outer_id: str | None = Field(default=None, description="Outer wall light device id.")
+    controls: list[RoomControl] = Field(
+        default_factory=list, description="Hubitat actuators offered by the dashboard."
+    )
+
+    def find_control(self, key: str, kind: RoomControlKind) -> RoomControl | None:
+        """Return the configured control with this key and kind, if any."""
+        return next(
+            (
+                control
+                for control in self.controls
+                if control.key == key and control.kind is kind
+            ),
+            None,
+        )
+
+    def sole_control(self, kind: RoomControlKind) -> RoomControl | None:
+        """Return the only control of a kind, for bodies that omit ``control``.
+
+        Rooms with a single dimmer predate per-control addressing, so their
+        request bodies carry no control key.
+        """
+        matches = [control for control in self.controls if control.kind is kind]
+        return matches[0] if len(matches) == 1 else None
 
 
 class MapPoint(BaseModel):
@@ -746,22 +821,54 @@ class DeviceRoomControl(ControlRequest):
 
 
 class RoomDimmerControl(ControlRequest):
-    """Request body for setting a room light dimmer level."""
+    """Request body for setting a room light dimmer level.
+
+    ``control`` may be omitted by a room offering exactly one dimmer, which is
+    the shape the Hickory dashboard has always sent.
+    """
 
     level: int = Field(ge=0, le=100, description="Dimmer level as a percentage.")
+    control: str | None = Field(default=None, description="Configured control key.")
 
 
-class RoomWallLightControl(ControlRequest):
-    """Request body for switching a room wall light on or off."""
+class RoomSwitchControl(ControlRequest):
+    """Request body for switching one configured room switch on or off.
 
-    light: Literal["inner", "outer"] = Field(description="Which wall light to switch.")
+    The control key is accepted as ``light`` as well as ``control``: the wall
+    lights this endpoint was built for send the former, and widening the field
+    rather than adding a second endpoint keeps one handler for both.
+    """
+
+    control: str = Field(
+        min_length=1,
+        validation_alias=AliasChoices("control", "light"),
+        serialization_alias="control",
+        description="Configured control key.",
+    )
     state: Literal["on", "off"] = Field(description="Requested switch state.")
+
+
+class RoomFanSpeed(StrEnum):
+    """Speeds a Hubitat ``FanControl`` device is commanded to."""
+
+    OFF = "off"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class RoomFanControl(ControlRequest):
+    """Request body for setting a configured room fan's speed."""
+
+    control: str = Field(min_length=1, description="Configured control key.")
+    speed: RoomFanSpeed = Field(description="Requested fan speed.")
 
 
 class RoomTvControl(ControlRequest):
     """Request body for driving a room TV lift."""
 
     direction: Literal["up", "down"] = Field(description="Requested lift direction.")
+    control: str | None = Field(default=None, description="Configured control key.")
 
 
 class DeviceDisableUntilControl(ControlRequest):
@@ -838,8 +945,11 @@ class CommandResponse(BaseModel):
     status: str = "ok"
     device_id: int | None = None
     level: int | None = None
-    light: str | None = None
+    control: str | None = None
     state: str | None = None
+    # Two subsystems answer with a speed: the AE-200 numbers its fan speeds,
+    # while a Hubitat FanControl device names them.
+    speed: int | str | None = None
     direction: str | None = None
 
 
@@ -1012,24 +1122,25 @@ class RoomPresenceResponse(BaseModel):
     rooms: list[RoomPresence]
 
 
-class RoomSwitchState(BaseModel):
-    """Current state of one room switch."""
+class RoomControlState(BaseModel):
+    """Current state of one configured room actuator.
 
+    Only the fields a kind actually has are populated: ``level`` for dimmers,
+    ``speed`` for fans. Unreadable devices are omitted from the response rather
+    than reported with a guessed state.
+    """
+
+    key: str
+    kind: RoomControlKind
     switch: Literal["on", "off"]
-
-
-class RoomDimmerState(RoomSwitchState):
-    """Current level and switch state of one room dimmer."""
-
-    level: int = Field(ge=0, le=100)
+    level: int | None = Field(default=None, ge=0, le=100)
+    speed: str | None = None
 
 
 class RoomControlStatus(BaseModel):
-    """Available actuator states for a room dashboard."""
+    """Readable actuator states for a room dashboard."""
 
-    dimmer: RoomDimmerState | None = None
-    wall_inner: RoomSwitchState | None = None
-    wall_outer: RoomSwitchState | None = None
+    controls: list[RoomControlState] = Field(default_factory=list)
 
 
 class PresenceHistoryResponse(BaseModel):

--- a/app/room_config.py
+++ b/app/room_config.py
@@ -9,6 +9,13 @@ A ``members`` entry is matched against a room name or against the device name of
 the FCU that owns the room. Prefer the FCU name where one exists: FCU names are
 hardware identity and survive a room rename, while a room with no FCU (Garage,
 Data Closet) can only be named directly.
+
+Every ``device_id`` here is a device id **on hub 10.2.3.51**, the hub configured
+in ``temperature-bot-config.yaml``. Ids are per hub and are not interchangeable:
+the same physical sensor carries different ids on each hub it is meshed onto, so
+an id copied from another hub's dashboard is at best dead and at worst names a
+different device. Read ids from that hub, for example with
+``poetry run python -m app.hubitat --list-devices``.
 """
 
 from .models import RoomConfig, RoomControl, RoomControlKind
@@ -64,9 +71,12 @@ ROOM_CONFIGS: dict[str, RoomConfig] = {
     # room to address. The Garage and Sidewalk switches are just outside the
     # space and are driven from here on purpose.
     #
-    # Every control below is a device on Hubitat hub 10.2.3.52. We only reach
-    # 10.2.3.51 (Maker API app 520), so these tiles read as unavailable until
-    # the devices are exposed there. See doc/hardware-landscape.md.
+    # These ids came originally from the Hubitat dashboard on hub 10.2.3.52 and
+    # were wrong: device ids are per hub, and three of them named unrelated
+    # devices here (.52's 291 "Broadway Pendant Lights" is 291 "Kitchen Counter
+    # Lights" on .51). They are now the ids on 10.2.3.51, the only hub we reach.
+    # Two Broadway TV Cart switches are deliberately absent: they exist only on
+    # .52, and a placeholder id would be the same hazard again.
     "broadway": RoomConfig(
         url="/broadway",
         label="Broadway",
@@ -74,64 +84,52 @@ ROOM_CONFIGS: dict[str, RoomConfig] = {
         fans=["Broadway North", "Broadway South"],
         controls=[
             RoomControl(
-                key="tv-cart-left",
-                kind=RoomControlKind.SWITCH,
-                label="TV Cart Left",
-                device_id="395",
-            ),
-            RoomControl(
-                key="tv-cart-right",
-                kind=RoomControlKind.SWITCH,
-                label="TV Cart Right",
-                device_id="396",
-            ),
-            RoomControl(
                 key="pendant-lights",
                 kind=RoomControlKind.SWITCH,
                 label="Pendant Lights",
-                device_id="291",
+                device_id="260",
             ),
             RoomControl(
                 key="spot-lights",
                 kind=RoomControlKind.SWITCH,
                 label="Spot Lights",
-                device_id="393",
+                device_id="616",
             ),
             RoomControl(
                 key="whiteboard-washer",
                 kind=RoomControlKind.SWITCH,
                 label="Whiteboard Washer",
-                device_id="293",
+                device_id="356",
             ),
             RoomControl(
                 key="sidewalk-washer-north",
                 kind=RoomControlKind.SWITCH,
                 label="Sidewalk Washer North",
-                device_id="294",
+                device_id="354",
             ),
             RoomControl(
                 key="sidewalk-washer-south",
                 kind=RoomControlKind.SWITCH,
                 label="Sidewalk Washer South",
-                device_id="295",
+                device_id="355",
             ),
             RoomControl(
                 key="garage-washer-north",
                 kind=RoomControlKind.SWITCH,
                 label="Garage Washer North",
-                device_id="136",
+                device_id="360",
             ),
             RoomControl(
                 key="garage-washer-south",
                 kind=RoomControlKind.SWITCH,
                 label="Garage Washer South",
-                device_id="297",
+                device_id="361",
             ),
             RoomControl(
                 key="data-closet-fan",
                 kind=RoomControlKind.FAN,
                 label="Data Closet Fan",
-                device_id="137",
+                device_id="359",
             ),
         ],
     ),

--- a/app/room_config.py
+++ b/app/room_config.py
@@ -1,29 +1,139 @@
-"""Configuration for room dashboards (kitchen/hickory).
+"""Configuration for room dashboards.
 
-Each legacy dashboard specifies actuator controls. Sensor membership comes from
-canonical ``devices.room_id`` assignments.
+Sensor tiles are not configured here. They come from canonical
+``devices.room_id`` assignments; ``members`` only selects which rooms' sensors a
+dashboard gathers. What is configured here is deliberate presentation: which
+AE-200 units and which Hubitat actuators a dashboard offers.
+
+A ``members`` entry is matched against a room name or against the device name of
+the FCU that owns the room. Prefer the FCU name where one exists: FCU names are
+hardware identity and survive a room rename, while a room with no FCU (Garage,
+Data Closet) can only be named directly.
 """
 
-from .models import RoomConfig
+from .models import RoomConfig, RoomControl, RoomControlKind
 
 EMPTY_ROOM_CONFIG = RoomConfig(url="")
 
 ROOM_CONFIGS: dict[str, RoomConfig] = {
     "kitchen": RoomConfig(
         url="/kitchen",
+        label="Kitchen",
+        members=["kitchen"],
         ervs=["ERV Kitchen"],
         fans=["Kitchen"],
     ),
     "hickory": RoomConfig(
         url="/hickory",
+        label="Hickory",
+        members=["hickory"],
         ervs=["ERV Restrooms"],
         fans=["Restrooms/BOH", "Dungeon"],
-        tv_control=True,
-        tv_up_label="TV Up",
-        tv_down_label="TV Down",
-        dimmer_id="581",
-        wall_inner_id="454",
-        wall_outer_id="550",
+        controls=[
+            RoomControl(
+                key="tv",
+                kind=RoomControlKind.TV,
+                label="TV",
+                up_label="TV Up",
+                down_label="TV Down",
+            ),
+            RoomControl(
+                key="main",
+                kind=RoomControlKind.DIMMER,
+                label="Main Lights",
+                device_id="581",
+            ),
+            # Keyed "inner"/"outer" because that is what the wall-light request
+            # body has always sent as its control key.
+            RoomControl(
+                key="inner",
+                kind=RoomControlKind.SWITCH,
+                label="Green Wall - Inner",
+                device_id="454",
+            ),
+            RoomControl(
+                key="outer",
+                kind=RoomControlKind.SWITCH,
+                label="Green Wall - Outer",
+                device_id="550",
+            ),
+        ],
+    ),
+    # Broadway spans four canonical rooms: the space is served by two FCUs, and
+    # each FCU owns its own room, so there is deliberately no single "Broadway"
+    # room to address. The Garage and Sidewalk switches are just outside the
+    # space and are driven from here on purpose.
+    #
+    # Every control below is a device on Hubitat hub 10.2.3.52. We only reach
+    # 10.2.3.51 (Maker API app 520), so these tiles read as unavailable until
+    # the devices are exposed there. See doc/hardware-landscape.md.
+    "broadway": RoomConfig(
+        url="/broadway",
+        label="Broadway",
+        members=["Broadway North", "Broadway South", "Data Closet", "Garage"],
+        fans=["Broadway North", "Broadway South"],
+        controls=[
+            RoomControl(
+                key="tv-cart-left",
+                kind=RoomControlKind.SWITCH,
+                label="TV Cart Left",
+                device_id="395",
+            ),
+            RoomControl(
+                key="tv-cart-right",
+                kind=RoomControlKind.SWITCH,
+                label="TV Cart Right",
+                device_id="396",
+            ),
+            RoomControl(
+                key="pendant-lights",
+                kind=RoomControlKind.SWITCH,
+                label="Pendant Lights",
+                device_id="291",
+            ),
+            RoomControl(
+                key="spot-lights",
+                kind=RoomControlKind.SWITCH,
+                label="Spot Lights",
+                device_id="393",
+            ),
+            RoomControl(
+                key="whiteboard-washer",
+                kind=RoomControlKind.SWITCH,
+                label="Whiteboard Washer",
+                device_id="293",
+            ),
+            RoomControl(
+                key="sidewalk-washer-north",
+                kind=RoomControlKind.SWITCH,
+                label="Sidewalk Washer North",
+                device_id="294",
+            ),
+            RoomControl(
+                key="sidewalk-washer-south",
+                kind=RoomControlKind.SWITCH,
+                label="Sidewalk Washer South",
+                device_id="295",
+            ),
+            RoomControl(
+                key="garage-washer-north",
+                kind=RoomControlKind.SWITCH,
+                label="Garage Washer North",
+                device_id="136",
+            ),
+            RoomControl(
+                key="garage-washer-south",
+                kind=RoomControlKind.SWITCH,
+                label="Garage Washer South",
+                device_id="297",
+            ),
+            RoomControl(
+                key="data-closet-fan",
+                kind=RoomControlKind.FAN,
+                label="Data Closet Fan",
+                device_id="137",
+            ),
+        ],
     ),
 }
 

--- a/app/room_config.py
+++ b/app/room_config.py
@@ -75,14 +75,28 @@ ROOM_CONFIGS: dict[str, RoomConfig] = {
     # were wrong: device ids are per hub, and three of them named unrelated
     # devices here (.52's 291 "Broadway Pendant Lights" is 291 "Kitchen Counter
     # Lights" on .51). They are now the ids on 10.2.3.51, the only hub we reach.
-    # Two Broadway TV Cart switches are deliberately absent: they exist only on
-    # .52, and a placeholder id would be the same hazard again.
+    # The two TV Cart switches carry no id at all: they exist only on .52, and a
+    # placeholder would be the same hazard again. They stay on the page as
+    # visibly unavailable tiles so the missing hardware is obvious rather than
+    # quietly absent.
     "broadway": RoomConfig(
         url="/broadway",
         label="Broadway",
         members=["Broadway North", "Broadway South", "Data Closet", "Garage"],
         fans=["Broadway North", "Broadway South"],
         controls=[
+            RoomControl(
+                key="tv-cart-left",
+                kind=RoomControlKind.SWITCH,
+                label="TV Cart Left",
+                unavailable_note="Only on hub 10.2.3.52; not meshed onto 10.2.3.51",
+            ),
+            RoomControl(
+                key="tv-cart-right",
+                kind=RoomControlKind.SWITCH,
+                label="TV Cart Right",
+                unavailable_note="Only on hub 10.2.3.52; not meshed onto 10.2.3.51",
+            ),
             RoomControl(
                 key="pendant-lights",
                 kind=RoomControlKind.SWITCH,

--- a/app/routes_api.py
+++ b/app/routes_api.py
@@ -57,13 +57,16 @@ from .models import (
     RoomPatch,
     PresenceHistoryResponse,
     RoomPresenceResponse,
+    RoomConfig,
+    RoomControl,
+    RoomControlKind,
+    RoomControlState,
     RoomControlStatus,
     RoomDimmerControl,
-    RoomDimmerState,
+    RoomFanControl,
+    RoomSwitchControl,
     RoomTvControl,
-    RoomWallLightControl,
     RulesMasterControl,
-    RoomSwitchState,
     SetTempControl,
     SpeedControl,
     TemperatureSeriesResponse,
@@ -665,7 +668,7 @@ def update_note(conn, body: NoteControl):
     return jsonify(json_ready(CommandResponse(device_id=device_id)))
 
 
-def _require_room_config(room_key: str):
+def _require_room_config(room_key: str) -> RoomConfig:
     """Return the dashboard configuration for a room key, or raise 404."""
     config = room_config.find_room_config(room_key.casefold())
     if config is None:
@@ -673,81 +676,150 @@ def _require_room_config(room_key: str):
     return config
 
 
-@api_v1.route("/hickory/room_status", defaults={"room_key": "hickory"})
+def _require_control(
+    config: RoomConfig, key: str | None, kind: RoomControlKind
+) -> RoomControl:
+    """Return one configured control, or raise 404 naming what was not found.
+
+    A body may omit the control key when the room offers exactly one control of
+    that kind, which is the shape the wall-mounted dashboards have always sent.
+    """
+    control = (
+        config.sole_control(kind) if key is None else config.find_control(key, kind)
+    )
+    if control is None:
+        raise NotFound(f"No {kind} control {key!r} configured" if key else f"No {kind} configured")
+    return control
+
+
+# Hubitat devices that are configured but unreachable would otherwise log once
+# per control per poll, which at a ten-second refresh buries everything else.
+# Warn on the transition into failure and again on recovery, not in between.
+_failed_control_devices: set[str] = set()
+
+
+def _read_control_device(device_id: str) -> HubitatControlDevice | None:
+    """Read one control device's live attributes, or None when unreadable."""
+    try:
+        device = HubitatControlDevice.model_validate(hubitat.get_device_info(device_id))
+    except (RuntimeError, OSError, ValueError) as e:
+        if device_id not in _failed_control_devices:
+            _failed_control_devices.add(device_id)
+            logger.warning("Room device %s status fetch failed: %s", device_id, e)
+        return None
+    if device_id in _failed_control_devices:
+        _failed_control_devices.discard(device_id)
+        logger.info("Room device %s status fetch recovered", device_id)
+    return device
+
+
+@api_v1.route(
+    "/hickory/room_status",
+    defaults={"room_key": "hickory"},
+    endpoint="hickory_room_status",
+)
 @api_v1.route("/room/<room_key>/room_status")
 def room_control_status(room_key: str):
-    """Return current state of one configured room's control devices."""
+    """Return current state of one configured room's control devices.
+
+    TV lifts are momentary and report no state, so they are absent here; so is
+    any control whose device could not be read.
+    """
     config = _require_room_config(room_key)
-    result = RoomControlStatus()
-
-    def read_device(device_id: str | None) -> HubitatControlDevice | None:
-        if device_id is None:
-            return None
-        try:
-            return HubitatControlDevice.model_validate(hubitat.get_device_info(device_id))
-        except (RuntimeError, OSError, ValueError) as e:
-            logger.warning("Room device %s status fetch failed: %s", device_id, e)
-            return None
-
-    if dimmer := read_device(config.dimmer_id):
-        result.dimmer = RoomDimmerState(
-            level=dimmer.attributes.level or 0,
-            switch=dimmer.attributes.switch or "off",
+    states = []
+    for control in config.controls:
+        if control.device_id is None:
+            continue
+        device = _read_control_device(control.device_id)
+        if device is None:
+            continue
+        states.append(
+            RoomControlState(
+                key=control.key,
+                kind=control.kind,
+                switch=device.attributes.switch or "off",
+                level=(
+                    device.attributes.level or 0
+                    if control.kind is RoomControlKind.DIMMER
+                    else None
+                ),
+                speed=(
+                    device.attributes.speed
+                    if control.kind is RoomControlKind.FAN
+                    else None
+                ),
+            )
         )
-    if wall_inner := read_device(config.wall_inner_id):
-        result.wall_inner = RoomSwitchState(
-            switch=wall_inner.attributes.switch or "off"
-        )
-    if wall_outer := read_device(config.wall_outer_id):
-        result.wall_outer = RoomSwitchState(
-            switch=wall_outer.attributes.switch or "off"
-        )
-    return jsonify(json_ready(result))
+    return jsonify(json_ready(RoomControlStatus(controls=states)))
 
 
-@api_v1.route("/hickory/dimmer", methods=["POST"], defaults={"room_key": "hickory"})
+@api_v1.route(
+    "/hickory/dimmer",
+    methods=["POST"],
+    defaults={"room_key": "hickory"},
+    endpoint="hickory_dimmer",
+)
 @api_v1.route("/room/<room_key>/dimmer", methods=["POST"])
 @validate()
 def room_dimmer(room_key: str, body: RoomDimmerControl):
     """Set a configured room's light dimmer level (0-100)."""
     config = _require_room_config(room_key)
-    device_id = config.dimmer_id
-    if not device_id:
-        raise NotFound("No dimmer configured")
+    control = _require_control(config, body.control, RoomControlKind.DIMMER)
     with _hubitat_control("Dimmer"):
-        hubitat.set_dimmer_level(device_id, body.level)
+        hubitat.set_dimmer_level(control.device_id, body.level)
     return jsonify(json_ready(CommandResponse(level=body.level)))
 
 
-@api_v1.route("/hickory/wall_light", methods=["POST"], defaults={"room_key": "hickory"})
+@api_v1.route(
+    "/hickory/wall_light",
+    methods=["POST"],
+    defaults={"room_key": "hickory"},
+    endpoint="hickory_wall_light",
+)
 @api_v1.route("/room/<room_key>/wall_light", methods=["POST"])
+@api_v1.route("/room/<room_key>/switch", methods=["POST"])
 @validate()
-def room_wall_light(room_key: str, body: RoomWallLightControl):
-    """Toggle a configured room's wall light on or off."""
+def room_switch(room_key: str, body: RoomSwitchControl):
+    """Switch one configured room control on or off.
+
+    Reachable as ``/switch`` and, for the wall lights it was introduced for, as
+    ``/wall_light`` with the control key spelled ``light``.
+    """
     config = _require_room_config(room_key)
-    id_map = {"inner": config.wall_inner_id, "outer": config.wall_outer_id}
-    device_id = id_map.get(body.light)
-    if not device_id:
-        # The name is valid but this room has no such light configured.
-        raise NotFound(f"No {body.light} wall light configured")
-    with _hubitat_control("Wall light"):
-        hubitat.set_switch(device_id, body.state)
-    return jsonify(json_ready(CommandResponse(light=body.light, state=body.state)))
+    control = _require_control(config, body.control, RoomControlKind.SWITCH)
+    with _hubitat_control("Switch"):
+        hubitat.set_switch(control.device_id, body.state)
+    return jsonify(json_ready(CommandResponse(control=control.key, state=body.state)))
 
 
-@api_v1.route("/hickory/tv", methods=["POST"], defaults={"room_key": "hickory"})
+@api_v1.route("/room/<room_key>/fan", methods=["POST"])
+@validate()
+def room_fan(room_key: str, body: RoomFanControl):
+    """Set a configured room fan's speed."""
+    config = _require_room_config(room_key)
+    control = _require_control(config, body.control, RoomControlKind.FAN)
+    with _hubitat_control("Fan"):
+        hubitat.set_fan_speed(control.device_id, body.speed)
+    return jsonify(json_ready(CommandResponse(speed=body.speed)))
+
+
+@api_v1.route(
+    "/hickory/tv",
+    methods=["POST"],
+    defaults={"room_key": "hickory"},
+    endpoint="hickory_tv",
+)
 @api_v1.route("/room/<room_key>/tv", methods=["POST"])
 @validate()
 def room_tv(room_key: str, body: RoomTvControl):
     """Control a configured room's TV lift (up/down)."""
     config = _require_room_config(room_key)
-    if not config.tv_up_label or not config.tv_down_label:
-        raise NotFound("No TV configured")
+    control = _require_control(config, body.control, RoomControlKind.TV)
     with _hubitat_control("TV"):
         hubitat.control_room_tv(
             body.direction,
-            up_label=config.tv_up_label,
-            down_label=config.tv_down_label,
+            up_label=control.up_label,
+            down_label=control.down_label,
         )
     return jsonify(json_ready(CommandResponse(direction=body.direction)))
 

--- a/app/routes_api.py
+++ b/app/routes_api.py
@@ -706,13 +706,25 @@ _failed_control_devices: set[str] = set()
 
 
 def _read_control_device(device_id: str) -> HubitatControlDevice | None:
-    """Read one control device's live attributes, or None when unreadable."""
+    """Read one control device's live attributes, or None when unreadable.
+
+    A payload carrying no ``attributes`` key at all is not a device description,
+    so it counts as unreadable rather than as a device that happens to report
+    nothing. An empty attribute list is the latter and is kept: the device
+    answered, we simply learned no state from it.
+    """
     try:
-        device = HubitatControlDevice.model_validate(hubitat.get_device_info(device_id))
+        payload = hubitat.get_device_info(device_id)
+        if not isinstance(payload, dict) or "attributes" not in payload:
+            raise ValueError(f"no attributes in payload: {payload!r:.120}")
+        device = HubitatControlDevice.model_validate(payload)
     except (RuntimeError, OSError, ValueError) as e:
         if device_id not in _failed_control_devices:
             _failed_control_devices.add(device_id)
-            logger.warning("Room device %s status fetch failed: %s", device_id, e)
+            # "Unreadable" covers both a failed request and a payload we could
+            # not make sense of. Saying "fetch failed" for the second would send
+            # someone hunting a network problem that is not there.
+            logger.warning("Room device %s unreadable: %s", device_id, e)
         return None
     if device_id in _failed_control_devices:
         _failed_control_devices.discard(device_id)

--- a/app/routes_api.py
+++ b/app/routes_api.py
@@ -684,11 +684,14 @@ def _require_control(
     A body may omit the control key when the room offers exactly one control of
     that kind, which is the shape the wall-mounted dashboards have always sent.
     """
-    control = (
-        config.sole_control(kind) if key is None else config.find_control(key, kind)
-    )
+    if key is None:
+        control = config.sole_control(kind)
+        if control is None:
+            raise NotFound(f"No {kind} configured")
+        return control
+    control = config.find_control(key, kind)
     if control is None:
-        raise NotFound(f"No {kind} control {key!r} configured" if key else f"No {kind} configured")
+        raise NotFound(f"No {kind} control {key!r} configured")
     return control
 
 
@@ -737,9 +740,12 @@ def room_control_status(room_key: str):
             RoomControlState(
                 key=control.key,
                 kind=control.kind,
-                switch=device.attributes.switch or "off",
+                # Pass attributes through as reported. An absent attribute is
+                # reported absent rather than defaulted, so the page never shows
+                # a running fan as off or a lit dimmer at zero.
+                switch=device.attributes.switch,
                 level=(
-                    device.attributes.level or 0
+                    device.attributes.level
                     if control.kind is RoomControlKind.DIMMER
                     else None
                 ),

--- a/app/routes_api.py
+++ b/app/routes_api.py
@@ -688,10 +688,14 @@ def _require_control(
         control = config.sole_control(kind)
         if control is None:
             raise NotFound(f"No {kind} configured")
-        return control
-    control = config.find_control(key, kind)
-    if control is None:
-        raise NotFound(f"No {kind} control {key!r} configured")
+    else:
+        control = config.find_control(key, kind)
+        if control is None:
+            raise NotFound(f"No {kind} control {key!r} configured")
+    if control.unavailable_note:
+        # Rendered on the page so the gap is visible, but there is no device to
+        # command, so a request for one is as much a 404 as an unknown key.
+        raise NotFound(f"Control {control.key!r} has no reachable device")
     return control
 
 

--- a/app/routes_web.py
+++ b/app/routes_web.py
@@ -23,7 +23,6 @@ from .version import __version__
 from . import db
 from . import db_alerts
 from . import rules_engine
-from . import hubitat
 from . import room_config
 from .display_names import display_device_name
 from .dashboard_views import build_dashboard_page
@@ -360,54 +359,30 @@ def _filter_speed_control_devices(devices, device_names):
     ]
 
 
-def _get_hubitat_sensors(sensor_names):
-    """Fetch and filter Hubitat temperature sensors by exact name match.
+def _canonical_room_sensors(conn, room_ids: set[int]) -> list[RoomDashboardSensor]:
+    """Build room sensor tiles from persisted assignment and shared freshness.
 
-    Returns an entry for every configured name.  Sensors not found in
-    Hubitat (or unreachable) are represented as placeholder dicts with
-    ``offline=True`` so the template can still render them.
+    A dashboard may span several rooms (Broadway is served by two FCUs, and each
+    FCU owns its own room), so membership is a set. Freshness is still selected
+    per room, because the shared selector answers questions about one room.
     """
-    if not sensor_names:
-        return []
-
-    try:
-        all_hubitat = hubitat.get_all_devices()
-    except (ValueError, RuntimeError, OSError) as e:
-        logger.warning("Failed to fetch Hubitat sensors: %s", e)
-        all_hubitat = []
-
-    found = [
-        dev
-        for dev in all_hubitat
-        if "TemperatureMeasurement" in dev.get("capabilities", [])
-        and dev.get("name") in sensor_names
-    ]
-    found_names = {dev.get("name") for dev in found}
-
-    for name in sensor_names:
-        if name not in found_names:
-            logger.warning("Configured sensor %r not found in Hubitat", name)
-            found.append({"name": name, "label": name, "offline": True, "attributes": {}})
-
-    return found
-
-
-def _canonical_room_sensors(conn, room_id: int) -> list[RoomDashboardSensor]:
-    """Build room sensor tiles from persisted assignment and shared freshness."""
     snapshots = db.fetch_latest_room_metric_snapshots(conn)
     at_time = time.time()
-    temperatures = select_room_metric_sources(
-        snapshots, room_id=room_id, metric=RoomMetric.TEMPERATURE, at_time=at_time
-    )
-    humidities = select_room_metric_sources(
-        snapshots, room_id=room_id, metric=RoomMetric.HUMIDITY, at_time=at_time
-    )
-    temperature_by_device = {
-        source.device_id: source.value for source in temperatures.sources
-    }
-    humidity_by_device = {
-        source.device_id: source.value for source in humidities.sources
-    }
+    temperature_by_device: dict[int, float] = {}
+    humidity_by_device: dict[int, float] = {}
+    for room_id in room_ids:
+        temperatures = select_room_metric_sources(
+            snapshots, room_id=room_id, metric=RoomMetric.TEMPERATURE, at_time=at_time
+        )
+        humidities = select_room_metric_sources(
+            snapshots, room_id=room_id, metric=RoomMetric.HUMIDITY, at_time=at_time
+        )
+        temperature_by_device.update(
+            {source.device_id: source.value for source in temperatures.sources}
+        )
+        humidity_by_device.update(
+            {source.device_id: source.value for source in humidities.sources}
+        )
     return sorted(
         [
             RoomDashboardSensor(
@@ -425,7 +400,7 @@ def _canonical_room_sensors(conn, room_id: int) -> list[RoomDashboardSensor]:
                 ),
             )
             for snapshot in snapshots
-            if snapshot.room_id == room_id
+            if snapshot.room_id in room_ids
             and snapshot.device_type
             not in {DEVICE_TYPE_FCU, DEVICE_TYPE_ERV, DEVICE_TYPE_INTERNAL}
             and snapshot.temp10x is not None
@@ -444,40 +419,81 @@ def _collect_device_notes(devices):
     return " | ".join(notes) if notes else None
 
 
+def _owning_fcu_name(conn, room: Room | None) -> str:
+    """Return the casefolded device name of the FCU that owns a room."""
+    if not (room and room.fcu_device_id):
+        return ""
+    owner = db.get_device(conn, room.fcu_device_id)
+    return str((owner or {}).get("device_name") or "").casefold()
+
+
 def _room_control_key(conn, room: Room | None, fallback: str) -> str:
     """Bind configured controls to the room's stable owning FCU identity."""
-    if room and room.fcu_device_id:
-        owner = db.get_device(conn, room.fcu_device_id)
-        owner_key = str((owner or {}).get("device_name") or "").casefold()
-        if room_config.find_room_config(owner_key) is not None:
-            return owner_key
+    owner_key = _owning_fcu_name(conn, room)
+    if owner_key and room_config.find_room_config(owner_key) is not None:
+        return owner_key
     return fallback.casefold()
+
+
+def _find_room(conn, rooms: list[Room], key: str) -> Room | None:
+    """Resolve one room key against a room name, then an owning FCU name.
+
+    Both spellings are accepted because neither alone covers the rooms we need
+    to address: an FCU name survives a room rename, but a room with no FCU can
+    only be named directly.
+    """
+    wanted = key.casefold()
+    by_name = next(
+        (
+            candidate
+            for candidate in rooms
+            if (candidate.room_name or "").casefold() == wanted
+        ),
+        None,
+    )
+    if by_name is not None:
+        return by_name
+    return next(
+        (
+            candidate
+            for candidate in rooms
+            if _owning_fcu_name(conn, candidate) == wanted
+        ),
+        None,
+    )
+
+
+def _member_room_ids(conn, rooms: list[Room], config, addressed: Room | None) -> set[int]:
+    """Resolve a dashboard's member rooms, warning about keys that match nothing.
+
+    Membership is keyed by name, so renaming a member room silently drops it.
+    Log the miss rather than rendering a quietly incomplete dashboard.
+    """
+    if not config.members:
+        return {addressed.room_id} if addressed and addressed.room_id else set()
+    room_ids = set()
+    for key in config.members:
+        member = _find_room(conn, rooms, key)
+        if member is None or member.room_id is None:
+            logger.warning(
+                "Room dashboard member %r matches no room name or FCU name", key
+            )
+            continue
+        room_ids.add(member.room_id)
+    return room_ids
 
 
 def _render_room_dashboard_with_data(conn, location: str, room_id: int | None = None):
     """Render room dashboard with device data filtered by configuration."""
-    room_key = location.lower()
     rooms = db.get_rooms(conn)
-    room = db.get_room(conn, room_id) if room_id is not None else next(
-        (
-            candidate
-            for candidate in rooms
-            if (candidate.room_name or "").casefold() == room_key
-        ),
-        None,
+    room = (
+        db.get_room(conn, room_id)
+        if room_id is not None
+        else _find_room(conn, rooms, location)
     )
-    if room is None and room_id is None:
-        room = next(
-            (
-                candidate
-                for candidate in rooms
-                if _room_control_key(conn, candidate, "") == room_key
-            ),
-            None,
-        )
     if room_id is not None and room is None:
         return "Unknown room", 404
-    control_key = _room_control_key(conn, room, room_key)
+    control_key = _room_control_key(conn, room, location)
     config = room_config.get_room_config(control_key)
 
     all_devices = db.get_device_status(conn)
@@ -487,10 +503,8 @@ def _render_room_dashboard_with_data(conn, location: str, room_id: int | None = 
 
     fan_devices = _filter_speed_control_devices(all_devices, config.fans)
 
-    hubitat_sensors = (
-        _canonical_room_sensors(conn, room.room_id)
-        if room and room.room_id
-        else []
+    hubitat_sensors = _canonical_room_sensors(
+        conn, _member_room_ids(conn, rooms, config, room)
     )
 
     # Collect notes
@@ -507,10 +521,7 @@ def _render_room_dashboard_with_data(conn, location: str, room_id: int | None = 
         fan_devices=fan_devices,
         hubitat_sensors=hubitat_sensors,
         notes=notes,
-        show_tv_control=config.tv_control,
-        dimmer_id=config.dimmer_id,
-        wall_inner_id=config.wall_inner_id,
-        wall_outer_id=config.wall_outer_id,
+        room_controls=config.controls,
         room_control_key=control_key,
     )
 
@@ -578,6 +589,12 @@ def _register_room_routes(app):
     def hickory_dashboard(conn):
         """Hickory HVAC control dashboard."""
         return _render_room_dashboard_with_data(conn, "Hickory")
+
+    @app.route("/broadway")
+    @with_db_connection
+    def broadway_dashboard(conn):
+        """Broadway dashboard, spanning the rooms its two FCUs own."""
+        return _render_room_dashboard_with_data(conn, "Broadway")
 
     @app.get("/room/<int:room_id>")
     @with_db_connection

--- a/app/routes_web.py
+++ b/app/routes_web.py
@@ -26,6 +26,7 @@ from . import rules_engine
 from . import room_config
 from .display_names import display_device_name
 from .dashboard_views import build_dashboard_page
+from .util import github_style_duration
 from .models import (
     DeviceMetadataControl,
     Room,
@@ -389,7 +390,15 @@ def _canonical_room_sensors(conn, room_ids: set[int]) -> list[RoomDashboardSenso
                 id=snapshot.device_id,
                 name=snapshot.device_name,
                 display_name=snapshot.display_name or snapshot.device_name,
-                offline=snapshot.device_id not in temperature_by_device,
+                stale_for=(
+                    None
+                    if snapshot.device_id in temperature_by_device
+                    # The reading stops being valid at logtime + duration, so
+                    # that, not logtime, is the moment we last had current data.
+                    else github_style_duration(
+                        snapshot.logtime + snapshot.duration, now=at_time
+                    )
+                ),
                 attributes=RoomDashboardSensorAttributes(
                     temperature=temperature_by_device.get(snapshot.device_id),
                     humidity=(

--- a/app/routes_web.py
+++ b/app/routes_web.py
@@ -30,6 +30,7 @@ from .util import github_style_duration
 from .models import (
     DeviceMetadataControl,
     Room,
+    RoomConfig,
     RoomDashboardSensor,
     RoomDashboardSensorAttributes,
 )
@@ -428,28 +429,32 @@ def _collect_device_notes(devices):
     return " | ".join(notes) if notes else None
 
 
-def _owning_fcu_name(conn, room: Room | None) -> str:
+def _owning_fcu_name(fcu_names: dict[int, str], room: Room | None) -> str:
     """Return the casefolded device name of the FCU that owns a room."""
-    if not (room and room.fcu_device_id):
+    if room is None or room.room_id is None:
         return ""
-    owner = db.get_device(conn, room.fcu_device_id)
-    return str((owner or {}).get("device_name") or "").casefold()
+    return fcu_names.get(room.room_id, "").casefold()
 
 
-def _room_control_key(conn, room: Room | None, fallback: str) -> str:
+def _room_control_key(
+    fcu_names: dict[int, str], room: Room | None, fallback: str
+) -> str:
     """Bind configured controls to the room's stable owning FCU identity."""
-    owner_key = _owning_fcu_name(conn, room)
+    owner_key = _owning_fcu_name(fcu_names, room)
     if owner_key and room_config.find_room_config(owner_key) is not None:
         return owner_key
     return fallback.casefold()
 
 
-def _find_room(conn, rooms: list[Room], key: str) -> Room | None:
+def _find_room(
+    rooms: list[Room], fcu_names: dict[int, str], key: str
+) -> Room | None:
     """Resolve one room key against a room name, then an owning FCU name.
 
     Both spellings are accepted because neither alone covers the rooms we need
     to address: an FCU name survives a room rename, but a room with no FCU can
-    only be named directly.
+    only be named directly. Room name wins, so a room deliberately named after
+    another room's FCU still resolves to itself.
     """
     wanted = key.casefold()
     by_name = next(
@@ -466,13 +471,18 @@ def _find_room(conn, rooms: list[Room], key: str) -> Room | None:
         (
             candidate
             for candidate in rooms
-            if _owning_fcu_name(conn, candidate) == wanted
+            if _owning_fcu_name(fcu_names, candidate) == wanted
         ),
         None,
     )
 
 
-def _member_room_ids(conn, rooms: list[Room], config, addressed: Room | None) -> set[int]:
+def _member_room_ids(
+    rooms: list[Room],
+    fcu_names: dict[int, str],
+    config: RoomConfig,
+    addressed: Room | None,
+) -> set[int]:
     """Resolve a dashboard's member rooms, warning about keys that match nothing.
 
     Membership is keyed by name, so renaming a member room silently drops it.
@@ -482,7 +492,7 @@ def _member_room_ids(conn, rooms: list[Room], config, addressed: Room | None) ->
         return {addressed.room_id} if addressed and addressed.room_id else set()
     room_ids = set()
     for key in config.members:
-        member = _find_room(conn, rooms, key)
+        member = _find_room(rooms, fcu_names, key)
         if member is None or member.room_id is None:
             logger.warning(
                 "Room dashboard member %r matches no room name or FCU name", key
@@ -495,14 +505,15 @@ def _member_room_ids(conn, rooms: list[Room], config, addressed: Room | None) ->
 def _render_room_dashboard_with_data(conn, location: str, room_id: int | None = None):
     """Render room dashboard with device data filtered by configuration."""
     rooms = db.get_rooms(conn)
+    fcu_names = db.get_room_fcu_names(conn)
     room = (
         db.get_room(conn, room_id)
         if room_id is not None
-        else _find_room(conn, rooms, location)
+        else _find_room(rooms, fcu_names, location)
     )
     if room_id is not None and room is None:
         return "Unknown room", 404
-    control_key = _room_control_key(conn, room, location)
+    control_key = _room_control_key(fcu_names, room, location)
     config = room_config.get_room_config(control_key)
 
     all_devices = db.get_device_status(conn)
@@ -513,7 +524,7 @@ def _render_room_dashboard_with_data(conn, location: str, room_id: int | None = 
     fan_devices = _filter_speed_control_devices(all_devices, config.fans)
 
     hubitat_sensors = _canonical_room_sensors(
-        conn, _member_room_ids(conn, rooms, config, room)
+        conn, _member_room_ids(rooms, fcu_names, config, room)
     )
 
     # Collect notes

--- a/app/static/room_dashboard.js
+++ b/app/static/room_dashboard.js
@@ -473,13 +473,14 @@ function roomControlEndpoint(action, roomKeyOverride = null) {
 }
 
 /**
- * Set the dimmer level via API.
+ * Set a dimmer's level via API.
+ * @param {string} control - Configured control key
  * @param {number} level - 0-100
  */
-function setDimmerLevel(level) {
+function setDimmerLevel(control, level) {
     apiCall(
         roomControlEndpoint('dimmer'),
-        { level },
+        { control, level },
         'Error setting dimmer.'
     );
 }
@@ -496,6 +497,42 @@ function requestRoomStatus(endpoint, request = fetch) {
     });
 }
 
+/**
+ * Apply one control's polled state to its tile.
+ *
+ * Controls the server could not read are absent from the response entirely, so
+ * their tiles keep whatever they last showed rather than being told a state the
+ * device never reported.
+ * @param {Document} pageDocument - Document to update
+ * @param {Object} state - One entry from the room_status controls list
+ */
+function applyControlState(pageDocument, state) {
+    const scope = `[data-control-key="${state.key}"]`;
+    if (state.kind === 'dimmer') {
+        const slider = pageDocument.querySelector(`input.dimmer-slider${scope}`);
+        const valueEl = pageDocument.querySelector(`.dimmer-value${scope}`);
+        // Don't yank the handle out from under a finger mid-drag.
+        if (slider && !slider.matches(':active')) {
+            slider.value = state.level;
+        }
+        if (valueEl) {
+            valueEl.textContent = state.level + '%';
+        }
+        return;
+    }
+    if (state.kind === 'fan') {
+        // A fan that is off reports its last speed, so trust `switch` over
+        // `speed` when deciding which button is lit.
+        const active = state.switch === 'on' ? state.speed : 'off';
+        pageDocument.querySelectorAll(`button.fan-btn${scope}`).forEach(button => {
+            button.classList.toggle(
+                'is-on', button.getAttribute('data-speed') === active);
+        });
+        return;
+    }
+    updateSwitchButton(state.key, state.switch, pageDocument);
+}
+
 function createRoomStatusRefresher(request = fetch, documentRef) {
     const pageDocument = documentRef ?? document;
     return createSingleFlight(async () => {
@@ -507,22 +544,8 @@ function createRoomStatusRefresher(request = fetch, documentRef) {
                 roomControlEndpoint('room_status'),
                 request,
             );
-            if (data.dimmer) {
-                const slider = pageDocument.getElementById('dimmer-slider');
-                const valueEl = pageDocument.getElementById('dimmer-value');
-                if (slider && !slider.matches(':active')) {
-                    slider.value = data.dimmer.level;
-                }
-                if (valueEl) {
-                    valueEl.textContent = data.dimmer.level + '%';
-                }
-            }
-            if (data.wall_inner) {
-                updateWallButton('inner', data.wall_inner.switch);
-            }
-            if (data.wall_outer) {
-                updateWallButton('outer', data.wall_outer.switch);
-            }
+            (data.controls || []).forEach(
+                state => applyControlState(pageDocument, state));
             return true;
         } catch (error) {
             if (DEBUG) {
@@ -538,33 +561,33 @@ const refreshRoomStatus = typeof document === 'undefined'
     : createRoomStatusRefresher();
 
 /**
- * Set up dimmer slider interaction.
+ * Set up every dimmer slider on the page, each addressing its own control.
  */
-function setupDimmer() {
-    const slider = document.getElementById('dimmer-slider');
-    if (!slider) {
-        return;
-    }
+function setupDimmers() {
+    document.querySelectorAll('input.dimmer-slider[data-control-key]').forEach(slider => {
+        const control = slider.getAttribute('data-control-key');
+        const valueEl = document.querySelector(
+            `.dimmer-value[data-control-key="${control}"]`);
+        const debouncedSet = debounce(level => setDimmerLevel(control, level), 300);
 
-    const valueEl = document.getElementById('dimmer-value');
-    const debouncedSet = debounce(setDimmerLevel, 300);
-
-    slider.addEventListener('input', () => {
-        const level = parseInt(slider.value);
-        if (valueEl) {
-            valueEl.textContent = level + '%';
-        }
-        debouncedSet(level);
+        slider.addEventListener('input', () => {
+            const level = parseInt(slider.value);
+            if (valueEl) {
+                valueEl.textContent = level + '%';
+            }
+            debouncedSet(level);
+        });
     });
 }
 
 /**
- * Update a wall light button to reflect current state.
- * @param {string} light - 'inner' or 'outer'
+ * Update a switch button to reflect current state.
+ * @param {string} control - Configured control key
  * @param {string} state - 'on' or 'off'
+ * @param {Document} pageDocument - Document to update
  */
-function updateWallButton(light, state) {
-    const btn = document.getElementById('wall-' + light + '-btn');
+function updateSwitchButton(control, state, pageDocument = document) {
+    const btn = pageDocument.querySelector(`button.wall-btn[data-control-key="${control}"]`);
     if (!btn) {
         return;
     }
@@ -574,24 +597,49 @@ function updateWallButton(light, state) {
 }
 
 /**
- * Handle wall light button click — toggle on/off.
+ * Handle switch button click — toggle on/off.
  * @param {HTMLElement} button - Clicked button element
  */
-function handleWallButton(button) {
-    const light = button.getAttribute('data-light');
+function handleSwitchButton(button) {
+    const control = button.getAttribute('data-control-key');
     const isOn = button.classList.contains('is-on');
     const newState = isOn ? 'off' : 'on';
 
     button.disabled = true;
     apiCall(
-        roomControlEndpoint('wall_light'),
-        { light, state: newState },
-        'Error toggling wall light.'
+        roomControlEndpoint('switch'),
+        { control, state: newState },
+        'Error toggling switch.'
     ).then(() => {
-        updateWallButton(light, newState);
+        updateSwitchButton(control, newState);
         button.disabled = false;
     }).catch(() => {
         button.disabled = false;
+    });
+}
+
+/**
+ * Handle fan speed button click.
+ * @param {HTMLElement} button - Clicked button element
+ */
+function handleFanButton(button) {
+    const control = button.getAttribute('data-control-key');
+    const speed = button.getAttribute('data-speed');
+    const siblings = document.querySelectorAll(
+        `button.fan-btn[data-control-key="${control}"]`);
+    siblings.forEach(b => { b.disabled = true; });
+
+    apiCall(
+        roomControlEndpoint('fan'),
+        { control, speed },
+        'Error setting fan speed.'
+    ).then(() => {
+        siblings.forEach(b => {
+            b.classList.toggle('is-on', b === button);
+            b.disabled = false;
+        });
+    }).catch(() => {
+        siblings.forEach(b => { b.disabled = false; });
     });
 }
 
@@ -600,13 +648,15 @@ function handleWallButton(button) {
  * @param {HTMLElement} button - Clicked button element
  */
 function handleTvButton(button) {
+    const control = button.getAttribute('data-control-key');
     const direction = button.getAttribute('data-direction');
-    const buttons = document.querySelectorAll('.tv-btn');
+    const buttons = document.querySelectorAll(
+        `.tv-btn[data-control-key="${control}"]`);
     buttons.forEach(b => { b.disabled = true; });
 
     apiCall(
         roomControlEndpoint('tv'),
-        { direction },
+        { control, direction },
         'Error controlling TV.'
     ).then(() => {
         buttons.forEach(b => { b.disabled = false; });
@@ -752,12 +802,17 @@ function setupRoomDashboard() {
     // Set up set temperature controls
     setupSetTempControls();
 
-    // Set up dimmer
-    setupDimmer();
+    // Set up dimmers
+    setupDimmers();
 
-    // Set up wall light buttons
-    document.querySelectorAll('.wall-btn[data-light]').forEach(button => {
-        button.addEventListener('click', () => handleWallButton(button));
+    // Set up switch buttons
+    document.querySelectorAll('.wall-btn[data-control-key]').forEach(button => {
+        button.addEventListener('click', () => handleSwitchButton(button));
+    });
+
+    // Set up fan speed buttons
+    document.querySelectorAll('.fan-btn[data-control-key][data-speed]').forEach(button => {
+        button.addEventListener('click', () => handleFanButton(button));
     });
 
     initializeSensorTemperatures();
@@ -781,6 +836,7 @@ if (typeof window !== 'undefined') {
 // Node.js export for testing.
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
+        applyControlState,
         computeFitScale,
         createRoomStatusRefresher,
         createStatusRefresher,

--- a/app/static/room_dashboard.js
+++ b/app/static/room_dashboard.js
@@ -533,6 +533,66 @@ function applyControlState(pageDocument, state) {
     updateSwitchButton(state.key, state.switch, pageDocument);
 }
 
+// Every interactive element a control tile can hold. Kept document-scoped (like
+// applyControlState) so availability is decided by the same selector contract.
+const CONTROL_INPUT_SELECTORS = [
+    'button.wall-btn',
+    'button.fan-btn',
+    'button.tv-btn',
+    'input.dimmer-slider',
+];
+
+/**
+ * Mark one control as readable or not, and disable its inputs when it is not.
+ * @param {Document} pageDocument - Document to update
+ * @param {string} key - Configured control key
+ * @param {boolean} available - Whether the server could read the device
+ */
+function setControlAvailability(pageDocument, key, available) {
+    const scope = `[data-control-key="${key}"]`;
+    const tile = pageDocument.querySelector(`.room-control-tile${scope}`);
+    if (tile) {
+        tile.classList.toggle('control-unavailable', !available);
+    }
+    CONTROL_INPUT_SELECTORS.forEach(selector => {
+        pageDocument.querySelectorAll(`${selector}${scope}`).forEach(element => {
+            element.disabled = !available;
+        });
+    });
+    if (!available) {
+        const button = pageDocument.querySelector(`button.wall-btn${scope}`);
+        if (button) {
+            button.textContent = 'Unavailable';
+        }
+    }
+}
+
+/**
+ * Reconcile every rendered control against the controls the server could read.
+ *
+ * Called only after a *successful* poll. A failed request means we cannot tell
+ * whether the devices are reachable, which is not the same as knowing they are
+ * not, so it must leave the tiles alone rather than greying out the whole page
+ * on a momentary network blip.
+ *
+ * TV lifts are momentary and deliberately report no state, so they are never in
+ * the response and must not be judged by their absence from it.
+ * @param {Document} pageDocument - Document to update
+ * @param {Array<Object>} states - The controls list from room_status
+ */
+function reconcileControlAvailability(pageDocument, states) {
+    const readable = new Set(states.map(state => state.key));
+    pageDocument
+        .querySelectorAll('.room-control-tile[data-control-key]')
+        .forEach(tile => {
+            if (tile.getAttribute('data-control-kind') === 'tv') {
+                return;
+            }
+            const key = tile.getAttribute('data-control-key');
+            setControlAvailability(pageDocument, key, readable.has(key));
+        });
+}
+
 function createRoomStatusRefresher(request = fetch, documentRef) {
     const pageDocument = documentRef ?? document;
     return createSingleFlight(async () => {
@@ -544,8 +604,9 @@ function createRoomStatusRefresher(request = fetch, documentRef) {
                 roomControlEndpoint('room_status'),
                 request,
             );
-            (data.controls || []).forEach(
-                state => applyControlState(pageDocument, state));
+            const states = data.controls || [];
+            states.forEach(state => applyControlState(pageDocument, state));
+            reconcileControlAvailability(pageDocument, states);
             return true;
         } catch (error) {
             if (DEBUG) {
@@ -838,6 +899,7 @@ if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         applyControlState,
         computeFitScale,
+        reconcileControlAvailability,
         createRoomStatusRefresher,
         createStatusRefresher,
         refreshRoomStatus,

--- a/app/static/room_dashboard.js
+++ b/app/static/room_dashboard.js
@@ -497,18 +497,74 @@ function requestRoomStatus(endpoint, request = fetch) {
     });
 }
 
+// Optimistic control state, mirroring the AE-200 speed buttons above: a command
+// is reflected the moment it is sent, and the poll loop is not allowed to revert
+// it until the backend catches up or this backstop elapses. Hubitat read-back
+// can lag a command, which would otherwise bounce a button back and forth for a
+// poll or two. Keyed by control key.
+const CONTROL_RECONCILE_MS = 60000;
+const pendingControlChanges = {};
+
+/**
+ * Record the state a control was just commanded into.
+ * @param {string} key - Configured control key
+ * @param {Object} intent - {state} for a switch, {speed} for a fan
+ */
+function recordPendingControl(key, intent) {
+    pendingControlChanges[key] = {
+        ...intent,
+        expiresAt: Date.now() + CONTROL_RECONCILE_MS,
+    };
+}
+
+/** Which fan speed button a polled state should light. */
+function activeFanSpeed(state) {
+    // A stopped fan still reports the speed it last ran at, so an explicit
+    // "off" wins over `speed`. A state with no `switch` at all is a device that
+    // did not report one, which is not the same as reporting off.
+    return state.switch === 'off' ? 'off' : state.speed;
+}
+
+/**
+ * Whether a polled state has caught up with the command we last sent.
+ * @param {Object} state - One entry from the room_status controls list
+ * @param {Object} pending - Recorded intent
+ * @returns {boolean}
+ */
+function controlStateMatchesPending(state, pending) {
+    if (pending.state !== undefined) {
+        return state.switch === pending.state;
+    }
+    if (pending.speed !== undefined) {
+        return activeFanSpeed(state) === pending.speed;
+    }
+    return true;
+}
+
 /**
  * Apply one control's polled state to its tile.
  *
  * Controls the server could not read are absent from the response entirely, so
  * their tiles keep whatever they last showed rather than being told a state the
- * device never reported.
+ * device never reported. Individual attributes may also be absent, and are
+ * likewise left alone rather than defaulted.
  * @param {Document} pageDocument - Document to update
  * @param {Object} state - One entry from the room_status controls list
  */
 function applyControlState(pageDocument, state) {
+    const pending = pendingControlChanges[state.key];
+    if (pending) {
+        if (Date.now() < pending.expiresAt && !controlStateMatchesPending(state, pending)) {
+            return;  // Backend hasn't caught up; hold the commanded state.
+        }
+        delete pendingControlChanges[state.key];
+    }
+
     const scope = `[data-control-key="${state.key}"]`;
     if (state.kind === 'dimmer') {
+        if (state.level == null) {
+            return;
+        }
         const slider = pageDocument.querySelector(`input.dimmer-slider${scope}`);
         const valueEl = pageDocument.querySelector(`.dimmer-value${scope}`);
         // Don't yank the handle out from under a finger mid-drag.
@@ -521,9 +577,7 @@ function applyControlState(pageDocument, state) {
         return;
     }
     if (state.kind === 'fan') {
-        // A fan that is off reports its last speed, so trust `switch` over
-        // `speed` when deciding which button is lit.
-        const active = state.switch === 'on' ? state.speed : 'off';
+        const active = activeFanSpeed(state);
         pageDocument.querySelectorAll(`button.fan-btn${scope}`).forEach(button => {
             button.classList.toggle(
                 'is-on', button.getAttribute('data-speed') === active);
@@ -551,6 +605,14 @@ const CONTROL_INPUT_SELECTORS = [
 function setControlAvailability(pageDocument, key, available) {
     const scope = `[data-control-key="${key}"]`;
     const tile = pageDocument.querySelector(`.room-control-tile${scope}`);
+    const wasUnavailable = tile ? tile.classList.contains('control-unavailable') : false;
+    // Only act on a change. Writing `disabled` on every poll would re-enable a
+    // button that a click handler had disabled for the duration of its command,
+    // letting a second command reach the hub while the first is still in
+    // flight.
+    if (available !== wasUnavailable) {
+        return;
+    }
     if (tile) {
         tile.classList.toggle('control-unavailable', !available);
     }
@@ -652,6 +714,13 @@ function updateSwitchButton(control, state, pageDocument = document) {
     if (!btn) {
         return;
     }
+    if (state !== 'on' && state !== 'off') {
+        // Readable device that reported no switch attribute. Saying nothing
+        // beats asserting OFF for something that may well be on.
+        btn.textContent = '—';
+        btn.classList.remove('is-on');
+        return;
+    }
     const isOn = state === 'on';
     btn.textContent = isOn ? 'ON' : 'OFF';
     btn.classList.toggle('is-on', isOn);
@@ -666,15 +735,22 @@ function handleSwitchButton(button) {
     const isOn = button.classList.contains('is-on');
     const newState = isOn ? 'off' : 'on';
 
+    // Show the commanded state at once and hold it against the poll loop until
+    // the hub's read-back agrees.
+    recordPendingControl(control, { state: newState });
+    updateSwitchButton(control, newState);
+
     button.disabled = true;
     apiCall(
         roomControlEndpoint('switch'),
         { control, state: newState },
         'Error toggling switch.'
     ).then(() => {
-        updateSwitchButton(control, newState);
         button.disabled = false;
     }).catch(() => {
+        // The command failed, so stop holding a state the device never took;
+        // the next poll restores the truth.
+        delete pendingControlChanges[control];
         button.disabled = false;
     });
 }
@@ -688,18 +764,21 @@ function handleFanButton(button) {
     const speed = button.getAttribute('data-speed');
     const siblings = document.querySelectorAll(
         `button.fan-btn[data-control-key="${control}"]`);
-    siblings.forEach(b => { b.disabled = true; });
+
+    recordPendingControl(control, { speed });
+    siblings.forEach(b => {
+        b.classList.toggle('is-on', b === button);
+        b.disabled = true;
+    });
 
     apiCall(
         roomControlEndpoint('fan'),
         { control, speed },
         'Error setting fan speed.'
     ).then(() => {
-        siblings.forEach(b => {
-            b.classList.toggle('is-on', b === button);
-            b.disabled = false;
-        });
+        siblings.forEach(b => { b.disabled = false; });
     }).catch(() => {
+        delete pendingControlChanges[control];
         siblings.forEach(b => { b.disabled = false; });
     });
 }
@@ -899,7 +978,10 @@ if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         applyControlState,
         computeFitScale,
+        pendingControlChanges,
         reconcileControlAvailability,
+        recordPendingControl,
+        setControlAvailability,
         createRoomStatusRefresher,
         createStatusRefresher,
         refreshRoomStatus,

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -46,11 +46,14 @@
   <div class="pure-menu pure-menu-horizontal">
     <a href="." class="pure-menu-heading pure-menu-link{% if current_page == 'home' %} pure-menu-selected{% endif %}">BasisTech HVAC</a>
     <ul class="pure-menu-list">
-      <li class="pure-menu-item{% if current_page in ['kitchen', 'hickory', 'map'] %} pure-menu-selected{% endif %}">
+      {# Room dashboards render with hide_nav, so only /map can select this item. #}
+      <li class="pure-menu-item{% if current_page == 'map' %} pure-menu-selected{% endif %}">
         <a href="#" id="rooms-menu-link" class="pure-menu-link">Rooms ▾</a>
         <div id="rooms-popup" class="github-popup">
-          <a href="/hickory">Hickory</a>
-          <a href="/kitchen">Kitchen</a>
+          {# Generated from app/room_config.py so a new dashboard needs no edit here. #}
+          {% for dashboard in room_dashboards %}
+          <a href="{{ dashboard.url }}">{{ dashboard.label }}</a>
+          {% endfor %}
           <a href="/map">Map</a>
         </div>
       </li>

--- a/app/templates/room_dashboard.html
+++ b/app/templates/room_dashboard.html
@@ -309,10 +309,31 @@ body {
   text-align: center;
 }
 
+/* Grid stretches every tile in a row to the same height, but a label that wraps
+   to two lines would otherwise push only its own button down. Pinning the
+   control area to the bottom of the tile keeps a row's buttons on one line
+   whatever the labels do. */
+.room-control-buttons,
+.dimmer-control {
+  margin-top: auto;
+}
+
 .room-control-buttons {
   display: flex;
   gap: 0.5em;
   width: 100%;
+}
+
+/* A control whose Hubitat device could not be read. Distinct from "still
+   loading": the tile is legible but visibly inert, so an operator can see the
+   device is missing rather than tapping a button that will never answer. */
+.room-control-tile.control-unavailable {
+  opacity: 0.55;
+}
+
+.room-control-tile.control-unavailable .room-control-tile-label {
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
 }
 
 .tv-btn {
@@ -640,15 +661,20 @@ body {
         <span class="dimmer-value" data-control-key="{{ control.key }}">--%</span>
       </div>
       {% elif control.kind == 'fan' %}
+      {# Abbreviated to match the AE-200 speed buttons below; the wire values
+         stay off/low/medium/high. #}
       <div class="room-control-buttons">
-        {% for speed in ['off', 'low', 'medium', 'high'] %}
+        {% for speed, caption in [('off', 'OFF'), ('low', 'LO'), ('medium', 'MED'), ('high', 'HI')] %}
         <button class="fan-btn" data-control-key="{{ control.key }}" data-speed="{{ speed }}">
-          {{ speed | capitalize }}
+          {{ caption }}
         </button>
         {% endfor %}
       </div>
       {% else %}
-      <button class="wall-btn" data-control-key="{{ control.key }}">...</button>
+      {# Wrapped like the other kinds so one rule bottom-aligns every control. #}
+      <div class="room-control-buttons">
+        <button class="wall-btn" data-control-key="{{ control.key }}">…</button>
+      </div>
       {% endif %}
     </div>
     {% endfor %}

--- a/app/templates/room_dashboard.html
+++ b/app/templates/room_dashboard.html
@@ -650,9 +650,17 @@ body {
 <div class="device-card room-controls-card">
   <div class="room-controls-grid">
     {% for control in room_controls %}
-    <div class="room-control-tile" data-control-key="{{ control.key }}" data-control-kind="{{ control.kind }}">
+    <div class="room-control-tile{% if control.unavailable_note %} control-unavailable{% endif %}"
+         data-control-key="{{ control.key }}" data-control-kind="{{ control.kind }}"
+         {% if control.unavailable_note %}title="{{ control.unavailable_note }}"{% endif %}>
       <div class="room-control-tile-label">{{ control.label }}</div>
-      {% if control.kind == 'tv' %}
+      {% if control.unavailable_note %}
+      {# Known to have no reachable device, so say so at render time rather
+         than waiting for a poll that will never report it. #}
+      <div class="room-control-buttons">
+        <button class="wall-btn" data-control-key="{{ control.key }}" disabled>Unavailable</button>
+      </div>
+      {% elif control.kind == 'tv' %}
       <div class="room-control-buttons">
         <button class="tv-btn" data-control-key="{{ control.key }}" data-direction="up">▲ Up</button>
         <button class="tv-btn" data-control-key="{{ control.key }}" data-direction="down">▼ Down</button>

--- a/app/templates/room_dashboard.html
+++ b/app/templates/room_dashboard.html
@@ -397,6 +397,44 @@ body {
   background: #66bb6a;
 }
 
+/* Fan speeds share the wall-light button shape but sit in a row, and mark the
+   selected speed the way the AE-200 speed buttons do. */
+.fan-btn {
+  flex: 1 1 0;
+  min-width: 0;
+  box-sizing: border-box;
+  height: clamp(44px, 7vh, 54px);
+  padding: 0 0.25em;
+  border: 3px solid transparent;
+  border-radius: 10px;
+  font: bold clamp(0.65rem, 1.4vw, 1em) sans-serif;
+  line-height: 1;
+  cursor: pointer;
+  color: white;
+  background: #90a4ae;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.12);
+  transition: all 0.15s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+.fan-btn.is-on {
+  background: #66bb6a;
+  border-color: var(--color-yellow-border);
+}
+
+.fan-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.18);
+}
+
+.fan-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .wall-btn:hover:not(:disabled) {
   transform: translateY(-1px);
   box-shadow: 0 4px 8px rgba(0,0,0,0.18);
@@ -486,7 +524,7 @@ body {
   .sensor-tile { padding: 0.6em; min-height: 60px; }
   .sensor-temp { font-size: 1.3em; }
   .room-control-buttons { gap: 0.35em; }
-  .tv-btn, .wall-btn { padding: 0 0.2em; }
+  .tv-btn, .wall-btn, .fan-btn { padding: 0 0.2em; }
   .room-controls-grid { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
 }
 
@@ -581,39 +619,39 @@ body {
 </div>
 {% endmacro %}
 
-<!-- Room Controls (TV, Lights) — moved above the device cards per Carl; caption
-     removed since the TV / Main Lights / Green Wall labels are self-evident. -->
-{% if show_tv_control %}
+<!-- Room Controls — moved above the device cards per Carl; caption removed since
+     the per-tile labels are self-evident. Rendered from the room's configured
+     control list, so a new control is a config entry rather than more markup. -->
+{% if room_controls %}
 <div class="device-card room-controls-card">
   <div class="room-controls-grid">
-    <div class="room-control-tile">
-      <div class="room-control-tile-label">TV</div>
+    {% for control in room_controls %}
+    <div class="room-control-tile" data-control-key="{{ control.key }}" data-control-kind="{{ control.kind }}">
+      <div class="room-control-tile-label">{{ control.label }}</div>
+      {% if control.kind == 'tv' %}
       <div class="room-control-buttons">
-        <button class="tv-btn" id="tv-up-btn" data-direction="up">▲ Up</button>
-        <button class="tv-btn" id="tv-down-btn" data-direction="down">▼ Down</button>
+        <button class="tv-btn" data-control-key="{{ control.key }}" data-direction="up">▲ Up</button>
+        <button class="tv-btn" data-control-key="{{ control.key }}" data-direction="down">▼ Down</button>
       </div>
-    </div>
-    {% if dimmer_id %}
-    <div class="room-control-tile">
-      <div class="room-control-tile-label">Main Lights</div>
+      {% elif control.kind == 'dimmer' %}
       <div class="dimmer-control">
-        <input type="range" id="dimmer-slider" class="dimmer-slider" min="0" max="100" value="0">
-        <span class="dimmer-value" id="dimmer-value">--%</span>
+        <input type="range" class="dimmer-slider" data-control-key="{{ control.key }}"
+               min="0" max="100" value="0">
+        <span class="dimmer-value" data-control-key="{{ control.key }}">--%</span>
       </div>
+      {% elif control.kind == 'fan' %}
+      <div class="room-control-buttons">
+        {% for speed in ['off', 'low', 'medium', 'high'] %}
+        <button class="fan-btn" data-control-key="{{ control.key }}" data-speed="{{ speed }}">
+          {{ speed | capitalize }}
+        </button>
+        {% endfor %}
+      </div>
+      {% else %}
+      <button class="wall-btn" data-control-key="{{ control.key }}">...</button>
+      {% endif %}
     </div>
-    {% endif %}
-    {% if wall_inner_id %}
-    <div class="room-control-tile">
-      <div class="room-control-tile-label">Green Wall - Inner</div>
-      <button class="wall-btn" id="wall-inner-btn" data-light="inner">...</button>
-    </div>
-    {% endif %}
-    {% if wall_outer_id %}
-    <div class="room-control-tile">
-      <div class="room-control-tile-label">Green Wall - Outer</div>
-      <button class="wall-btn" id="wall-outer-btn" data-light="outer">...</button>
-    </div>
-    {% endif %}
+    {% endfor %}
   </div>
 </div>
 {% endif %}

--- a/app/templates/room_dashboard.html
+++ b/app/templates/room_dashboard.html
@@ -524,14 +524,17 @@ body {
   text-align: center;
 }
 
-.sensor-offline {
+.sensor-stale {
   opacity: 0.5;
   border-left-color: #999;
 }
 
-.offline-label {
+/* "No data for 2h" is several times longer than the reading it replaces, so it
+   sizes down and is allowed to wrap rather than overflow a narrow tile. */
+.stale-label {
   color: #999;
-  font-size: 1.1em;
+  font: 600 0.95em sans-serif;
+  line-height: 1.25;
 }
 
 /* Responsive */
@@ -699,12 +702,15 @@ body {
 <div class="sensors-card">
   <div class="sensors-grid">
     {% for sensor in hubitat_sensors %}
-    <div class="sensor-tile{% if sensor.offline %} sensor-offline{% endif %}">
+    <div class="sensor-tile{% if sensor.stale_for %} sensor-stale{% endif %}">
       <div class="sensor-header">
         <div class="sensor-name" title="{{ sensor.name }}">{{ sensor.display_name or sensor.label or sensor.name }}</div>
       </div>
-      {% if sensor.offline %}
-      <div class="sensor-temp offline-label">Offline</div>
+      {% if sensor.stale_for %}
+      {# Say how long we have been without data rather than calling the sensor
+         offline: the runner or the hub may be what stopped, and the duration
+         separates a brief hiccup from a device silent for days. #}
+      <div class="sensor-temp stale-label">No data for {{ sensor.stale_for }}</div>
       {% else %}
       <div class="sensor-temp" id="sensor-{{ sensor.id }}-temp" data-temp-c="{% if sensor.attributes and sensor.attributes.temperature %}{{ sensor.attributes.temperature }}{% endif %}">
         {% if sensor.attributes and sensor.attributes.temperature %}

--- a/app/test_data/hubitat_control_devices.json
+++ b/app/test_data/hubitat_control_devices.json
@@ -1,0 +1,201 @@
+{
+  "switch": {
+    "id": "260",
+    "name": "Broadway Pendant Lights on Somerville Broadway",
+    "label": "Broadway Pendant Lights",
+    "type": "GE Enbrighten Z-Wave Smart Switch",
+    "attributes": [
+      {
+        "name": "switch",
+        "currentValue": "on",
+        "dataType": "ENUM",
+        "values": [
+          "on",
+          "off"
+        ]
+      },
+      {
+        "name": "pushed",
+        "currentValue": 2,
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "hubMeshDisabled",
+        "currentValue": "false",
+        "dataType": "STRING"
+      },
+      {
+        "name": "doubleTapped",
+        "currentValue": 1,
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "held",
+        "currentValue": 2,
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "released",
+        "currentValue": 2,
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "numberOfButtons",
+        "currentValue": 2,
+        "dataType": "NUMBER"
+      }
+    ]
+  },
+  "fan": {
+    "id": "359",
+    "name": "Data Closet Fan on Somerville Broadway",
+    "label": "Data Closet Fan",
+    "type": "GE Smart Fan Control",
+    "attributes": [
+      {
+        "name": "numberOfButtons",
+        "currentValue": 2,
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "pushed",
+        "currentValue": 1,
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "switch",
+        "currentValue": "on",
+        "dataType": "ENUM",
+        "values": [
+          "on",
+          "off"
+        ]
+      },
+      {
+        "name": "hubMeshDisabled",
+        "currentValue": "false",
+        "dataType": "STRING"
+      },
+      {
+        "name": "doubleTapped",
+        "currentValue": null,
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "level",
+        "currentValue": 98,
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "speed",
+        "currentValue": "high",
+        "dataType": "ENUM",
+        "values": [
+          "low",
+          "medium-low",
+          "medium",
+          "medium-high",
+          "high",
+          "on",
+          "off",
+          "auto"
+        ]
+      },
+      {
+        "name": "supportedFanSpeeds",
+        "currentValue": null,
+        "dataType": "JSON_OBJECT"
+      }
+    ]
+  },
+  "dimmer": {
+    "id": "581",
+    "name": "All Hue lights",
+    "label": "Hickory Dimmable Lights",
+    "type": "hueBridgeGroup",
+    "attributes": [
+      {
+        "name": "saturation",
+        "currentValue": 55,
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "colorName",
+        "currentValue": "Incandescent",
+        "dataType": "STRING"
+      },
+      {
+        "name": "color",
+        "currentValue": null,
+        "dataType": "STRING"
+      },
+      {
+        "name": "RGB",
+        "currentValue": null,
+        "dataType": "STRING"
+      },
+      {
+        "name": "hue",
+        "currentValue": 13,
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "level",
+        "currentValue": 70,
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "lightEffects",
+        "currentValue": "{\"0\":\"None\",\"1\":\"Color Loop\"}",
+        "dataType": "JSON_OBJECT"
+      },
+      {
+        "name": "colorTemperature",
+        "currentValue": 2732,
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "effect",
+        "currentValue": "none",
+        "dataType": "STRING"
+      },
+      {
+        "name": "effectName",
+        "currentValue": null,
+        "dataType": "STRING"
+      },
+      {
+        "name": "switch",
+        "currentValue": "on",
+        "dataType": "ENUM",
+        "values": [
+          "on",
+          "off"
+        ]
+      },
+      {
+        "name": "colorName",
+        "currentValue": "Incandescent",
+        "dataType": "STRING"
+      },
+      {
+        "name": "switch",
+        "currentValue": "on",
+        "dataType": "ENUM",
+        "values": [
+          "on",
+          "off"
+        ]
+      },
+      {
+        "name": "colorMode",
+        "currentValue": "CT",
+        "dataType": "ENUM",
+        "values": [
+          "CT",
+          "RGB"
+        ]
+      }
+    ]
+  }
+}

--- a/doc/Hubitat_Info.md
+++ b/doc/Hubitat_Info.md
@@ -4,6 +4,11 @@ This document describes how Temperature Bot talks to Hubitat, what must be set
 up on the Hubitat side, how sensors are discovered, and how Hubitat readings
 are stored.
 
+If you do not already know what a Hubitat hub or a Maker API app is, read
+`doc/hardware-landscape.md` first. It also documents the two-hub topology: this
+document describes hub `10.2.3.51` and Maker API app `520`, which is the only
+Hubitat installation Temperature Bot can reach.
+
 ## Source Map
 
 - `app/hubitat.py`: Hubitat Maker API client, simulator support, and device
@@ -11,8 +16,8 @@ are stored.
 - `bin/runner.py`: minute runner that polls Hubitat and writes readings.
 - `app/db.py`: device creation, current status, time-series queries, and log
   compression.
-- `app/room_config.py`: current static room-dashboard Hubitat sensor lists and
-  Hickory control device ids.
+- `app/room_config.py`: room-dashboard membership and actuator configuration.
+  Sensor membership is canonical; the actuator devices are configured here.
 - `app/routes_api.py`: JSON API routes for status, charts, debug views, rooms,
   and Hickory Hubitat controls.
 - `app/routes_web.py`: room-dashboard rendering and Hubitat sensor filtering.
@@ -42,13 +47,16 @@ successful collection. Temperature Bot re-enumerates the Maker API
 should be picked up on the next scan. Production cron normally runs that scan
 once per minute.
 
-Room dashboards are different: the current `/kitchen` and `/hickory`
-dashboards still use exact static sensor names in `app/room_config.py`. A newly
-logged Hubitat sensor will appear in the database and chart/status APIs, but it
-will not appear on those room dashboards until its exact Hubitat `name` is added
-to the room's `RoomConfig.sensors` list. The database has `rooms` and
-`devices.room_id`, plus `/api/v1/update_device_room`, but the room dashboards
-do not currently use that metadata for Hubitat sensor selection.
+Room dashboards select sensors canonically: `_canonical_room_sensors()` reads
+`devices.room_id`, so a newly logged Hubitat sensor appears on a room dashboard
+as soon as it is assigned to that room. Assign it by dragging its row in the
+main-page Air Quality matrix, or through `/api/v1/update_device_room`. No code
+or configuration change is required, and no sensor names are listed in
+`app/room_config.py`.
+
+Actuators are the exception. Which switches, dimmers, and lifts a dashboard
+offers is deliberate presentation configuration, so it stays in
+`app/room_config.py` rather than being derived from room membership.
 
 ## Configuration And Authentication
 
@@ -196,8 +204,9 @@ Hubitat data reaches the app through several paths:
 - `/api/v1/debug/hubitat_devices`: live Maker API device names and payloads.
 - `/all_devices`: web debug page that compares database, Hubitat, and AE-200
   devices through debug APIs.
-- `/kitchen` and `/hickory`: room dashboards that fetch live Hubitat sensor
-  payloads and filter by `app/room_config.py`.
+- `/kitchen`, `/hickory`, `/broadway`, and `/room/<room_id>`: room dashboards
+  whose sensor tiles come from canonical `devices.room_id` membership and whose
+  actuator tiles come from `app/room_config.py`.
 
 Temperature chart and lighting chart display names prefer the current Hubitat
 `label` when Hubitat is reachable, then apply the shared display-name helper.
@@ -290,7 +299,7 @@ Temperature Bot creates the `devices` row and starts writing `devlog` rows.
 Because the runner enumerates `/devices/all` every scan, no Temperature Bot
 restart or local database edit is needed for normal logging.
 
-They are not automatically added to the current room-dashboard sensor tiles.
-Add the exact Hubitat `name` to `app/room_config.py` for the relevant room until
-the room dashboards are changed to use `devices.room_id` or another metadata
-driven assignment path.
+They do not appear on a room dashboard until they are assigned to a room, because
+dashboard sensor tiles come from `devices.room_id`. A new sensor starts
+Unassigned; drag it onto a room in the main-page Air Quality matrix, and it
+appears on that room's dashboard immediately. No code change is involved.

--- a/doc/Hubitat_Info.md
+++ b/doc/Hubitat_Info.md
@@ -239,9 +239,12 @@ control by the `key` given to it in `app/room_config.py`:
   `medium`, or `high`.
 - `POST /api/v1/room/<room_key>/tv` with `direction` of `up` or `down`.
 - `GET /api/v1/room/<room_key>/room_status` returns `{"controls": [...]}`, one
-  entry per readable control, carrying `key`, `kind`, `switch`, and whichever of
-  `level` or `speed` that kind has. A TV lift is momentary and reports no state;
-  a control whose device could not be read is omitted rather than guessed at.
+  entry per readable control. Each carries `key` and `kind`, plus whichever of
+  `switch`, `level` (dimmers), and `speed` (fans) the device actually reported.
+  A TV lift is momentary and reports no state, so it never appears; a control
+  whose device could not be read is omitted rather than guessed at; and an
+  attribute the device omitted is absent rather than defaulted, so a running fan
+  that reports no `switch` is never published as off.
 
 A control key the room does not configure is a 404, the same answer an unknown
 room gets.

--- a/doc/Hubitat_Info.md
+++ b/doc/Hubitat_Info.md
@@ -219,6 +219,7 @@ The source contains these Hubitat control helpers:
 - `hubitat.send_device_command(device_id, command, secondary_value="")`
 - `hubitat.set_dimmer_level(device_id, level)`
 - `hubitat.set_switch(device_id, state)`
+- `hubitat.set_fan_speed(device_id, speed)`
 - `hubitat.control_hickory_tv(direction)`
 
 They use Maker API command URLs:
@@ -227,17 +228,32 @@ They use Maker API command URLs:
 GET /apps/api/{appId}/devices/{device_id}/{command}/{secondary_value}?access_token={access_token}
 ```
 
-Current app routes expose configured room controls:
+Current app routes expose configured room controls. Each body addresses one
+control by the `key` given to it in `app/room_config.py`:
 
-- `POST /api/v1/room/<room_key>/dimmer` with integer `level` from 0 to 100.
-- `POST /api/v1/room/<room_key>/wall_light` with `light` of `inner` or `outer`, and
-  `state` of `on` or `off`.
+- `POST /api/v1/room/<room_key>/switch` with `control` and `state` of `on` or
+  `off`.
+- `POST /api/v1/room/<room_key>/dimmer` with integer `level` from 0 to 100, and
+  `control` when the room has more than one dimmer.
+- `POST /api/v1/room/<room_key>/fan` with `control` and `speed` of `off`, `low`,
+  `medium`, or `high`.
 - `POST /api/v1/room/<room_key>/tv` with `direction` of `up` or `down`.
-- `GET /api/v1/room/<room_key>/room_status` for current control states.
+- `GET /api/v1/room/<room_key>/room_status` returns `{"controls": [...]}`, one
+  entry per readable control, carrying `key`, `kind`, `switch`, and whichever of
+  `level` or `speed` that kind has. A TV lift is momentary and reports no state;
+  a control whose device could not be read is omitted rather than guessed at.
+
+A control key the room does not configure is a 404, the same answer an unknown
+room gets.
 
 Device ids and TV component labels are configured per room in
 `app/room_config.py`. The helper sends `on` to the selected TV component
-switch. The old `/api/v1/hickory/...` paths remain compatibility aliases.
+switch.
+
+`/api/v1/room/<room_key>/wall_light` is an alias of `/switch` that spells the
+control key `light`, and the `/api/v1/hickory/...` paths remain compatibility
+aliases. Each alias is registered under its own Flask endpoint name; sharing one
+endpoint made Werkzeug 308-redirect the generic URL to the Hickory-specific one.
 
 Simulator mode only simulates `get_all_devices()`. Command helpers still build
 Maker API command URLs and are not safe to assume simulated.

--- a/doc/Hubitat_Info.md
+++ b/doc/Hubitat_Info.md
@@ -277,8 +277,51 @@ Maker API command URLs and are not safe to assume simulated.
 - device command execution.
 
 The runner currently uses only the all-devices URL for collection. The web/API
-control code uses all-devices reads and command execution. The dashboard dump
-and per-device helper functions are available for diagnostics and future work.
+control code uses per-device reads for room control status and the all-devices
+read elsewhere, plus command execution. The dashboard dump and the remaining
+per-device helpers are available for diagnostics and future work.
+
+### The two attribute shapes
+
+The two read endpoints disagree about `attributes`, and the difference is easy
+to miss because both are valid JSON describing the same device:
+
+```text
+GET /devices/all       "attributes": {"switch": "on", "level": "70", ...}
+GET /devices/<id>      "attributes": [{"name": "switch", "currentValue": "on",
+                                       "dataType": "ENUM"}, ...]
+```
+
+`HubitatControlDevice` accepts both and normalizes the list into the mapping.
+Before it did, every room control status read failed model validation, so the
+Hickory tiles reported their controls unreadable in production and each failure
+logged a large warning.
+
+Two quirks the captured fixtures in `app/test_data/hubitat_control_devices.json`
+pin down:
+
+- A `FanControl` device publishes a wider speed vocabulary than the four speeds
+  we command — `low`, `medium-low`, `medium`, `medium-high`, `high`, `on`,
+  `off`, `auto`. This is why the speed we report is an untyped string.
+- The `hueBridgeGroup` driver lists `switch` and `colorName` twice. The last
+  entry wins; both carried the same value when observed.
+
+Attributes a device does not report are absent, not defaulted. A fan with no
+`switch` attribute must not be published as off.
+
+### Hub endpoints outside Maker API
+
+Maker API only ever describes the devices it has been told to expose. To see
+what the hub itself knows, including Hub Mesh devices shared from another hub,
+read the hub UI's own JSON. These need no access token and are read-only:
+
+```text
+GET http://10.2.3.51/hub2/devicesList     every device, with source Linked/System/User
+GET http://10.2.3.51/apps/api/520/rooms   Hubitat's own rooms, which we do not use
+```
+
+The first is the right tool for "is this device on the hub at all", a question
+the Maker API device list cannot answer.
 
 ## Tests And Local Development
 

--- a/doc/agent-index.md
+++ b/doc/agent-index.md
@@ -7,6 +7,10 @@ surface quickly.
 
 ## Workflow Entrypoints
 
+- `doc/hardware-landscape.md`: what the physical equipment is, the two Hubitat
+  hubs and why only one is reachable, Maker API apps versus dashboards, FCU/ERV
+  definitions, and how a device becomes a row. Read this before any hardware
+  task if you have not seen the building.
 - `AGENTS.md`: maintainer workflow selection, signed commit rules, and
   non-interactive shell command requirements.
 - `CLAUDE.md`: Claude-specific architecture summary and Makefile test examples.

--- a/doc/agent-index.md
+++ b/doc/agent-index.md
@@ -31,32 +31,42 @@ surface quickly.
 - `doc/rooms-implementation-plan.md`: approved FCU-owned room model, grouped
   sensor matrix, room calculations, implementation beads, and issue map.
 
-## Hickory Dashboard Map
+## Room Dashboard Map
 
-Use this section for `/hickory`, `/kitchen`, room control tiles, and room
-dashboard frontend work.
+Use this section for `/hickory`, `/kitchen`, `/broadway`, `/room/<room_id>`,
+room control tiles, and room dashboard frontend work.
 
 - `app/routes_web.py`
   - `_render_room_dashboard_with_data()`: gathers room dashboard data and
     renders `room_dashboard.html`.
-  - `/hickory` and `/kitchen`: current room dashboard routes.
+  - `_find_room()`: resolves a room key by room name, then by owning FCU name.
+  - `_member_room_ids()`: resolves a dashboard's member rooms and warns about
+    keys that match nothing.
+  - `_canonical_room_sensors()`: sensor tiles for a set of room ids.
 - `app/room_config.py`
-  - Hardcoded room dashboard membership and Hickory-specific control ids.
-  - Hickory currently has TV, dimmer, and wall light controls.
+  - Per-dashboard member rooms, AE-200 unit names, and actuator controls.
+    Sensor membership is canonical and is never listed here.
+  - Broadway spans four rooms and configures nine switches plus a fan; its
+    devices live on the Hubitat hub we cannot reach.
+- `app/models.py`
+  - `RoomConfig`, `RoomControl`, `RoomControlKind`: the control vocabulary.
+    Adding a control is a config entry, not new markup or a new endpoint.
 - `app/templates/room_dashboard.html`
-  - Shared room dashboard Jinja template for Kitchen and Hickory.
-  - Pre-renders HVAC cards, room controls, sensors, live clock, and script
-    includes.
+  - Shared room dashboard Jinja template. Loops the configured control list and
+    pre-renders HVAC cards, sensors, live clock, and script includes.
 - `app/static/room_dashboard.js`
   - Room dashboard behavior: speed buttons, set temperature controls, configured
     room controls, polling, and scale-to-fit.
-  - Derives room-control endpoints from the template's room key.
+  - `applyControlState()`: applies one polled control state to its tile.
+  - Derives room-control endpoints from the template's room key, and addresses
+    controls by `data-control-key`.
 - `app/routes_api.py`
   - `/api/v1/status`: live HVAC/device status.
   - `/api/v1/set_drive`, `/api/v1/set_fan_speed`, `/api/v1/set_temp`: HVAC
     control APIs.
-  - `/api/v1/room/<room_key>/room_status`, `/dimmer`, `/wall_light`, `/tv`:
-    configured room-control APIs. Legacy Hickory aliases remain compatible.
+  - `/api/v1/room/<room_key>/room_status`, `/switch`, `/dimmer`, `/fan`, `/tv`:
+    configured room-control APIs. `/wall_light` and the Hickory aliases remain
+    compatible, each under its own Flask endpoint name.
 
 ## Canonical Room Metrics
 

--- a/doc/hardware-landscape.md
+++ b/doc/hardware-landscape.md
@@ -54,8 +54,20 @@ reports temperature, humidity, illuminance, motion, tamper, and battery. The
 switches are a mix of in-wall relays and smart plugs (GE Enbrighten, Zooz,
 Minoston) plus a Hue bridge group for dimmable lights.
 
-**Pairing** — joining a device to the hub's radio mesh — happens on the hub, by
-a person standing next to the device. Temperature Bot never pairs anything.
+Three different operations get muddled here, and keeping them apart saves a lot
+of confusion:
+
+- **Pairing** joins a device to a hub's *radio* mesh. This is the only one that
+  involves the physical device, and it is rare — everything in the building is
+  already paired. Temperature Bot never pairs anything.
+- **Hub Mesh** shares an already-paired device from one hub to another. It is a
+  web-UI setting on the hubs, done from a browser anywhere on the network.
+- **Exposing** a device through Maker API is ticking a checkbox in an app's
+  configuration page, also from a browser.
+
+Only the first needs anyone near the hardware. Asking for the second or third
+does not require a site visit, and describing them as though it did will
+rightly get you corrected.
 
 ### Apps, and why they matter more than you would expect
 
@@ -82,37 +94,56 @@ code:
 
 | Hub | Used for | App | Notes |
 | --- | --- | --- | --- |
-| `10.2.3.51` | **Everything Temperature Bot does** | Maker API, app `520` | Configured in `temperature-bot-config.yaml`. Authorizes 21 devices. |
-| `10.2.3.52` | Hubitat's own wall dashboards | Dashboard, app `449` ("Broadway Controls") and others | We do not talk to this hub at all. |
+| `10.2.3.51` | **Everything Temperature Bot does** | Maker API, app `520` | Configured in `temperature-bot-config.yaml`. |
+| `10.2.3.52` | Hubitat's own wall dashboards | Dashboard, app `449` ("Broadway Controls") and others | We never call this hub. |
 
 `temperature-bot-config.yaml` has exactly one `hubitat.host` and one
 `hubitat.appId`. **The code cannot reach a second hub.** Supporting one would be
 a change to the configuration model, not just an extra token.
 
-**Hub Mesh** is a Hubitat feature that mirrors a device from one hub onto
-another so both can use it. Some of our sensors are meshed this way, and the
-mirrored copy **gets a different device id on each hub**. The same physical
-sensor in the Broadway space is:
+**Hub Mesh** shares a device from one hub onto another so both can use it. A
+shared device is a first-class device on the receiving hub — it appears in that
+hub's device list with `source: Linked` — but it **gets a different device id on
+each hub**. The same physical sensor in the Broadway space is:
 
 - id `37` on hub `.52`, labelled `Broadway Sensor Center`
 - id `525` on hub `.51`, labelled `Broadway Center`
 
-So a device id copied from a Hubitat dashboard URL or layout is meaningless to
-us unless that device is also meshed to `.51` and ticked in Maker API app 520.
+So an id copied from another hub's dashboard is at best dead here and at worst
+names a different device. This is not hypothetical: three Broadway control ids
+were once taken from `.52`, and on `.51` they were Kitchen Counter Lights, Cedar
+Lights, and Willow Lights.
 
-### Practical consequence
+### Two different questions, and the trap between them
 
-When someone says "add the X control to a Temperature Bot page", the first
-question is not a code question. It is: *is X exposed by Maker API app 520 on
-hub `.51`?* Check with:
+"Is the device **on** hub `.51`?" and "is it **exposed** by Maker API app 520?"
+are different questions with different answers. At the time of writing the hub
+has 118 devices and the app exposes 29 of them. Answering the first with a tool
+that reports the second is a mistake that has already been made here, and it led
+to a request for hardware work that was not needed.
+
+Check exposure — what we can actually read and command:
 
 ```bash
 poetry run python -m app.hubitat --list-devices
 ```
 
-If it is not in that list, the work is blocked on a hub-side change by someone
-on site — mesh the device to `.51` if needed, then tick it in the Maker API app.
-No amount of application code substitutes for that.
+Check presence — everything the hub knows about, meshed devices included:
+
+```bash
+curl -s http://10.2.3.51/hub2/devicesList | python3 -m json.tool | less
+```
+
+Then:
+
+- **Exposed** → nothing to do; use its `.51` id.
+- **On the hub but not exposed** → tick it in the Maker API app at
+  `http://10.2.3.51/installedapp/configure/520/mainPage`, then **Done**. Browser
+  only. Leave the existing selections alone and do not touch "Create New Access
+  Token", which would invalidate the token in the config file and stop all
+  collection.
+- **Not on the hub** → it needs Hub Mesh from whichever hub has it. Still a
+  browser change, but on the other hub.
 
 ## The AE-200
 
@@ -191,8 +222,15 @@ Consecutive identical readings are run-length encoded into one row with a longer
 
 ## Rooms
 
-A **room** is our own concept, not a Hubitat or Mitsubishi one. It exists so the
-UI can say "the Bamboo room is 23°" rather than naming a sensor.
+A **room** in this application is our own model. It exists so the UI can say
+"the Bamboo room is 23°" rather than naming a sensor.
+
+Be aware that **Hubitat has its own, separate room concept** — 14 of them,
+including a "Broadway" (id 132) — and every device payload carries `room` and
+`roomId` fields from it. Maker API even exposes room endpoints. We read none of
+that: our rooms live in the `rooms` table and are assigned through our own UI.
+The two models overlap in name and disagree in structure, so a Hubitat room name
+in a device payload is not evidence about our topology.
 
 The rules, from `doc/rooms-implementation-plan.md`:
 
@@ -232,8 +270,9 @@ switch command is not automatically safe just because the simulator is on.
 
 | Symptom | Likely cause |
 | --- | --- |
-| A device appears on a Hubitat dashboard but not in our UI | Not ticked in Maker API app 520, or only exists on hub `.52`. |
-| A device id from a Hubitat URL does not work in our config | Ids are per-hub. Hub Mesh gives the same sensor a different id on each hub. |
+| A device appears on a Hubitat dashboard but not in our UI | Usually just not ticked in Maker API app 520. Check `/hub2/devicesList` before concluding it is absent from the hub — most Broadway devices were already meshed onto `.51` and merely unexposed. |
+| A device id from a Hubitat URL does not work in our config | Ids are per-hub. Hub Mesh gives the same device a different id on each hub, and the foreign id may name an unrelated device here. |
+| A control tile is inert and the log shows validation failures | Maker API sends `attributes` as a mapping from `/devices/all` but as a list from `/devices/<id>`. See `doc/Hubitat_Info.md`. |
 | A room dashboard tile says "No data for 2h" | Its last reading is older than the ten-minute freshness cutoff. Says nothing about the device itself — the runner, cron, or the hub may be what stopped. |
 | A control tile says "Unavailable" | Different condition: the live Maker API read for that device just failed, so it is not exposed on hub `.51` or the hub is unreachable. |
 | A sensor logs data but appears on no room page | It has no `room_id`. Assign it in the Air Quality matrix. |

--- a/doc/hardware-landscape.md
+++ b/doc/hardware-landscape.md
@@ -234,7 +234,8 @@ switch command is not automatically safe just because the simulator is on.
 | --- | --- |
 | A device appears on a Hubitat dashboard but not in our UI | Not ticked in Maker API app 520, or only exists on hub `.52`. |
 | A device id from a Hubitat URL does not work in our config | Ids are per-hub. Hub Mesh gives the same sensor a different id on each hub. |
-| A sensor reads but shows Offline on a room dashboard | Its last reading is older than the ten-minute freshness cutoff. |
+| A room dashboard tile says "No data for 2h" | Its last reading is older than the ten-minute freshness cutoff. Says nothing about the device itself — the runner, cron, or the hub may be what stopped. |
+| A control tile says "Unavailable" | Different condition: the live Maker API read for that device just failed, so it is not exposed on hub `.51` or the hub is unreachable. |
 | A sensor logs data but appears on no room page | It has no `room_id`. Assign it in the Air Quality matrix. |
 | AE-200 values are stale or commands are slow | The WebSocket is serialized and slow by nature; see `doc/performance-monitoring.md`. |
 | Airthings values stop updating | Cloud-only integration — check internet and Airthings service. |

--- a/doc/hardware-landscape.md
+++ b/doc/hardware-landscape.md
@@ -1,0 +1,240 @@
+# Hardware Landscape
+
+An orientation for anyone who works on Temperature Bot without having stood in
+the building. It explains what the physical equipment is, who talks to whom, and
+why a device you can plainly see somewhere else may be invisible to this
+application.
+
+Every other hardware document here answers "how does our code call X". This one
+answers "what is X, and why is it in the picture at all". Read this first, then:
+
+- `doc/Hubitat_Info.md` for the Hubitat Maker API mechanics.
+- `doc/AE200-TemperatureBot.md` for AE-200 operation modes.
+- `doc/airthings.md` for the Airthings API.
+- `doc/calculated-temperatures-and-rooms.md` for how readings become room
+  temperatures.
+
+## The Shape Of The System
+
+Temperature Bot owns no hardware. It is a reader and a remote control for four
+independent systems that were installed for their own reasons:
+
+```text
+  Zigbee / Z-Wave sensors  ──radio──>  Hubitat hub  ──HTTP──┐
+  Zigbee / Z-Wave switches ──radio──>  (Maker API)          │
+                                                            │
+  Mitsubishi fan coils + ERVs ──building LAN──> AE-200 ─────┼──> Temperature Bot
+                                                            │      (bin/runner.py,
+  Airthings air-quality monitors ──> Airthings cloud ───────┤       once a minute)
+                                                            │           │
+  Outdoor air quality ──> AQICN / AirNow / Google ──────────┘           v
+                                                                     SQLite
+                                                                        │
+                                                                        v
+                                                                  Flask web UI
+```
+
+`bin/runner.py` runs from cron every minute, polls each system, and writes rows
+into one SQLite database. The web UI reads that database. Nothing streams; every
+number you see on a page was pulled by a poll.
+
+## Hubitat
+
+### What the hardware is
+
+A **Hubitat Elevation hub** is a small always-on box on the office LAN. It is a
+home-automation controller: battery- and mains-powered sensors and switches
+around the building speak short-range radio protocols (**Z-Wave** and
+**Zigbee** — low-power mesh radios, not WiFi), and the hub is the one device
+that speaks those radios and bridges them to the network. Nothing else in our
+stack can hear a Z-Wave sensor directly.
+
+The sensors are mostly **Aeotec MultiSensor 6** units: one small puck that
+reports temperature, humidity, illuminance, motion, tamper, and battery. The
+switches are a mix of in-wall relays and smart plugs (GE Enbrighten, Zooz,
+Minoston) plus a Hue bridge group for dimmable lights.
+
+**Pairing** — joining a device to the hub's radio mesh — happens on the hub, by
+a person standing next to the device. Temperature Bot never pairs anything.
+
+### Apps, and why they matter more than you would expect
+
+A Hubitat hub runs **apps**. Two kinds matter to us, and confusing them is the
+single most common source of "why can't the bot see this device":
+
+- A **Maker API app** is a programmable allowlist. You install it, tick a set of
+  devices, and it issues an app id and an access token. It then exposes *only
+  the ticked devices* over plain HTTP. This is our entire interface to Hubitat —
+  everything we read and every command we send goes through one Maker API app.
+- A **Dashboard app** is a display page for humans: a grid of tiles at a URL you
+  can open on a wall tablet. It has its own app id and its own token, and its
+  own separate list of devices.
+
+These lists are unrelated. **A device shown on a Hubitat dashboard is not
+thereby visible to Temperature Bot.** If it is not ticked in our Maker API app,
+it does not exist as far as this code is concerned — no reading, no command, no
+`devices` row, no error message pointing at the cause.
+
+### There are two hubs
+
+This is the part that most often surprises people, including agents reading the
+code:
+
+| Hub | Used for | App | Notes |
+| --- | --- | --- | --- |
+| `10.2.3.51` | **Everything Temperature Bot does** | Maker API, app `520` | Configured in `temperature-bot-config.yaml`. Authorizes 21 devices. |
+| `10.2.3.52` | Hubitat's own wall dashboards | Dashboard, app `449` ("Broadway Controls") and others | We do not talk to this hub at all. |
+
+`temperature-bot-config.yaml` has exactly one `hubitat.host` and one
+`hubitat.appId`. **The code cannot reach a second hub.** Supporting one would be
+a change to the configuration model, not just an extra token.
+
+**Hub Mesh** is a Hubitat feature that mirrors a device from one hub onto
+another so both can use it. Some of our sensors are meshed this way, and the
+mirrored copy **gets a different device id on each hub**. The same physical
+sensor in the Broadway space is:
+
+- id `37` on hub `.52`, labelled `Broadway Sensor Center`
+- id `525` on hub `.51`, labelled `Broadway Center`
+
+So a device id copied from a Hubitat dashboard URL or layout is meaningless to
+us unless that device is also meshed to `.51` and ticked in Maker API app 520.
+
+### Practical consequence
+
+When someone says "add the X control to a Temperature Bot page", the first
+question is not a code question. It is: *is X exposed by Maker API app 520 on
+hub `.51`?* Check with:
+
+```bash
+poetry run python -m app.hubitat --list-devices
+```
+
+If it is not in that list, the work is blocked on a hub-side change by someone
+on site — mesh the device to `.51` if needed, then tick it in the Maker API app.
+No amount of application code substitutes for that.
+
+## The AE-200
+
+### What the hardware is
+
+The **Mitsubishi AE-200** is a central controller for the building's
+air conditioning. It is a wall-mounted unit wired to the HVAC equipment on
+Mitsubishi's own control bus, and it presents that equipment to the LAN. Ours is
+at `10.2.1.20`.
+
+Two kinds of equipment hang off it, and the distinction runs through the whole
+codebase:
+
+- An **FCU** (fan coil unit) is an air conditioner for one space: a coil with
+  hot or cold water or refrigerant, and a fan blowing room air across it. It
+  heats and cools. It has a mode (Cool/Heat/Fan/Dry/Auto), a fan speed, a
+  setpoint, and it reports an inlet air temperature. This is what people mean by
+  "the AC in the Bamboo room".
+- An **ERV** (energy recovery ventilator) does *not* heat or cool. It exchanges
+  stale indoor air for fresh outdoor air, passing the two streams alongside each
+  other so the outgoing air pre-conditions the incoming air. It has a fan speed
+  and nothing else. It is a ventilation device.
+
+In the UI, FCUs get the full card with a setpoint; ERVs get a speed row only.
+
+### How we talk to it
+
+Over a **WebSocket** at `ws://10.2.1.20/b_xmlproc/`, exchanging XML. This is not
+a documented public API; the client in `app/ae200.py` originated from the
+`natevoci/ae200` reverse-engineering project.
+
+The connection is slow and intolerant of concurrency, which shapes a surprising
+amount of the code: commands are serialized across processes with a file lock,
+timings are recorded (`doc/performance-monitoring.md`), and `AE200_SIMULATOR=1`
+swaps in canned payloads from `app/test_data/` so development does not touch the
+real hardware.
+
+`pyproject.toml` declares `pymodbus`, but no module imports it. There is no live
+Modbus path today, despite what older notes may say.
+
+## Airthings
+
+**Airthings** monitors are consumer air-quality devices — radon, CO2, VOC,
+particulates, plus temperature and humidity. Unlike everything else here they
+are **cloud-only**: the device talks to Airthings' servers, and we read the
+readings back out of `consumer-api.airthings.com` with OAuth client credentials.
+There is no local path, so this integration depends on the office internet
+connection and on Airthings' service being up.
+
+## Outdoor Air Quality
+
+Not hardware at all. `app/airquality.py` fetches the outdoor AQI for the area
+from public services — **AQICN**, **AirNow** (the US EPA's feed, keyed by zip
+code), and Google's air-quality API. This is what the rules engine consults
+before deciding whether opening up ventilation is a good idea.
+
+## How A Physical Device Becomes A Row
+
+Every source above converges on the `devices` table, one row per thing, and the
+`devlog` table, which is the time series. `bin/runner.py` creates a `devices`
+row automatically the first time a source reports a device it has not seen.
+
+Each row carries a `device_type`, assigned from the device's capabilities:
+
+| `device_type` | Meaning |
+| --- | --- |
+| `FCU` | An AE-200 fan coil unit. |
+| `ERV` | An AE-200 ventilator. |
+| `SENSOR` | Anything that measures — Hubitat sensors, Airthings monitors. |
+| `CONTROL` | A Hubitat actuator: switch, dimmer, relay, button. |
+| `INTERNAL` | Not hardware. Pseudo-devices such as `rules_engine`. |
+
+Temperatures are stored as `temp10x` — degrees Celsius times ten, as an integer.
+Consecutive identical readings are run-length encoded into one row with a longer
+`duration` rather than repeated.
+
+## Rooms
+
+A **room** is our own concept, not a Hubitat or Mitsubishi one. It exists so the
+UI can say "the Bamboo room is 23°" rather than naming a sensor.
+
+The rules, from `doc/rooms-implementation-plan.md`:
+
+- Every FCU owns exactly one room, created automatically when the FCU is
+  discovered. This is why there is a "Broadway North" room and a "Broadway
+  South" room and no single "Broadway" room — there are two fan coil units
+  serving that space.
+- Rooms can also exist without an FCU (Garage, Data Closet).
+- Every other physical device can be assigned to a room. ERVs and `INTERNAL`
+  pseudo-devices cannot.
+- `room_id IS NULL` means Unassigned, which is a display grouping, not a row.
+- A room's `room_id` is its stable identity; `room_name` is a display label and
+  can be renamed.
+
+Assignments are made by dragging rows in the Air Quality matrix on the main
+page. A room's temperature is a weighted average of the fresh readings from its
+assigned sensors; its humidity is an equal-weight mean. Readings older than ten
+minutes are excluded rather than shown stale.
+
+## Simulators
+
+None of the above is needed to develop locally. `make local-dev` runs with
+simulator flags set, serving canned payloads:
+
+| Flag | Replaces |
+| --- | --- |
+| `HUBITAT_SIMULATOR=1` | Maker API device list |
+| `AE200_SIMULATOR=1` | AE-200 WebSocket |
+| `AIRTHINGS_SIMULATOR=1` | Airthings cloud |
+| `AQICN_SIMULATOR=1` | Outdoor AQI |
+
+One caveat worth knowing: the Hubitat simulator only simulates *reading*.
+Command helpers still build real Maker API URLs, so a code path that sends a
+switch command is not automatically safe just because the simulator is on.
+
+## Troubleshooting Map
+
+| Symptom | Likely cause |
+| --- | --- |
+| A device appears on a Hubitat dashboard but not in our UI | Not ticked in Maker API app 520, or only exists on hub `.52`. |
+| A device id from a Hubitat URL does not work in our config | Ids are per-hub. Hub Mesh gives the same sensor a different id on each hub. |
+| A sensor reads but shows Offline on a room dashboard | Its last reading is older than the ten-minute freshness cutoff. |
+| A sensor logs data but appears on no room page | It has no `room_id`. Assign it in the Air Quality matrix. |
+| AE-200 values are stale or commands are slow | The WebSocket is serialized and slow by nature; see `doc/performance-monitoring.md`. |
+| Airthings values stop updating | Cloud-only integration — check internet and Airthings service. |

--- a/doc/rooms-implementation-review.md
+++ b/doc/rooms-implementation-review.md
@@ -37,8 +37,12 @@ Not yet implemented:
   rendering.
 - `/devices` receives `room_id` and `room_name` from `db.get_device_metadata()`
   but does not show or save room assignments.
-- Room dashboard membership is hardcoded by exact device names in
-  `app/room_config.py`, not by `devices.room_id`.
+- Resolved: room dashboard sensor membership comes from `devices.room_id`.
+  `app/room_config.py` names member rooms, not sensors, and a dashboard may
+  span several rooms (Broadway spans four). Membership keys are matched against
+  a room name or an owning FCU name, so renaming a room with no FCU still
+  breaks its membership; the render logs a warning when a key resolves to
+  nothing.
 - Resolved: room control APIs use `/api/v1/room/<room_key>/...`, and
   `room_dashboard.js` derives that key from the rendered dashboard contract.
   Legacy Hickory paths remain compatibility aliases.
@@ -144,33 +148,24 @@ Acceptance criteria:
 
 ### 5. Generalize room dashboards
 
-Keep `/hickory` and `/kitchen` working, but move toward one room dashboard
-renderer addressed by room key or room id.
+Delivered. `/hickory`, `/kitchen`, `/broadway`, and `/room/<room_id>` all render
+through `_render_room_dashboard_with_data()`, sensor membership comes from
+`devices.room_id`, and the Rooms menu is generated from `ROOM_CONFIGS`.
 
-Acceptance criteria:
-
-- A new room dashboard does not require copy-pasting route functions.
-- Dashboard device membership can come from `devices.room_id`, with temporary
-  config overrides only where needed.
-- Existing `/hickory` and `/kitchen` URLs remain compatible.
-- The Rooms menu is generated from configured or database-backed rooms instead
-  of hardcoding two links in `base.html`.
+Remaining: a new dashboard still needs a three-line route function alongside its
+config entry, because the config is keyed by dashboard rather than mounted from
+its own `url` field.
 
 ### 6. Generalize room control APIs
 
-Address #158 by adding generic room-control endpoints, for example
-`/api/v1/room/<location>/room_status`, `/dimmer`, `/wall_light`, and `/tv`, or a
-similar consistent route shape.
+Delivered. Controls are a typed list on `RoomConfig`, addressed by a per-room
+`key`, over `/api/v1/room/<room_key>/{room_status,switch,dimmer,fan,tv}`.
+Unknown rooms and unconfigured control keys both answer 404. The Hickory paths
+and `/wall_light` remain aliases, each with its own Flask endpoint name.
 
-Acceptance criteria:
-
-- Unknown rooms return clear 404-style JSON errors.
-- Rooms without a given control return a clear unsupported-control error.
-- Existing Hickory endpoints either remain as compatibility wrappers or are
-  redirected internally without breaking current clients.
-- `room_dashboard.js` derives endpoint URLs from template data instead of
-  hardcoding Hickory.
-- Control request bodies use Pydantic models instead of ad hoc dictionaries.
+The vocabulary is no longer Hickory's: a control is a `switch`, `dimmer`, `fan`,
+or `tv`, rather than the former fixed `tv_control` / `dimmer_id` /
+`wall_inner_id` / `wall_outer_id` fields.
 
 ### 7. Fix Hickory room status reads
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from app import routes_api
 from app.main import app as flask_app
 from app.paths import SCHEMA_FILE_PATH
 
@@ -57,6 +58,21 @@ def db_path(conn):
 def reduce_websockets_logging():
     """Reduce websockets debug logging for tests."""
     logging.getLogger("websockets.client").setLevel(logging.INFO)
+
+
+@pytest.fixture(autouse=True)
+def reset_failed_control_devices():
+    """Clear the warn-once set that room control status reads share.
+
+    ``routes_api`` remembers which control devices it has already warned about
+    so an unreachable hub does not log ten lines every ten-second poll. That set
+    is process-global, so without this a test that drove a device into failure
+    would silently decide whether a later test sees a warning at all.
+    """
+    # pylint: disable=protected-access
+    routes_api._failed_control_devices.clear()
+    yield
+    routes_api._failed_control_devices.clear()
 
 
 ################################################################

--- a/tests/test_api_error_contracts.py
+++ b/tests/test_api_error_contracts.py
@@ -33,6 +33,8 @@ ERROR_CASES = [
      "validation_error"),
     ("POST", "/api/v1/hickory/tv", {"direction": "sideways"}, 400,
      "validation_error"),
+    ("POST", "/api/v1/room/hickory/fan", {"control": "data-closet-fan",
+     "speed": "turbo"}, 400, "validation_error"),
     ("POST", "/api/v1/rules_master", {}, 400, "validation_error"),
     ("POST", "/api/v1/set_device_disabled_until", {}, 400, "validation_error"),
     # Query-string checks
@@ -48,6 +50,13 @@ ERROR_CASES = [
     ("GET", "/api/v1/presence/history?room_id=999999", None, 404, "not_found"),
     ("GET", "/api/v1/room/nosuchroom/room_status", None, 404, "not_found"),
     ("POST", "/api/v1/room/nosuchroom/dimmer", {"level": 50}, 404, "not_found"),
+    # A control key the room does not configure, like an unknown room, is a 404.
+    ("POST", "/api/v1/room/hickory/switch", {"control": "ceiling", "state": "on"},
+     404, "not_found"),
+    ("POST", "/api/v1/room/hickory/fan", {"control": "extractor", "speed": "high"},
+     404, "not_found"),
+    # Kitchen configures no actuators at all.
+    ("POST", "/api/v1/room/kitchen/dimmer", {"level": 50}, 404, "not_found"),
     ("GET", "/api/v1/fcu_history?fcu_device_id=999999", None, 404, "not_found"),
     ("GET", "/api/v1/fcu_temp_sources?fcu_device_id=999999", None, 404, "not_found"),
     ("POST", "/api/v1/update_device_room", {"device_id": 999999, "room_id": None},

--- a/tests/test_device_types.py
+++ b/tests/test_device_types.py
@@ -103,3 +103,32 @@ def test_control_attributes_tolerate_junk_entries():
         {"attributes": [{"name": "switch", "currentValue": "on"}, "junk", {"noname": 1}]}
     )
     assert device.attributes.switch == "on"
+
+
+def test_duplicate_attribute_prefers_the_last_reported_value():
+    """A trailing null must not erase a real reading from an earlier duplicate.
+
+    The Hue group driver lists switch twice. Both entries agree today, so
+    last-wins looked harmless, but a null in the later slot would have shown a
+    lit group as unknown.
+    """
+    device = HubitatControlDevice.model_validate(
+        {
+            "attributes": [
+                {"name": "switch", "currentValue": "on"},
+                {"name": "switch", "currentValue": None},
+            ]
+        }
+    )
+    assert device.attributes.switch == "on"
+
+    # A later real value still supersedes an earlier one.
+    superseded = HubitatControlDevice.model_validate(
+        {
+            "attributes": [
+                {"name": "switch", "currentValue": "on"},
+                {"name": "switch", "currentValue": "off"},
+            ]
+        }
+    )
+    assert superseded.attributes.switch == "off"

--- a/tests/test_device_types.py
+++ b/tests/test_device_types.py
@@ -1,6 +1,10 @@
 """Tests for discovery-driven device classification."""
 
+import json
+from pathlib import Path
+
 from app.device_types import (
+    HubitatControlDevice,
     HubitatDevice,
     classify_hubitat_device,
     classify_legacy_hubitat_name,
@@ -51,3 +55,51 @@ def test_legacy_hubitat_names_are_only_a_backfill_fallback():
 
 def test_unrecognized_hubitat_device_defaults_to_control():
     assert classify_hubitat_device(_device())[0] == "CONTROL"
+
+
+def test_control_attributes_accept_the_live_single_device_shape():
+    """Maker API returns two attribute shapes and only one was accepted.
+
+    ``/devices/all`` sends a mapping, but ``/devices/<id>`` -- the endpoint room
+    control status actually calls -- sends a list of records. Rejecting the list
+    made every live control read fail validation, so Hickory's controls reported
+    unreadable in production and Broadway's would have too. The payloads here
+    were captured from the production hub.
+    """
+    payloads = json.loads(
+        (Path(__file__).resolve().parents[1] / "app/test_data/hubitat_control_devices.json")
+        .read_text(encoding="utf-8")
+    )
+
+    switch = HubitatControlDevice.model_validate(payloads["switch"])
+    assert switch.attributes.switch == "on"
+
+    # A fan carries speed and level alongside switch; its speed vocabulary is
+    # wider than the four speeds we offer, so it must survive untouched.
+    fan = HubitatControlDevice.model_validate(payloads["fan"])
+    assert fan.attributes.switch == "on"
+    assert fan.attributes.speed == "high"
+    assert fan.attributes.level == 98
+
+    # The Hue group lists switch and colorName twice; last entry wins.
+    dimmer = HubitatControlDevice.model_validate(payloads["dimmer"])
+    assert dimmer.attributes.switch == "on"
+    assert dimmer.attributes.level == 70
+
+
+def test_control_attributes_still_accept_the_mapping_shape():
+    """The /devices/all mapping shape must keep working alongside the list."""
+    device = HubitatControlDevice.model_validate(
+        {"attributes": {"switch": "off", "level": "42", "speed": "medium-low"}}
+    )
+    assert device.attributes.switch == "off"
+    assert device.attributes.level == 42
+    assert device.attributes.speed == "medium-low"
+
+
+def test_control_attributes_tolerate_junk_entries():
+    """A malformed entry must not lose the rest of a device's state."""
+    device = HubitatControlDevice.model_validate(
+        {"attributes": [{"name": "switch", "currentValue": "on"}, "junk", {"noname": 1}]}
+    )
+    assert device.attributes.switch == "on"

--- a/tests/test_room_dashboard_routes.py
+++ b/tests/test_room_dashboard_routes.py
@@ -193,3 +193,43 @@ def test_single_room_dashboard_shows_only_its_own_room(
     body = flask_test_client.get(f"/room/{room.room_id}").get_data(as_text=True)
     assert "Solo Sensor" in body
     assert "Other Sensor" not in body
+
+
+def test_kitchen_membership_still_resolves_its_own_room(
+    flask_test_client, test_database_conn_with_test_data
+):
+    """Kitchen must keep working now that membership comes from a config string.
+
+    Broadway's multi-room union is covered above, but Kitchen is the plain
+    single-member case, and a typo in its one members entry would render an
+    empty dashboard while every other test still passed.
+    """
+    conn, _, _ = test_database_conn_with_test_data
+    kitchen = db.create_room(conn, Room(room_name="Kitchen"))
+    elsewhere = db.create_room(conn, Room(room_name="Bamboo"))
+    _add_sensor(conn, "Lobby Sensor", kitchen.room_id, 230)
+    _add_sensor(conn, "Bamboo Sensor", elsewhere.room_id, 210)
+
+    body = flask_test_client.get("/kitchen").get_data(as_text=True)
+    assert "Lobby Sensor" in body
+    assert "Bamboo Sensor" not in body
+    assert "23.0°C" in body
+
+
+def test_kitchen_membership_follows_its_fcu_after_a_rename(
+    flask_test_client, test_database_conn_with_test_data
+):
+    """A member key also matches the owning FCU, so a rename keeps the sensors.
+
+    This is the whole reason membership is not keyed by room name alone.
+    """
+    conn, _, _ = test_database_conn_with_test_data
+    conn.execute("INSERT INTO devices (device_name, device_type) VALUES ('Kitchen', 'FCU')")
+    conn.commit()
+    db.reconcile_fcu_rooms(conn)
+    room = next(item for item in db.get_rooms(conn) if item.room_name == "Kitchen")
+    db.update_room(conn, Room(room_id=room.room_id, room_name="Canteen"))
+    _add_sensor(conn, "Lobby Sensor", room.room_id, 230)
+
+    body = flask_test_client.get("/kitchen").get_data(as_text=True)
+    assert "Lobby Sensor" in body

--- a/tests/test_room_dashboard_routes.py
+++ b/tests/test_room_dashboard_routes.py
@@ -233,3 +233,32 @@ def test_kitchen_membership_follows_its_fcu_after_a_rename(
 
     body = flask_test_client.get("/kitchen").get_data(as_text=True)
     assert "Lobby Sensor" in body
+
+
+def test_control_with_no_reachable_device_is_shown_as_unavailable(flask_test_client):
+    """A control we cannot reach yet stays visible instead of disappearing.
+
+    Dropping it would hide the fact that hardware is missing. Giving it a
+    placeholder device id is worse: ids are per hub, and that is exactly how
+    three Broadway controls came to name unrelated devices on the wrong hub.
+    An explicit note carries the state with no id at all.
+    """
+    body = flask_test_client.get("/broadway").get_data(as_text=True)
+
+    assert 'data-control-key="tv-cart-left"' in body
+    assert "TV Cart Left" in body
+    # Rendered unavailable server-side, not left to a poll that will never
+    # report a control the API deliberately omits. Counts the rendered class
+    # attribute, since the stylesheet also mentions the class.
+    assert body.count('class="room-control-tile control-unavailable"') == 2
+    assert "not meshed onto 10.2.3.51" in body
+
+
+def test_unreachable_control_cannot_be_commanded(flask_test_client):
+    """The tile is visible, but there is no device behind it to switch."""
+    resp = flask_test_client.post(
+        "/api/v1/room/broadway/switch",
+        json={"control": "tv-cart-left", "state": "on"},
+    )
+    assert resp.status_code == 404
+    assert resp.get_json()["code"] == "not_found"

--- a/tests/test_room_dashboard_routes.py
+++ b/tests/test_room_dashboard_routes.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 import time
 
 from app import db
@@ -76,7 +77,9 @@ def test_canonical_room_dashboard_tracks_rename_and_assignment(
     conn.commit()
     stale = flask_test_client.get(f"/room/{room.room_id}")
     assert b"Friendly Sensor" in stale.data
-    assert b"Offline" in stale.data
+    # A reading past the freshness cutoff reports its age rather than claiming
+    # the sensor is offline, which is not something this page can know.
+    assert re.search(r"No data for \d+[smhd]", stale.data.decode())
 
     db.update_device_room(conn, sensor_id, other.room_id)
     moved = flask_test_client.get(f"/room/{room.room_id}")

--- a/tests/test_room_dashboard_routes.py
+++ b/tests/test_room_dashboard_routes.py
@@ -1,10 +1,36 @@
 """Integration coverage for canonical room dashboard membership."""
 
 import json
+import logging
 import time
 
 from app import db
 from app.models import Room
+
+
+def _add_sensor(conn, display_name, room_id, temp10x, humidity=None):
+    """Create one assigned sensor with a fresh reading."""
+    sensor_id = conn.execute(
+        """
+        INSERT INTO devices (device_name, display_name, device_type, room_id)
+        VALUES (?, ?, 'SENSOR', ?)
+        """,
+        (display_name.lower().replace(" ", "-"), display_name, room_id),
+    ).lastrowid
+    conn.execute(
+        """
+        INSERT INTO devlog (device_id, logtime, duration, temp10x, status_json)
+        VALUES (?, ?, 1, ?, ?)
+        """,
+        (
+            sensor_id,
+            int(time.time()),
+            temp10x,
+            json.dumps({"humidity": humidity} if humidity is not None else {}),
+        ),
+    )
+    conn.commit()
+    return sensor_id
 
 
 def test_canonical_room_dashboard_tracks_rename_and_assignment(
@@ -80,3 +106,87 @@ def test_configured_controls_follow_owned_fcu_after_room_rename(
     assert legacy.status_code == 200
     assert b'data-room-control-key="hickory"' in legacy.data
     assert b"Library" in legacy.data
+
+
+def test_broadway_unions_the_sensors_of_every_member_room(
+    flask_test_client, test_database_conn_with_test_data
+):
+    """One dashboard gathers sensors across the several rooms it is configured for.
+
+    Broadway is served by two FCUs, and every FCU owns its own room, so the
+    space cannot be one room. The dashboard spans them instead.
+    """
+    conn, _, _ = test_database_conn_with_test_data
+    north = db.create_room(conn, Room(room_name="Broadway North"))
+    south = db.create_room(conn, Room(room_name="Broadway South"))
+    closet = db.create_room(conn, Room(room_name="Data Closet"))
+    elsewhere = db.create_room(conn, Room(room_name="Bamboo"))
+    _add_sensor(conn, "North Sensor", north.room_id, 231)
+    _add_sensor(conn, "South Sensor", south.room_id, 239, humidity=58.4)
+    _add_sensor(conn, "Closet Sensor", closet.room_id, 247)
+    _add_sensor(conn, "Bamboo Sensor", elsewhere.room_id, 210)
+
+    response = flask_test_client.get("/broadway")
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+
+    assert "North Sensor" in body
+    assert "South Sensor" in body
+    assert "Closet Sensor" in body
+    # A room the dashboard does not list stays off it.
+    assert "Bamboo Sensor" not in body
+    # Freshness and formatting still come from the shared selector.
+    assert "23.1°C" in body
+    assert "58%" in body
+
+
+def test_broadway_renders_its_configured_controls(flask_test_client):
+    """Each configured control renders one tile addressed by its own key."""
+    response = flask_test_client.get("/broadway")
+    body = response.get_data(as_text=True)
+
+    assert 'data-control-key="pendant-lights"' in body
+    assert "Pendant Lights" in body
+    # The fan is a distinct kind, not an AE-200 card.
+    assert 'data-control-kind="fan"' in body
+    assert 'data-control-key="data-closet-fan"' in body
+    assert 'data-speed="medium"' in body
+    # Broadway has no TV lift.
+    assert 'data-control-kind="tv"' not in body
+
+
+def test_unresolvable_member_room_is_reported(
+    flask_test_client, test_database_conn_with_test_data, caplog
+):
+    """Membership is keyed by name, so a rename must not silently drop a room."""
+    conn, _, _ = test_database_conn_with_test_data
+    north = db.create_room(conn, Room(room_name="Broadway North"))
+    _add_sensor(conn, "North Sensor", north.room_id, 231)
+
+    with caplog.at_level(logging.WARNING, logger="app.routes_web"):
+        response = flask_test_client.get("/broadway")
+
+    assert response.status_code == 200
+    assert "North Sensor" in response.get_data(as_text=True)
+    unresolved = [
+        record.getMessage()
+        for record in caplog.records
+        if "matches no room name" in record.getMessage()
+    ]
+    assert len(unresolved) == 3
+    assert any("Data Closet" in message for message in unresolved)
+
+
+def test_single_room_dashboard_shows_only_its_own_room(
+    flask_test_client, test_database_conn_with_test_data
+):
+    """A config with no members falls back to the room the URL addressed."""
+    conn, _, _ = test_database_conn_with_test_data
+    room = db.create_room(conn, Room(room_name="Solo Room"))
+    other = db.create_room(conn, Room(room_name="Other Room"))
+    _add_sensor(conn, "Solo Sensor", room.room_id, 220)
+    _add_sensor(conn, "Other Sensor", other.room_id, 225)
+
+    body = flask_test_client.get(f"/room/{room.room_id}").get_data(as_text=True)
+    assert "Solo Sensor" in body
+    assert "Other Sensor" not in body

--- a/tests/test_room_integration.py
+++ b/tests/test_room_integration.py
@@ -85,7 +85,10 @@ def test_room_identity_move_rename_and_staleness_reach_all_consumers(
     assert re.search(
         rf'id="room-summary-temp-{room_id}"[^>]*>--', stale_page
     )
-    assert b"Offline" in flask_test_client.get(f"/room/{room_id}").data
+    # Says how long we have been without data, not that the sensor is off:
+    # the runner or the hub may be what stopped.
+    stale_room = flask_test_client.get(f"/room/{room_id}").data.decode()
+    assert re.search(r"No data for \d+[smhd]", stale_room)
     stale_presence = flask_test_client.get("/api/v1/presence").json["rooms"]
     assert next(room for room in stale_presence if room["room_id"] == room_id)[
         "state"

--- a/tests/test_room_scale.js
+++ b/tests/test_room_scale.js
@@ -10,6 +10,7 @@
  * "fit the tighter of the two axes" and degenerate-size guards.
  */
 const {
+  applyControlState,
   computeFitScale,
   createRoomStatusRefresher,
   createStatusRefresher,
@@ -187,6 +188,111 @@ async function testRoomControlStatusSingleFlight() {
     console.error('FAIL failed room-control request must release single-flight');
   }
 }
+
+/**
+ * Minimal DOM stand-in: enough for applyControlState's selector-based lookups
+ * without pulling in a headless browser.
+ */
+function fakeElement(attributes = {}, { dragging = false } = {}) {
+  const classes = new Set();
+  return {
+    value: null,
+    textContent: "",
+    getAttribute: name => attributes[name] ?? null,
+    // A slider reports :active only while a pointer is on it.
+    matches: selector => selector === ":active" && dragging,
+    classList: {
+      toggle: (name, on) => (on ? classes.add(name) : classes.delete(name)),
+      contains: name => classes.has(name),
+    },
+  };
+}
+
+function fakeDocument(elementsBySelector) {
+  return {
+    querySelector: selector => elementsBySelector[selector] ?? null,
+    querySelectorAll: selector => elementsBySelector[selector] ?? [],
+  };
+}
+
+function check(label, condition) {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`FAIL ${label}`);
+  }
+}
+
+function testDimmerState() {
+  const slider = fakeElement();
+  const valueEl = fakeElement();
+  const doc = fakeDocument({
+    'input.dimmer-slider[data-control-key="main"]': slider,
+    '.dimmer-value[data-control-key="main"]': valueEl,
+  });
+  applyControlState(doc, { key: "main", kind: "dimmer", switch: "on", level: 42 });
+  check("dimmer state moves the slider", slider.value === 42);
+  check("dimmer state labels the level", valueEl.textContent === "42%");
+
+  // Mid-drag the poll must not yank the handle back to the server's value.
+  const dragging = fakeElement({}, { dragging: true });
+  const draggingDoc = fakeDocument({
+    'input.dimmer-slider[data-control-key="main"]': dragging,
+    '.dimmer-value[data-control-key="main"]': fakeElement(),
+  });
+  applyControlState(draggingDoc, { key: "main", kind: "dimmer", switch: "on", level: 7 });
+  check("a slider being dragged is left alone", dragging.value === null);
+}
+
+function testFanState() {
+  const buttons = ["off", "low", "medium", "high"].map(speed =>
+    fakeElement({ "data-speed": speed }));
+  const doc = fakeDocument({
+    'button.fan-btn[data-control-key="fan"]': buttons,
+  });
+
+  applyControlState(doc, { key: "fan", kind: "fan", switch: "on", speed: "medium" });
+  check("running fan lights its speed",
+    buttons[2].classList.contains("is-on"));
+  check("running fan lights only its speed",
+    buttons.filter(b => b.classList.contains("is-on")).length === 1);
+
+  // A stopped fan still reports the speed it last ran at. Trusting `speed` over
+  // `switch` here would light a speed button on a fan that is not turning.
+  applyControlState(doc, { key: "fan", kind: "fan", switch: "off", speed: "high" });
+  check("stopped fan lights Off, not its last speed",
+    buttons[0].classList.contains("is-on") && !buttons[3].classList.contains("is-on"));
+}
+
+function testSwitchState() {
+  const button = fakeElement();
+  const doc = fakeDocument({
+    'button.wall-btn[data-control-key="inner"]': button,
+  });
+  applyControlState(doc, { key: "inner", kind: "switch", switch: "on" });
+  check("switch on reads ON", button.textContent === "ON");
+  check("switch on is highlighted", button.classList.contains("is-on"));
+
+  applyControlState(doc, { key: "inner", kind: "switch", switch: "off" });
+  check("switch off reads OFF", button.textContent === "OFF");
+  check("switch off is not highlighted", !button.classList.contains("is-on"));
+}
+
+// A control the server could not read is absent from the response, so nothing
+// should throw when its tile has no matching element either.
+function testMissingElements() {
+  const doc = fakeDocument({});
+  applyControlState(doc, { key: "gone", kind: "dimmer", switch: "on", level: 5 });
+  applyControlState(doc, { key: "gone", kind: "fan", switch: "on", speed: "low" });
+  applyControlState(doc, { key: "gone", kind: "switch", switch: "on" });
+  check("absent control elements are tolerated", true);
+}
+
+testDimmerState();
+testFanState();
+testSwitchState();
+testMissingElements();
 
 testRoomStatusPolling()
   .then(testDeviceStatusSingleFlight)

--- a/tests/test_room_scale.js
+++ b/tests/test_room_scale.js
@@ -12,7 +12,10 @@
 const {
   applyControlState,
   computeFitScale,
+  pendingControlChanges,
   reconcileControlAvailability,
+  recordPendingControl,
+  setControlAvailability,
   createRoomStatusRefresher,
   createStatusRefresher,
   requestRoomStatus,
@@ -204,6 +207,8 @@ function fakeElement(attributes = {}, { dragging = false } = {}) {
     // A slider reports :active only while a pointer is on it.
     matches: selector => selector === ":active" && dragging,
     classList: {
+      add: name => classes.add(name),
+      remove: name => classes.delete(name),
       toggle: (name, on) => (on ? classes.add(name) : classes.delete(name)),
       contains: name => classes.has(name),
     },
@@ -360,11 +365,102 @@ function testUnavailableControls() {
     tiles[1].classList.contains("control-unavailable"));
 }
 
+function testAbsentAttributes() {
+  // A readable device that reported no switch. Treating that as "off" would
+  // light the OFF button under a fan that is actually running.
+  const fanButtons = ["off", "low", "medium", "high"].map(speed =>
+    fakeElement({ "data-speed": speed }));
+  const switchButton = fakeElement();
+  const slider = fakeElement();
+  const valueEl = fakeElement();
+  const doc = fakeDocument({
+    'button.fan-btn[data-control-key="fan"]': fanButtons,
+    'button.wall-btn[data-control-key="sw"]': switchButton,
+    'input.dimmer-slider[data-control-key="dim"]': slider,
+    '.dimmer-value[data-control-key="dim"]': valueEl,
+  });
+
+  applyControlState(doc, { key: "fan", kind: "fan", speed: "medium" });
+  check("fan with no switch attribute trusts its reported speed",
+    fanButtons[2].classList.contains("is-on") &&
+    !fanButtons[0].classList.contains("is-on"));
+
+  applyControlState(doc, { key: "sw", kind: "switch" });
+  check("switch with no switch attribute shows unknown, not OFF",
+    switchButton.textContent === "—" && !switchButton.classList.contains("is-on"));
+
+  applyControlState(doc, { key: "dim", kind: "dimmer" });
+  check("dimmer with no level is left alone rather than snapped to 0%",
+    slider.value === null && valueEl.textContent === "");
+}
+
+function testPendingControlReconcile() {
+  const buttons = ["off", "low", "medium", "high"].map(speed =>
+    fakeElement({ "data-speed": speed }));
+  const doc = fakeDocument({
+    'button.fan-btn[data-control-key="fan"]': buttons,
+  });
+
+  // User taps MED: the handler records the intent and lights MED at once.
+  recordPendingControl("fan", { speed: "medium" });
+  buttons.forEach(b => b.classList.toggle("is-on",
+    b.getAttribute("data-speed") === "medium"));
+  // The hub has not caught up and still reports the old speed.
+  applyControlState(doc, { key: "fan", kind: "fan", switch: "on", speed: "high" });
+  check("a lagging poll does not bounce the highlight off the commanded speed",
+    buttons[2].classList.contains("is-on") && !buttons[3].classList.contains("is-on"));
+
+  // Once the hub agrees, the pending hold is released and later polls apply.
+  applyControlState(doc, { key: "fan", kind: "fan", switch: "on", speed: "medium" });
+  applyControlState(doc, { key: "fan", kind: "fan", switch: "on", speed: "high" });
+  check("once the hub agrees, later polls are applied again",
+    buttons[3].classList.contains("is-on"));
+
+  // A switch command that the device has not yet echoed holds the same way.
+  const switchButton = fakeElement();
+  const switchDoc = fakeDocument({
+    'button.wall-btn[data-control-key="sw"]': switchButton,
+  });
+  recordPendingControl("sw", { state: "on" });
+  applyControlState(switchDoc, { key: "sw", kind: "switch", switch: "off" });
+  check("a lagging switch poll does not revert the commanded state",
+    switchButton.textContent === "");
+  delete pendingControlChanges.sw;
+}
+
+function testAvailabilityOnlyWritesOnTransition() {
+  // The poll runs every 10s and a command takes a moment. If a poll rewrote
+  // `disabled` unconditionally it would re-enable a button mid-command and let
+  // a second request reach the hub.
+  const button = fakeElement();
+  const tile = fakeTile("sw", "switch");
+  const doc = fakeDocument({
+    ".room-control-tile[data-control-key]": [tile],
+    '.room-control-tile[data-control-key="sw"]': tile,
+    'button.wall-btn[data-control-key="sw"]': button,
+  });
+
+  button.disabled = true;  // a click handler disabled it for its POST
+  reconcileControlAvailability(doc, [{ key: "sw", kind: "switch", switch: "on" }]);
+  check("a poll leaves an in-flight button disabled", button.disabled === true);
+
+  // A genuine transition still writes.
+  reconcileControlAvailability(doc, []);
+  check("becoming unavailable still disables and marks the tile",
+    tile.classList.contains("control-unavailable") && button.disabled === true);
+  button.disabled = true;
+  reconcileControlAvailability(doc, [{ key: "sw", kind: "switch", switch: "on" }]);
+  check("recovering still re-enables", button.disabled === false);
+}
+
 testDimmerState();
 testFanState();
 testSwitchState();
 testMissingElements();
 testUnavailableControls();
+testAbsentAttributes();
+testPendingControlReconcile();
+testAvailabilityOnlyWritesOnTransition();
 
 testRoomStatusPolling()
   .then(testDeviceStatusSingleFlight)

--- a/tests/test_room_scale.js
+++ b/tests/test_room_scale.js
@@ -12,6 +12,7 @@
 const {
   applyControlState,
   computeFitScale,
+  reconcileControlAvailability,
   createRoomStatusRefresher,
   createStatusRefresher,
   requestRoomStatus,
@@ -154,7 +155,7 @@ async function testRoomControlStatusSingleFlight() {
   const responseReady = new Promise(resolve => { releaseRequest = resolve; });
   const documentRef = {
     querySelector: () => ({}),
-    getElementById: () => null,
+    querySelectorAll: () => [],
   };
   const refreshRoomStatus = createRoomStatusRefresher(async () => {
     requests++;
@@ -198,6 +199,7 @@ function fakeElement(attributes = {}, { dragging = false } = {}) {
   return {
     value: null,
     textContent: "",
+    disabled: false,
     getAttribute: name => attributes[name] ?? null,
     // A slider reports :active only while a pointer is on it.
     matches: selector => selector === ":active" && dragging,
@@ -208,10 +210,34 @@ function fakeElement(attributes = {}, { dragging = false } = {}) {
   };
 }
 
-function fakeDocument(elementsBySelector) {
+function fakeTile(key, kind) {
+  const classes = new Set();
   return {
-    querySelector: selector => elementsBySelector[selector] ?? null,
-    querySelectorAll: selector => elementsBySelector[selector] ?? [],
+    key,
+    getAttribute: name =>
+      ({ "data-control-key": key, "data-control-kind": kind })[name] ?? null,
+    classList: {
+      toggle: (name, on) => (on ? classes.add(name) : classes.delete(name)),
+      contains: name => classes.has(name),
+    },
+  };
+}
+
+function fakeDocument(elementsBySelector) {
+  // Mirrors the real DOM's split: querySelector yields one node or null,
+  // querySelectorAll always yields a list.
+  return {
+    querySelector: selector => {
+      const found = elementsBySelector[selector];
+      return (Array.isArray(found) ? found[0] : found) ?? null;
+    },
+    querySelectorAll: selector => {
+      const found = elementsBySelector[selector];
+      if (!found) {
+        return [];
+      }
+      return Array.isArray(found) ? found : [found];
+    },
   };
 }
 
@@ -289,10 +315,56 @@ function testMissingElements() {
   check("absent control elements are tolerated", true);
 }
 
+function testUnavailableControls() {
+  const switchButton = fakeElement();
+  const fanButton = fakeElement({ "data-speed": "low" });
+  const tvButton = fakeElement({ "data-direction": "up" });
+  const tiles = [
+    fakeTile("pendant-lights", "switch"),
+    fakeTile("data-closet-fan", "fan"),
+    fakeTile("tv", "tv"),
+  ];
+  const doc = fakeDocument({
+    ".room-control-tile[data-control-key]": tiles,
+    '.room-control-tile[data-control-key="pendant-lights"]': tiles[0],
+    '.room-control-tile[data-control-key="data-closet-fan"]': tiles[1],
+    '.room-control-tile[data-control-key="tv"]': tiles[2],
+    'button.wall-btn[data-control-key="pendant-lights"]': switchButton,
+    'button.fan-btn[data-control-key="data-closet-fan"]': [fanButton],
+    'button.tv-btn[data-control-key="tv"]': [tvButton],
+  });
+
+  // Nothing readable: the unreachable-hub case Broadway is in today.
+  reconcileControlAvailability(doc, []);
+  check("unreadable switch tile is marked unavailable",
+    tiles[0].classList.contains("control-unavailable"));
+  check("unreadable switch says so rather than showing a placeholder",
+    switchButton.textContent === "Unavailable");
+  check("unreadable switch is disabled", switchButton.disabled === true);
+  check("unreadable fan is disabled", fanButton.disabled === true);
+
+  // A TV lift is momentary and never reports state. Judging it by its absence
+  // from the response would grey out a control that works perfectly.
+  check("tv tile is never marked unavailable",
+    !tiles[2].classList.contains("control-unavailable"));
+  check("tv button stays enabled", tvButton.disabled === false);
+
+  // The device comes back once someone exposes it on the reachable hub.
+  reconcileControlAvailability(doc, [
+    { key: "pendant-lights", kind: "switch", switch: "on" },
+  ]);
+  check("recovered control drops the unavailable mark",
+    !tiles[0].classList.contains("control-unavailable"));
+  check("recovered control is re-enabled", switchButton.disabled === false);
+  check("a still-unreadable sibling stays marked",
+    tiles[1].classList.contains("control-unavailable"));
+}
+
 testDimmerState();
 testFanState();
 testSwitchState();
 testMissingElements();
+testUnavailableControls();
 
 testRoomStatusPolling()
   .then(testDeviceStatusSingleFlight)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -23,7 +23,6 @@ from app.routes_web import (
     _rules_forecast_table,
 )
 from app import room_config
-from app import routes_api
 from app.version import __version__
 
 def test_status_endpoint(flask_test_client): # noqa: F811
@@ -954,11 +953,63 @@ def test_room_status_reports_fan_speed(mock_get_device_info, flask_test_client):
     }
 
 
+@patch("app.routes_api.hubitat.get_device_info")
+def test_room_status_passes_absent_attributes_through(mock_get_device_info, flask_test_client):  # noqa: F811
+    """A readable device that omits an attribute must not be given a value.
+
+    Defaulting a missing switch to "off" would show a running fan as stopped,
+    and a missing level as 0 would show a lit dimmer at zero percent. The
+    browser distinguishes absent from off; the API has to preserve that.
+    """
+    mock_get_device_info.return_value = {"attributes": {"speed": "medium"}}
+    states = {
+        state["key"]: state
+        for state in flask_test_client.get(
+            "/api/v1/room/broadway/room_status"
+        ).get_json()["controls"]
+    }
+    assert states["data-closet-fan"] == {
+        "key": "data-closet-fan",
+        "kind": "fan",
+        "speed": "medium",
+    }
+    assert states["pendant-lights"] == {"key": "pendant-lights", "kind": "switch"}
+
+
+@patch("app.routes_api.hubitat.set_dimmer_level")
+def test_dimmer_accepts_the_control_key_the_browser_sends(_mock, flask_test_client):  # noqa: F811
+    """room_dashboard.js addresses dimmers by control key, not by room alone.
+
+    The older tests post the legacy body with no control key, so without this a
+    find_control regression would break every dashboard while the suite stayed
+    green.
+    """
+    resp = flask_test_client.post(
+        "/api/v1/room/hickory/dimmer",
+        json={"control": "main", "level": 40},
+    )
+    assert resp.status_code == 200
+    _mock.assert_called_once_with("581", 40)
+
+
+@patch("app.routes_api.hubitat.control_room_tv")
+def test_tv_accepts_the_control_key_the_browser_sends(_mock, flask_test_client):  # noqa: F811
+    """Same contract check for the TV lift, which the browser also keys."""
+    resp = flask_test_client.post(
+        "/api/v1/room/hickory/tv",
+        json={"control": "tv", "direction": "down"},
+    )
+    assert resp.status_code == 200
+    _mock.assert_called_once_with("down", up_label="TV Up", down_label="TV Down")
+
+
 @patch("app.routes_api.hubitat.get_device_info", side_effect=RuntimeError("unreachable"))
 def test_unreachable_control_warns_once_per_device(mock_get_device_info, flask_test_client, caplog):  # noqa: F811
-    """Ten unreachable controls polled every ten seconds must not flood the log."""
-    # pylint: disable=protected-access
-    routes_api._failed_control_devices.clear()
+    """Ten unreachable controls polled every ten seconds must not flood the log.
+
+    The warn-once set is cleared by an autouse fixture in conftest, so this does
+    not depend on which tests ran before it.
+    """
     with caplog.at_level(logging.WARNING, logger="app.routes_api"):
         first = flask_test_client.get("/api/v1/room/broadway/room_status")
         second = flask_test_client.get("/api/v1/room/broadway/room_status")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -4,6 +4,7 @@ Simple test to check if Flask routes are working
 """
 # pylint: disable=unused-import,too-many-lines
 import datetime
+import logging
 from html import unescape
 from unittest.mock import patch
 
@@ -19,10 +20,10 @@ from app.dashboard_views import (
 from app.routes_web import (
     _filter_speed_control_devices,
     _format_rules_result,
-    _get_hubitat_sensors,
     _rules_forecast_table,
 )
 from app import room_config
+from app import routes_api
 from app.version import __version__
 
 def test_status_endpoint(flask_test_client): # noqa: F811
@@ -217,7 +218,7 @@ def test_dashboard_air_quality_device_expires_after_30_days():
     )
 
 
-@patch("app.routes_web.hubitat.get_name_to_label")
+@patch("app.hubitat.get_name_to_label")
 @patch("app.routes_web.time.time", return_value=1300)
 @patch("app.routes_web.db.get_device_status")
 def test_index_does_not_fetch_hubitat_labels_on_render(
@@ -279,7 +280,7 @@ def test_table_update_summary_uses_oldest_status_end_time():
     )
 
 
-@patch("app.routes_web.hubitat.get_name_to_label", return_value={})
+@patch("app.hubitat.get_name_to_label", return_value={})
 @patch("app.routes_web.time.time", return_value=1300)
 @patch("app.routes_web.db.get_device_status")
 def test_index_table_update_summaries_render_at_table_bottom(
@@ -327,7 +328,7 @@ def test_index_table_update_summaries_render_at_table_bottom(
     assert html.count("oldest update at") == 3
 
 
-@patch("app.routes_web.hubitat.get_name_to_label", return_value={})
+@patch("app.hubitat.get_name_to_label", return_value={})
 @patch("app.routes_web.time.time", return_value=1300)
 @patch("app.routes_web.db.get_device_status")
 def test_index_air_quality_table_hides_expired_devices(
@@ -364,7 +365,7 @@ def test_index_air_quality_table_hides_expired_devices(
     assert "from Expired Air" not in html
 
 
-@patch("app.routes_web.hubitat.get_name_to_label", return_value={})
+@patch("app.hubitat.get_name_to_label", return_value={})
 @patch("app.routes_web.db.get_device_status")
 def test_fcu_matrix_has_raw_fcu_temp_and_room_temp_columns(
     mock_get_status, _mock_labels, flask_test_client
@@ -409,7 +410,7 @@ def test_fcu_matrix_has_raw_fcu_temp_and_room_temp_columns(
     assert 'aria-label="Move Auto cool set temperature"' in html
 
 
-@patch("app.routes_web.hubitat.get_name_to_label", return_value={})
+@patch("app.hubitat.get_name_to_label", return_value={})
 @patch("app.routes_web.db.get_device_status")
 def test_fcu_matrix_unit_cell_opens_temperature_source_editor(
     mock_get_status, _mock_labels, flask_test_client
@@ -456,7 +457,7 @@ def test_fcu_matrix_unit_cell_opens_temperature_source_editor(
     assert "room-temp-link" not in html
 
 
-@patch("app.routes_web.hubitat.get_name_to_label", return_value={})
+@patch("app.hubitat.get_name_to_label", return_value={})
 @patch("app.routes_web.time.time", return_value=1300)
 @patch("app.routes_web.db.get_device_status")
 def test_index_device_names_expose_rename_popup_contract(
@@ -680,74 +681,6 @@ def test_filter_speed_control_empty_names():
     assert result == []
 
 
-# -- _get_hubitat_sensors unit tests --
-
-_FAKE_HUBITAT_DEVICES = [
-    {
-        "name": "Hickory Sensor",
-        "label": "Hickory Sensor",
-        "id": "582",
-        "room": "Hickory",
-        "capabilities": ["TemperatureMeasurement", "RelativeHumidityMeasurement"],
-        "attributes": {"temperature": "23.4", "humidity": "24"},
-    },
-    {
-        "name": "Dungeon Cage",
-        "label": "Dungeon Cage",
-        "id": "98",
-        "room": "Dungeon",
-        "capabilities": ["TemperatureMeasurement"],
-        "attributes": {"temperature": "24.6"},
-    },
-    {
-        "name": "Some Light",
-        "label": "Some Light",
-        "id": "999",
-        "room": "Hickory",
-        "capabilities": ["Switch"],
-        "attributes": {"switch": "on"},
-    },
-]
-
-
-@patch("app.routes_web.hubitat.get_all_devices", return_value=_FAKE_HUBITAT_DEVICES)
-def test_get_hubitat_sensors_returns_matching(_mock):
-    """Configured names found in Hubitat are returned."""
-    result = _get_hubitat_sensors(["Hickory Sensor", "Dungeon Cage"])
-    names = [s["name"] for s in result]
-    assert names == ["Hickory Sensor", "Dungeon Cage"]
-    assert all("offline" not in s for s in result)
-
-
-@patch("app.routes_web.hubitat.get_all_devices", return_value=_FAKE_HUBITAT_DEVICES)
-def test_get_hubitat_sensors_offline_placeholder(_mock):
-    """Configured names NOT in Hubitat get an offline placeholder."""
-    result = _get_hubitat_sensors(["Hickory Sensor", "Missing Sensor"])
-    assert len(result) == 2
-    online = result[0]
-    offline = result[1]
-    assert online["name"] == "Hickory Sensor"
-    assert "offline" not in online
-    assert offline["name"] == "Missing Sensor"
-    assert offline["offline"] is True
-
-
-@patch("app.routes_web.hubitat.get_all_devices", return_value=_FAKE_HUBITAT_DEVICES)
-def test_get_hubitat_sensors_skips_non_temperature(_mock):
-    """Devices without TemperatureMeasurement capability are not returned."""
-    result = _get_hubitat_sensors(["Some Light"])
-    assert len(result) == 1
-    assert result[0]["offline"] is True
-
-
-@patch("app.routes_web.hubitat.get_all_devices", side_effect=RuntimeError("unreachable"))
-def test_get_hubitat_sensors_hubitat_unreachable(_mock):
-    """When Hubitat is unreachable, all sensors get offline placeholders."""
-    result = _get_hubitat_sensors(["Hickory Sensor", "Dungeon Cage"])
-    assert len(result) == 2
-    assert all(s["offline"] is True for s in result)
-
-
 # -- Hickory room API endpoint tests --
 
 _FAKE_ALL_DEVICES = [
@@ -776,16 +709,17 @@ _FAKE_ALL_DEVICES = [
 
 @patch("app.routes_api.hubitat.get_device_info")
 def test_room_status_returns_device_states(mock_get_device_info, flask_test_client):  # noqa: F811
-    """Room status returns dimmer level and wall light states."""
+    """Room status reports each readable control keyed by its configured key."""
     devices = {device["id"]: device for device in _FAKE_ALL_DEVICES}
     mock_get_device_info.side_effect = devices.__getitem__
     resp = flask_test_client.get("/api/v1/hickory/room_status")
     assert resp.status_code == 200
-    data = resp.get_json()
-    assert data["dimmer"]["level"] == 75
-    assert data["dimmer"]["switch"] == "on"
-    assert data["wall_inner"]["switch"] == "on"
-    assert data["wall_outer"]["switch"] == "off"
+    assert resp.get_json()["controls"] == [
+        {"key": "main", "kind": "dimmer", "level": 75, "switch": "on"},
+        {"key": "inner", "kind": "switch", "switch": "on"},
+        {"key": "outer", "kind": "switch", "switch": "off"},
+    ]
+    # The TV lift is momentary and has no device to read.
     assert [call.args[0] for call in mock_get_device_info.call_args_list] == [
         "581",
         "454",
@@ -798,10 +732,7 @@ def test_room_status_missing_devices(_mock, flask_test_client):  # noqa: F811
     """When configured devices aren't in Hubitat, they're omitted from response."""
     resp = flask_test_client.get("/api/v1/hickory/room_status")
     assert resp.status_code == 200
-    data = resp.get_json()
-    assert "dimmer" not in data
-    assert "wall_inner" not in data
-    assert "wall_outer" not in data
+    assert resp.get_json() == {"controls": []}
 
 
 @patch("app.routes_api.hubitat.get_device_info")
@@ -816,8 +747,10 @@ def test_room_status_one_device_error_keeps_other_states(mock_get_device_info, f
     resp = flask_test_client.get("/api/v1/hickory/room_status")
     assert resp.status_code == 200
     assert resp.get_json() == {
-        "dimmer": {"level": 75, "switch": "on"},
-        "wall_outer": {"switch": "off"},
+        "controls": [
+            {"key": "main", "kind": "dimmer", "level": 75, "switch": "on"},
+            {"key": "outer", "kind": "switch", "switch": "off"},
+        ]
     }
 
 
@@ -896,7 +829,7 @@ def test_wall_light_on(_mock, flask_test_client):  # noqa: F811
     )
     assert resp.status_code == 200
     data = resp.get_json()
-    assert data["light"] == "inner"
+    assert data["control"] == "inner"
     assert data["state"] == "on"
     _mock.assert_called_once_with("454", "on")
 
@@ -912,13 +845,14 @@ def test_wall_light_outer_off(_mock, flask_test_client):  # noqa: F811
     _mock.assert_called_once_with("550", "off")
 
 
-def test_wall_light_invalid_light(flask_test_client):  # noqa: F811
-    """Invalid light name returns 400."""
+def test_wall_light_unknown_control(flask_test_client):  # noqa: F811
+    """An unconfigured control key is a 404, like an unconfigured room."""
     resp = flask_test_client.post(
         "/api/v1/hickory/wall_light",
         json={"light": "ceiling", "state": "on"},
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 404
+    assert resp.get_json()["code"] == "not_found"
 
 
 def test_wall_light_invalid_state(flask_test_client):  # noqa: F811
@@ -949,6 +883,92 @@ def test_wall_light_hubitat_error(_mock, flask_test_client):  # noqa: F811
     assert resp.status_code == 502
     assert resp.get_json()["code"] == "upstream_unavailable"
     assert "hub down" not in resp.get_data(as_text=True)
+
+
+# /api/v1/room/<room_key>/switch and /fan — the generic control endpoints
+
+@patch("app.routes_api.hubitat.set_switch")
+def test_switch_endpoint_drives_a_configured_control(_mock, flask_test_client):  # noqa: F811
+    """The generic path addresses the same controls as the wall-light alias."""
+    resp = flask_test_client.post(
+        "/api/v1/room/hickory/switch",
+        json={"control": "outer", "state": "off"},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["control"] == "outer"
+    _mock.assert_called_once_with("550", "off")
+
+
+@patch("app.routes_api.hubitat.set_switch")
+def test_switch_endpoint_drives_a_broadway_control(_mock, flask_test_client):  # noqa: F811
+    """A room that configures neither a dimmer nor a TV still switches."""
+    resp = flask_test_client.post(
+        "/api/v1/room/broadway/switch",
+        json={"control": "pendant-lights", "state": "on"},
+    )
+    assert resp.status_code == 200
+    _mock.assert_called_once_with("291", "on")
+
+
+def test_switch_endpoint_rejects_a_control_of_another_kind(flask_test_client):  # noqa: F811
+    """A fan is not switchable through the switch endpoint."""
+    resp = flask_test_client.post(
+        "/api/v1/room/broadway/switch",
+        json={"control": "data-closet-fan", "state": "on"},
+    )
+    assert resp.status_code == 404
+
+
+@patch("app.routes_api.hubitat.set_fan_speed")
+def test_fan_endpoint_sets_a_named_speed(_mock, flask_test_client):  # noqa: F811
+    """Fan speeds are sent by name, not as an on/off switch."""
+    resp = flask_test_client.post(
+        "/api/v1/room/broadway/fan",
+        json={"control": "data-closet-fan", "speed": "medium"},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["speed"] == "medium"
+    _mock.assert_called_once_with("137", "medium")
+
+
+@patch("app.routes_api.hubitat.get_device_info")
+def test_room_status_reports_fan_speed(mock_get_device_info, flask_test_client):  # noqa: F811
+    """A fan reports its speed; switches in the same room report only on/off."""
+    mock_get_device_info.return_value = {
+        "attributes": {"switch": "on", "speed": "high", "level": 98}
+    }
+    resp = flask_test_client.get("/api/v1/room/broadway/room_status")
+    assert resp.status_code == 200
+    states = {state["key"]: state for state in resp.get_json()["controls"]}
+    assert states["data-closet-fan"] == {
+        "key": "data-closet-fan",
+        "kind": "fan",
+        "switch": "on",
+        "speed": "high",
+    }
+    # A switch carries no level even when the payload has one.
+    assert states["pendant-lights"] == {
+        "key": "pendant-lights",
+        "kind": "switch",
+        "switch": "on",
+    }
+
+
+@patch("app.routes_api.hubitat.get_device_info", side_effect=RuntimeError("unreachable"))
+def test_unreachable_control_warns_once_per_device(mock_get_device_info, flask_test_client, caplog):  # noqa: F811
+    """Ten unreachable controls polled every ten seconds must not flood the log."""
+    # pylint: disable=protected-access
+    routes_api._failed_control_devices.clear()
+    with caplog.at_level(logging.WARNING, logger="app.routes_api"):
+        first = flask_test_client.get("/api/v1/room/broadway/room_status")
+        second = flask_test_client.get("/api/v1/room/broadway/room_status")
+
+    assert first.get_json() == {"controls": []}
+    assert second.get_json() == {"controls": []}
+    # Both polls read every device; only the first poll reported the failures.
+    assert mock_get_device_info.call_count == 20
+    failures = [r for r in caplog.records if "status fetch failed" in r.getMessage()]
+    assert len(failures) == 10
 
 
 # /api/v1/hickory/tv

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -906,7 +906,7 @@ def test_switch_endpoint_drives_a_broadway_control(_mock, flask_test_client):  #
         json={"control": "pendant-lights", "state": "on"},
     )
     assert resp.status_code == 200
-    _mock.assert_called_once_with("291", "on")
+    _mock.assert_called_once_with("260", "on")
 
 
 def test_switch_endpoint_rejects_a_control_of_another_kind(flask_test_client):  # noqa: F811
@@ -927,7 +927,7 @@ def test_fan_endpoint_sets_a_named_speed(_mock, flask_test_client):  # noqa: F81
     )
     assert resp.status_code == 200
     assert resp.get_json()["speed"] == "medium"
-    _mock.assert_called_once_with("137", "medium")
+    _mock.assert_called_once_with("359", "medium")
 
 
 @patch("app.routes_api.hubitat.get_device_info")
@@ -1017,9 +1017,9 @@ def test_unreachable_control_warns_once_per_device(mock_get_device_info, flask_t
     assert first.get_json() == {"controls": []}
     assert second.get_json() == {"controls": []}
     # Both polls read every device; only the first poll reported the failures.
-    assert mock_get_device_info.call_count == 20
+    assert mock_get_device_info.call_count == 16
     failures = [r for r in caplog.records if "status fetch failed" in r.getMessage()]
-    assert len(failures) == 10
+    assert len(failures) == 8
 
 
 # /api/v1/hickory/tv

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1018,7 +1018,7 @@ def test_unreachable_control_warns_once_per_device(mock_get_device_info, flask_t
     assert second.get_json() == {"controls": []}
     # Both polls read every device; only the first poll reported the failures.
     assert mock_get_device_info.call_count == 16
-    failures = [r for r in caplog.records if "status fetch failed" in r.getMessage()]
+    failures = [r for r in caplog.records if "unreadable" in r.getMessage()]
     assert len(failures) == 8
 
 
@@ -1165,3 +1165,34 @@ def test_hickory_dashboard_uses_decluttered_layout(mock_get_status, flask_test_c
     assert room_controls_pos < first_device_card_pos, (
         "Room Controls must render above the first HVAC device card"
     )
+
+
+@patch("app.routes_api.hubitat.get_device_info", return_value={"id": "260"})
+def test_payload_without_attributes_counts_as_unreadable(_mock, flask_test_client):  # noqa: F811
+    """A 200 body that is not a device description must not read as reachable.
+
+    Reporting it as readable would leave the tile enabled and clickable while
+    the page knows nothing about the device -- the same lie the unavailable
+    state exists to prevent, arriving through a different door. An empty
+    attribute list is deliberately NOT this case: the device answered.
+    """
+    resp = flask_test_client.get("/api/v1/room/broadway/room_status")
+    assert resp.get_json() == {"controls": []}
+
+
+@patch("app.routes_api.hubitat.get_device_info", return_value={"id": "260", "attributes": []})
+def test_device_reporting_no_attributes_is_still_reachable(_mock, flask_test_client):  # noqa: F811
+    """A device that answers but reports no state is reachable, not unavailable.
+
+    Its tile stays enabled and commandable; only the state is unknown. This is
+    the distinction the previous test's payload fails to meet.
+    """
+    states = flask_test_client.get(
+        "/api/v1/room/broadway/room_status"
+    ).get_json()["controls"]
+    assert {state["key"] for state in states} == {
+        "pendant-lights", "spot-lights", "whiteboard-washer",
+        "sidewalk-washer-north", "sidewalk-washer-south",
+        "garage-washer-north", "garage-washer-south", "data-closet-fan",
+    }
+    assert all("switch" not in state for state in states)


### PR DESCRIPTION
Per Carl's request, set up a dashboard for Broadway that matches the Hubitat dashboard "Broadway Controls".

This works as far as I can tell, but some on-site config is needed first to mesh some actuators onto hub .51 and expose them in Maker app 520.  Apparently this can only be done from the wall units, so I can't do it from here. Simson, can you?

Here are detailed instructions from Claude. Overly detailed, but parts are Greek to me, so I'm leaving it all in.

```
Broadway dashboard is built and live at /broadway, but 10 of its tiles are inert until someone on site does a hub-side change. Everything below is on the Hubitat side — no code needed from you.

*The problem*

temperature-bot talks to exactly one hub: 10.2.3.51, Maker API app 520, which currently authorises 21 devices. The Broadway actuators all live on 10.2.3.52, where the "Broadway Controls" dashboard (app 449) is. We can't see any of them, so those tiles render greyed out and say "Unavailable".

The four Broadway temperature tiles already work, because those sensors are hub-meshed to .51 and ticked in app 520. Same treatment is what the actuators need.

*The 10 devices* (ids are .52 ids)

- 395  Broadway TV Cart Left
- 396  Broadway TV Cart Right
- 291  Broadway Pendant Lights
- 393  Broadway Spot Lights
- 293  Whiteboard Washer
- 294  Sidewalk Washer North
- 295  Sidewalk Washer South
- 136  Garage Washer North
- 297  Garage Washer South
- 137  Data Closet Fan

*What to do* — preferred: Hub Mesh all 10 from .52 onto .51, then add them to the devices exposed by Maker API app 520. Proven path, no code change.

The alternative — a Maker API app on .52 — also needs a code change: temperature-bot's config has a single hubitat host/appId, so a second hub is a config-model change, not just another token. Only worth it if meshing these is a problem for some reason.

*What we need in the commands*

- The nine switches need `on` and `off`.
- The Data Closet Fan needs `setSpeed` (we send off/low/medium/high).

Several of these render as button tiles on the Hubitat dashboard but do report a switch attribute, so on/off should be right. Shout if any of them is button-only and can't take on/off — that one needs different handling.

*What I need back*

Hub Mesh assigns new device ids on .51 — e.g. Broadway Sensor Center is 37 on .52 and 525 on .51. Our config references devices by id, so once they're meshed and authorised, send me the .51 ids and I'll update room_config.py.
  `poetry run python -m app.hubitat --list-devices` dumps them, or just paste the Maker API device list.

*How we'll know it worked*

Once the ids are in, the tiles stop saying "Unavailable" and start showing real state on their own — the page polls every 10s and picks them up with no restart.

Two things I'd flag about iat:

The new-ids step is the part most likely to get dropped — it's easy to read "mesh them and tick them" as the whole job and stop there. Meshing alone won't light the tiles up, because the ids in room_config.py are .52 ids and won't resolve.

The button-vs-switch caveat is a genuine open risk, not padding. I inferred those devices take on/off from the switch attribute in the dashboard's device payload, but I've never sent a command to one. If any is a scene-controller-style button device, on/off will fail and that control needs a different command path.

```