### PR TITLE
Use and document service-account database paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # Environment variables:
 # DB_PATH - Environment variable to use for local development.
 #           Uses var/db/temperature-bot.db if not set (note this is a relative path)
-#           For installation, cron & systemd use /var/db/temperature-bot.db
+#           For installation, cron & systemd use /var/db/temperature_bot/temperature-bot.db
 #
 # DEV_DB - your development DB. typically var/db/temperature-bot
 # AE200_SIMULATOR - set to 1 for `make local-dev` -
@@ -35,7 +35,7 @@ FLYWAY_VALIDATE_TEMP := /tmp/temperature-bot-flyway-validate.db
 
 # Remote host and paths used by fetch-dev-db (override as needed for your environment)
 FETCH_HOST              ?= air.basistech.net
-FETCH_REMOTE_DB         ?= /var/db/temperature-bot.db
+FETCH_REMOTE_DB         ?= /var/db/temperature_bot/temperature-bot.db
 FETCH_REMOTE_BACKUP_DIR ?= /var/db/temperature-bot-backups
 FETCH_REMOTE_CONFIG     ?= /home/air/temperature-bot/temperature-bot-config.yaml
 
@@ -44,7 +44,7 @@ FETCH_REMOTE_CONFIG     ?= /home/air/temperature-bot/temperature-bot-config.yaml
 DEPLOY_FLYWAY    ?= Y
 DEPLOY_HOSTNAME   ?= slg1
 DEPLOY_APP_DIR    ?= /home/air/temperature-bot
-DEPLOY_DB         ?= /var/db/temperature-bot.db
+DEPLOY_DB         ?= /var/db/temperature_bot/temperature-bot.db
 DEPLOY_BACKUP_DIR ?= /var/db/temperature-bot-backups
 STAGE_APP_DIR     ?= /home/air-stage/temperature-bot
 STAGE_DB_DIR      ?= /home/air-stage/var/db
@@ -337,11 +337,11 @@ outdated: $(REQ) ## Report outdated Python and CDN dependencies
 ## Cron targets
 ## Here mostly for testing. The actual cron entries are:
 ##
-##  * * * * * cd /home/air/temperature-bot ; DB_PATH=/var/db/temperature-bot.db TEMPERATURE_BOT_INSTANCE=production PERFORMANCE_CLIENT_ID=minute-runner .venv/bin/python -m bin.runner --loglevel INFO >> /home/air/temperature-bot.log 2>&1
+##  * * * * * cd /home/air/temperature-bot ; DB_PATH=/var/db/temperature_bot/temperature-bot.db TEMPERATURE_BOT_INSTANCE=production PERFORMANCE_CLIENT_ID=minute-runner .venv/bin/python -m bin.runner --loglevel INFO >> /home/air/temperature-bot.log 2>&1
 ##
 ##
-## @daily    cd /home/air/temperature-bot ; sleep 15 ; DB_PATH=/var/db/temperature-bot.db .venv/bin/python -m bin.runner --loglevel INFO --daily  >> /home/air/temperature-bot-daily.log 2>&1
-## @hourly   cd /home/air/temperature-bot ; sleep 30 ; DB_PATH=/var/db/temperature-bot.db .venv/bin/python -m bin.runner --loglevel INFO --aqi    >> /home/air/temperature-bot-hourly.log 2>&1
+## @daily    cd /home/air/temperature-bot ; sleep 15 ; DB_PATH=/var/db/temperature_bot/temperature-bot.db .venv/bin/python -m bin.runner --loglevel INFO --daily  >> /home/air/temperature-bot-daily.log 2>&1
+## @hourly   cd /home/air/temperature-bot ; sleep 30 ; DB_PATH=/var/db/temperature_bot/temperature-bot.db .venv/bin/python -m bin.runner --loglevel INFO --aqi    >> /home/air/temperature-bot-hourly.log 2>&1
 ##
 ## Question - should we just have cron do a 'make daily' and 'make every-minute' ?
 
@@ -355,7 +355,7 @@ daily: $(REQ) ## Run the daily data collection runner
 	$(PYTHON) -m bin.runner --daily
 
 monthly-backup: ## Back up the production database with a dated copy
-	sudo cp /var/db/temperature-bot.db /var/db/temperature-bot.backup.$$(date -I).db
+	sudo /bin/cp -f $(DEPLOY_DB) $(DEPLOY_BACKUP_DIR)/temperature-bot.$$(date -I).db
 
 .PHONY: every-minute performance-probe daily monthly-backup
 

--- a/doc/DATABASES.md
+++ b/doc/DATABASES.md
@@ -1,0 +1,142 @@
+# Database Inventory
+
+This is the live SQLite inventory for the Temperature Bot deployment on
+`slg1`. It records which database each instance actually uses and separates
+runtime databases from old working copies, snapshots, and tool caches.
+
+Last verified read-only on 2026-08-25 at 15:42 UTC. The installed systemd
+units and running-process environments are the source of truth; checked-in
+unit files describe intended configuration and may differ from the host.
+
+## Runtime databases
+
+| Database | Consumer | Runtime state | Schema | Latest `devlog` (UTC) | Notes |
+|---|---|---|---|---|---|
+| `/var/db/temperature_bot/temperature-bot.db` | `air_basistech_net.service` and `air-stage_basistech_net.service`, both configured as `temperature_bot` | `air-stage` is running on `127.0.0.1:8100`; `air` is restart-looping because it tries to bind the same port | Flyway V18 | 2026-08-25 13:34:03 | Production database. Staging must not use it; tracked by #218. |
+| `/home/deg/var/db/temperature-bot.db` | `deg1_basistech_net.service`, running as `deg` | Running on `127.0.0.1:8004` | Flyway V18 | 2026-08-25 13:34:03 | David's private copy. The file and existing WAL/SHM sidecars are owned by `deg`, but the parent directory is `root:root` mode `0755`; SQLite cannot reliably create or remove sidecars there. |
+| `/home/simsong/temperature-bot/var/db/temperature-bot.db` | `slg1_basistech_net.service`, running as `simsong` | Running on `127.0.0.1:8003` | Flyway V18 | 2026-08-13 09:34:02 | Simson's private copy. |
+
+No scheduled collector currently uses a database. The `temperature_bot`
+crontab contains only commented entries, and those comments still name the
+retired `/var/db/temperature-bot.db` path. No Temperature Bot systemd timers
+are installed.
+
+## Non-runtime application databases
+
+No effective systemd unit, active cron entry, or running process referenced
+the files in this table during the audit.
+
+| Database | Schema | Latest `devlog` (UTC) | Apparent purpose |
+|---|---|---|---|
+| `/var/db/temperature-bot.db` | Flyway V18 | 2026-08-25 13:34:03 | Retired production path. WAL and SHM files remain, as do references in `~` unit backups and commented cron lines. A read-only `PRAGMA quick_check` did not finish within 90 seconds; do not delete this file until retirement and recovery are verified. |
+| `/home/air/temperature-bot/hold/temperature-bot.db` | Flyway V15 | 2026-08-12 13:50:03 | Held snapshot from before the V16-V18 migrations. |
+| `/home/deg/temperature-bot/var/db/temperature-bot.db` | Flyway V15 | 2026-08-12 20:12:04 | David's former checkout-local working copy; superseded by `/home/deg/var/db/temperature-bot.db`. |
+| `/home/simsong/temperature-bot/temperature-bot.db` | Pre-Flyway schema | 2026-02-17 16:54:43 | Simson's legacy checkout-root working copy. |
+| `/home/air/temperature-bot/temperature-bot.db` | Empty SQLite database | — | Unused 4 KiB file at the application's fallback path. |
+| `/home/air-stage/temperature-bot/temperature-bot.db` | Empty SQLite database | — | Unused 4 KiB file at the application's fallback path. |
+| `/home/deg/air-backup/temperature-bot/temperature-bot.db` | Empty SQLite database | — | Unused 4 KiB file in an old checkout backup. |
+
+The intended private staging path,
+`/home/air-stage/var/db/temperature-bot.db`, does not exist. The installed
+staging unit instead points at production.
+
+## Backup and snapshot databases
+
+These files had no runtime consumer. Matching sizes and timestamps do not prove
+that separate copies are byte-identical or restorable; validate a chosen copy
+before recovery.
+
+The four legacy snapshot names below each exist in all three directories:
+
+- `/var/db`
+- `/home/deg/temperature-bot/var/db`
+- `/home/simsong/temperature-bot/var/db`
+
+| Filename | Copies | Schema | Latest `devlog` (UTC) | Use |
+|---|---:|---|---|---|
+| `temperature-bot.backup-2025-10-24.db` | 3 | Pre-Flyway schema | 2025-10-24 06:17:02 | Historical recovery snapshot. |
+| `temperature-bot.backup-2026-02-19.db` | 3 | Pre-Flyway schema | 2026-02-19 12:20:03 | Historical recovery snapshot. |
+| `temperature-bot.backup.2026-03-23.db` | 3 | Pre-Flyway schema | 2026-03-23 12:07:04 | Historical recovery snapshot. |
+| `temperature-bot.backup.2026-03-24.db` | 3 | Pre-Flyway schema | 2026-03-24 12:41:03 | Historical recovery snapshot. |
+
+The newer snapshot `temperature-bot.20260812T135122Z.db` exists once in each
+of these backup directories:
+
+- `/var/db/temperature-bot-backups`
+- `/home/deg/temperature-bot/var/db/temperature-bot-backups`
+- `/home/simsong/temperature-bot/var/db/temperature-bot-backups`
+
+All three copies are Flyway V15 and have a latest `devlog` timestamp of
+2026-08-12 13:51:04 UTC.
+
+`/var/db/temperature-bot-backups/fetch-dev-db.20260821T121635Z.972929.db` is a
+fourth newer snapshot. It is Flyway V15 with a latest `devlog` timestamp of
+2026-08-13 09:34:02 UTC. Its name identifies it as an incomplete cleanup from
+`make fetch-dev-db`; no consumer referenced it.
+
+## Ancillary SQLite files
+
+| Database | Contents | Consumer |
+|---|---|---|
+| `/home/air/temperature-bot/myapp/storage.db` | Legacy `log` table | No running process or surviving source file references it. |
+| `/home/air-stage/temperature-bot/myapp/storage.db` | Legacy `log` table | No running process or surviving source file references it. |
+| `/home/deg/air-backup/temperature-bot/myapp/storage.db` | Legacy `log` table | No running process or surviving source file references it. |
+| `/home/simsong/temperature-bot/.mypy_cache/3.12/cache.db` | MyPy `files2` cache table | MyPy tooling only; not application data. |
+
+The three `myapp` directories contain bytecode, editor backups, secrets files,
+and `storage.db`, but no live Python source. They are not part of the current
+repository application.
+
+## Path aliases
+
+These symlinks do not create additional databases:
+
+| Alias | Resolves to | Consequence |
+|---|---|---|
+| `/home/air/temperature-bot/var` | `/var` | `/home/air/temperature-bot/var/db/...` is the same file as `/var/db/...`. |
+| `/home/air-stage/temperature-bot/var` | `/var` | A path beneath the staging checkout's `var/db` would also reach `/var/db`; use `/home/air-stage/var/db` for a private staging database. |
+
+## Operational rules
+
+- Give every non-production service a private absolute `DB_PATH`. Only the
+  production service and production collectors may use
+  `/var/db/temperature_bot/temperature-bot.db`.
+- Ensure the service identity can write the database's parent directory as well
+  as the database, WAL, and SHM files. SQLite must be able to create, rename,
+  and remove sidecars.
+- Do not copy a live WAL-mode database with raw `cp` or `rsync`. Use SQLite
+  `.backup`, the backup API, or `VACUUM INTO`, then run `PRAGMA quick_check` on
+  the result.
+- Do not rely on the checkout-root fallback `temperature-bot.db`; every service,
+  timer, and cron job must set `DB_PATH` explicitly.
+- Treat `~` systemd files and commented cron entries as stale references, not
+  effective configuration. Verify with `systemctl show` and running-process
+  environments.
+- Quiesce writers and take a validated snapshot before moving, migrating,
+  replacing, or deleting a runtime database.
+
+## Read-only verification
+
+The core live checks are:
+
+```bash
+systemctl show air_basistech_net.service air-stage_basistech_net.service \
+  deg1_basistech_net.service slg1_basistech_net.service \
+  -p Id -p ActiveState -p SubState -p User -p Group \
+  -p WorkingDirectory -p Environment -p MainPID
+
+sudo grep -R -HEn 'DB_PATH|temperature-bot\.db' \
+  /etc/systemd/system /etc/cron.d /etc/crontab
+sudo sh -c "grep -HEn 'DB_PATH|temperature-bot\.db' \
+  /var/spool/cron/crontabs/*"
+
+sudo find -P /var/db /home/air /home/air-stage /home/deg /home/simsong \
+  -xdev -type f \( -iname '*.db' -o -iname '*.sqlite' \
+  -o -iname '*.sqlite3' \) -path '*temperature-bot*'
+
+sudo lsof -nP | grep -E 'temperature[-_]bot.*\.db(-wal|-shm)?$'
+```
+
+An application may close its SQLite connection between requests, so an empty
+`lsof` result does not prove that a configured database is unused. Effective
+unit and process environments are the primary consumer evidence.

--- a/doc/agent-index.md
+++ b/doc/agent-index.md
@@ -36,6 +36,9 @@ surface quickly.
 - `doc/operations-new-instance.md`: instance inventory, new-deployment runbook,
   Flyway-before-first-start ordering, per-instance deploy overrides, and
   rollback.
+- `doc/DATABASES.md`: live database-to-consumer inventory for `slg1`, including
+  runtime paths, historical copies, backups, symlink aliases, and SQLite safety
+  rules.
 - `doc/rooms-implementation-review.md`: room dashboard debt, open room issues,
   and Hickory/Kitchen dashboard generalization notes.
 - `doc/rooms-implementation-plan.md`: approved FCU-owned room model, grouped

--- a/doc/operations-new-instance.md
+++ b/doc/operations-new-instance.md
@@ -3,7 +3,8 @@
 How to bring up a new Temperature Bot deployment — a fresh host, or an
 additional observation instance on the shared BasisTech server. For schema and
 migration mechanics see `doc/sql-migrations.md`; for the AE-200 probe timer see
-`doc/performance-monitoring.md`.
+`doc/performance-monitoring.md`. For the read-only inventory of database paths
+actually installed on `slg1`, see `doc/DATABASES.md`.
 
 Most steps here are manual. `doc/tech-debt.md` and GitHub issues #31, #76, and
 #180 track automating them. The "Not yet automated" section at the end lists


### PR DESCRIPTION
## Summary

- change production fetch and deploy defaults to `/var/db/temperature_bot/temperature-bot.db`
- update the documented production cron paths
- make `monthly-backup` use `DEPLOY_DB` and the existing `DEPLOY_BACKUP_DIR`
- add `doc/DATABASES.md`, a live database-to-consumer inventory covering runtime databases, working copies, snapshots, ancillary SQLite files, aliases, and safety rules

## Read-only live audit

Effective service database paths on `slg1` at 2026-08-25 15:42 UTC:

- `air_basistech_net.service`: `/var/db/temperature_bot/temperature-bot.db`
- `air-stage_basistech_net.service`: `/var/db/temperature_bot/temperature-bot.db`
- `deg1_basistech_net.service`: `/home/deg/var/db/temperature-bot.db`
- `slg1_basistech_net.service`: `/home/simsong/temperature-bot/var/db/temperature-bot.db`

The new production database and the separate `deg` copy both pass SQLite `PRAGMA quick_check` and contain Flyway schema version 18. The installed staging unit still shares the production database and occupies `127.0.0.1:8100`, leaving the production unit in an auto-restart loop, contrary to #218. The `temperature_bot` crontab currently contains only commented entries, and those comments still name the retired `/var/db/temperature-bot.db` path. The complete read-only inventory is in `doc/DATABASES.md`; this PR does not modify or remove server files.

The production backup directory remains `/var/db/temperature-bot-backups`.

## Validation

- `make check`
- `make dependency-check`
- `make --dry-run monthly-backup`
- `make --dry-run deploy-flyway`
- `make --dry-run fetch-dev-db`

Refs #76.
Refs #218.
