### PR TITLE
Fix SQLite snapshots and service unit paths

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,8 +78,8 @@ make PYTEST_ARGS=tests/test_db.py::test_function_name pytest
 - Validate migrations with `make validate-migrations`.
 - Apply local pending migrations with `make migrate-db`.
 - Production deploy is `make deploy` on the production host. It validates
-  Flyway state, backs up `/var/db/temperature-bot.db`, migrates, and validates
-  again.
+  Flyway state, creates and checks a consistent SQLite snapshot of
+  `/var/db/temperature_bot/temperature-bot.db`, migrates, and validates again.
 
 When adding schema:
 

--- a/Makefile
+++ b/Makefile
@@ -358,6 +358,7 @@ daily: $(REQ) ## Run the daily data collection runner
 
 monthly-backup: ## Back up the production database with a dated copy
 	@set -eu; \
+	umask 077; \
 	backup="$(DEPLOY_BACKUP_DIR)/temperature-bot.$$(date -u +%Y%m%dT%H%M%SZ).db"; \
 	$(MONTHLY_BACKUP_RUNNER) sqlite3 -batch -init /dev/null -cmd ".timeout 30000" \
 	    "$(DEPLOY_DB)" "VACUUM INTO '$$backup';"; \
@@ -435,6 +436,7 @@ deploy-flyway: ## Back up, migrate, and validate the deployment database
 	flyway validate -url="jdbc:sqlite:$(DEPLOY_DB)" -locations="filesystem:$(FLYWAY_SQL_DIR)" -ignoreMigrationPatterns="*:pending"
 	/bin/mkdir -p $(DEPLOY_BACKUP_DIR)
 	@set -eu; \
+	umask 077; \
 	backup="$(DEPLOY_BACKUP_DIR)/temperature-bot.$$(date -u +%Y%m%dT%H%M%SZ).db"; \
 	sqlite3 -batch -init /dev/null -cmd ".timeout 30000" \
 	    "$(DEPLOY_DB)" "VACUUM INTO '$$backup';"; \

--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,13 @@ FETCH_REMOTE_CONFIG     ?= /home/air/temperature-bot/temperature-bot-config.yaml
 
 # Deployment defaults. Override only when intentionally targeting a different
 # checked-out installation or database.
-DEPLOY_FLYWAY    ?= Y
-DEPLOY_HOSTNAME   ?= slg1
-DEPLOY_APP_DIR    ?= /home/air/temperature-bot
-DEPLOY_DB         ?= /var/db/temperature_bot/temperature-bot.db
-DEPLOY_BACKUP_DIR ?= /var/db/temperature-bot-backups
+DEPLOY_FLYWAY          ?= Y
+DEPLOY_HOSTNAME        ?= slg1
+DEPLOY_APP_DIR         ?= /home/air/temperature-bot
+DEPLOY_DB              ?= /var/db/temperature_bot/temperature-bot.db
+DEPLOY_BACKUP_DIR      ?= /var/db/temperature-bot-backups
+DEPLOY_USER            ?= temperature_bot
+MONTHLY_BACKUP_RUNNER  ?= sudo -u $(DEPLOY_USER)
 STAGE_APP_DIR     ?= /home/air-stage/temperature-bot
 STAGE_DB_DIR      ?= /home/air-stage/var/db
 STAGE_DB          ?= $(STAGE_DB_DIR)/temperature-bot.db
@@ -355,7 +357,13 @@ daily: $(REQ) ## Run the daily data collection runner
 	$(PYTHON) -m bin.runner --daily
 
 monthly-backup: ## Back up the production database with a dated copy
-	sudo /bin/cp -f $(DEPLOY_DB) $(DEPLOY_BACKUP_DIR)/temperature-bot.$$(date -I).db
+	@set -eu; \
+	backup="$(DEPLOY_BACKUP_DIR)/temperature-bot.$$(date -u +%Y%m%dT%H%M%SZ).db"; \
+	$(MONTHLY_BACKUP_RUNNER) sqlite3 -batch -init /dev/null -cmd ".timeout 30000" \
+	    "$(DEPLOY_DB)" "VACUUM INTO '$$backup';"; \
+	test "$$($(MONTHLY_BACKUP_RUNNER) sqlite3 -batch -noheader -init /dev/null -readonly "$$backup" \
+	    "PRAGMA quick_check;")" = ok; \
+	echo "Created $$backup"
 
 .PHONY: every-minute performance-probe daily monthly-backup
 
@@ -426,7 +434,13 @@ deploy: ## Deploy latest code and run DB migrations on the production server
 deploy-flyway: ## Back up, migrate, and validate the deployment database
 	flyway validate -url="jdbc:sqlite:$(DEPLOY_DB)" -locations="filesystem:$(FLYWAY_SQL_DIR)" -ignoreMigrationPatterns="*:pending"
 	/bin/mkdir -p $(DEPLOY_BACKUP_DIR)
-	/bin/cp -f $(DEPLOY_DB) $(DEPLOY_BACKUP_DIR)/temperature-bot.$$(date -u +%Y%m%dT%H%M%SZ).db
+	@set -eu; \
+	backup="$(DEPLOY_BACKUP_DIR)/temperature-bot.$$(date -u +%Y%m%dT%H%M%SZ).db"; \
+	sqlite3 -batch -init /dev/null -cmd ".timeout 30000" \
+	    "$(DEPLOY_DB)" "VACUUM INTO '$$backup';"; \
+	test "$$(sqlite3 -batch -noheader -init /dev/null -readonly "$$backup" \
+	    "PRAGMA quick_check;")" = ok; \
+	echo "Created $$backup"
 	flyway migrate -url="jdbc:sqlite:$(DEPLOY_DB)" -locations="filesystem:$(FLYWAY_SQL_DIR)" -baselineOnMigrate=true
 	flyway validate -url="jdbc:sqlite:$(DEPLOY_DB)" -locations="filesystem:$(FLYWAY_SQL_DIR)"
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ edge, but shared keys should be centralized instead of repeated inline.
 ## Operations
 
 The periodic runner is `bin/runner.py`; production cron/systemd entries run it
-against `/var/db/temperature-bot.db`. The `make deploy` target is intended for
-the production host only. It pulls code, installs dependencies, validates
-Flyway migrations, backs up the production SQLite DB, applies pending
+against `/var/db/temperature_bot/temperature-bot.db`. The `make deploy` target
+is intended for the production host only. It pulls code, installs dependencies,
+validates Flyway migrations, backs up the production SQLite DB, applies pending
 migrations, and validates again.
 
 To stand up a new instance, or an additional observation instance on the shared

--- a/doc/Hubitat_Info.md
+++ b/doc/Hubitat_Info.md
@@ -182,13 +182,13 @@ Detailed `status_json` fields such as humidity, illuminance, battery, and
 motion are not preserved in compressed rows. This is already called out as tech
 debt in `doc/tech-debt.md`.
 
-Production database backups are whole-SQLite-file backups:
+Production database backups are consistent SQLite snapshots:
 
-- `make deploy` copies `/var/db/temperature-bot.db` to
+- `make deploy` snapshots `/var/db/temperature_bot/temperature-bot.db` to
   `/var/db/temperature-bot-backups/temperature-bot.<UTC timestamp>.db` before
-  migrations.
-- `make monthly-backup` copies `/var/db/temperature-bot.db` to
-  `/var/db/temperature-bot.backup.<date>.db`.
+  migrations and checks the snapshot with `PRAGMA quick_check`.
+- `make monthly-backup` creates and checks the same kind of timestamped snapshot
+  in `/var/db/temperature-bot-backups`.
 
 The code does not archive Hubitat event history separately. A Maker API event
 history URL is defined in `app/hubitat.py`, but it is not used by the runner.

--- a/doc/operations-new-instance.md
+++ b/doc/operations-new-instance.md
@@ -20,10 +20,10 @@ rather than a canonical record, and is marked unverified where it appears.
 
 | Name | Port | Service unit | App dir | Runs as | `DB_PATH` |
 |---|---|---|---|---|---|
-| `air.basistech.net` | 8100 | `air_basistech_net.service` | `/home/air/temperature-bot` | `simsong` | `/var/db/temperature-bot.db` |
-| staging | 8101 | `air-stage_basistech_net.service` | `/home/air-stage/temperature-bot` | `simsong` | `/home/air-stage/var/db/temperature-bot.db` |
-| `slg1.basistech.net` | 8003 | `slg1_basistech_net.service` | `/home/simsong/temperature-bot` | `simsong` | selectable — see below |
-| `deg1.basistech.net` | 8004 | `deg1_basistech_net.service` | `/home/deg/temperature-bot` | `deg` | selectable — see below |
+| `air.basistech.net` | 8100 | `air_basistech_net.service` | `/home/air/temperature-bot` | `temperature_bot` | `/var/db/temperature_bot/temperature-bot.db` |
+| staging | 8101 | `air-stage_basistech_net.service` | `/home/air-stage/temperature-bot` | `temperature_bot` | `/home/air-stage/var/db/temperature-bot.db` |
+| `slg1.basistech.net` | 8003 | `slg1_basistech_net.service` | `/home/simsong/temperature-bot` | `simsong` | `/home/simsong/temperature-bot/var/db/temperature-bot.db` |
+| `deg1.basistech.net` | 8004 | `deg1_basistech_net.service` | `/home/deg/temperature-bot` | `deg` | `/home/deg/var/db/temperature-bot.db` |
 
 Ports, app directories, service accounts, and `DB_PATH` in this table are read
 from the checked-in unit files in `etc/*.service`, which must be copied to
@@ -36,20 +36,19 @@ resource, and CPU and memory pressure from one instance is felt by all of them �
 including production. Deploying to a "test" instance is not free of production
 risk.
 
-`slg1` and `deg1` are parallel developer instances — one playground each, `slg1`
-for Simson and `deg1` for David. They differ only in DNS name, port, service
-account, and home directory. Neither is more authoritative or more "staging"
-than the other, and neither is inherently a sandbox: each selects its database
-through `DB_PATH` in its own unit file, and can point at the live production
-database or at a private copy. See "Choosing which database a developer instance
-uses" below.
+`slg1` and `deg1` are parallel developer instances — one playground each,
+`slg1` for Simson and `deg1` for David. They differ in DNS name, port, service
+account, home directory, and private database path. Neither is more
+authoritative or more "staging" than the other. Do not point either at the live
+production database.
 
 Consequences worth internalizing before touching anything:
 
 - **Read the installed unit before assuming which database an instance is on.**
   `/etc/systemd/system/<unit>` is what runs; the copy in `etc/` is only what was
   last committed, and the two drift. An instance pointed at
-  `/var/db/temperature-bot.db` is another front end on live production data.
+  `/var/db/temperature_bot/temperature-bot.db` is another front end on live
+  production data.
 - **Pointing at production is not read-only.** The web app writes — changelog
   entries, rules-disable timers, device metadata — and SQLite in WAL mode needs
   write access to the database and its directory even to read.
@@ -157,7 +156,7 @@ Or seed from a production snapshot instead, which carries its Flyway history
 with it:
 
 ```bash
-sqlite3 /var/db/temperature-bot.db ".backup '<DB_PATH>'"
+sqlite3 /var/db/temperature_bot/temperature-bot.db ".backup '<DB_PATH>'"
 ```
 
 > **Order matters.** If the Flask app or the runner starts against a missing or
@@ -252,32 +251,31 @@ Then load the site through nginx and confirm the dashboard renders. Watch CPU
 and memory for a few minutes — the shared machine hosts several instances, and
 worker counts are generous.
 
-## Choosing which database a developer instance uses
+## Refreshing a developer instance's private database
 
-`slg1` and `deg1` each select their database with `DB_PATH` in their unit file.
-Switching between the live production database and a private copy is routine:
-production data makes a change realistic, a private copy makes it safe. This
-section is the procedure for both instances — substitute the account, port, and
-unit name from the inventory table.
+`slg1` and `deg1` each use the private database named by `DB_PATH` in their unit
+file. Refresh that copy from a consistent production snapshot when realistic
+data is needed. This procedure applies to both instances; substitute the
+account, port, and unit name from the inventory table.
 
 ### 1. Get a database to point at
 
-Skip this when switching *to* production. To take a private copy, run this on
-the server:
+To take a private copy for `deg1`, run this on the server:
 
 ```bash
-mkdir -p /home/deg/temperature-bot/var/db
-sqlite3 /var/db/temperature-bot.db \
-  ".backup '/home/deg/temperature-bot/var/db/temperature-bot.db'"
+mkdir -p /home/deg/var/db
+sqlite3 /var/db/temperature_bot/temperature-bot.db \
+  ".backup '/home/deg/var/db/temperature-bot.db'"
 ```
 
 `.backup` is the right tool here: production is written every minute, and it
 takes a consistent snapshot where `cp` can capture a torn page.
 
-If reading `/var/db/temperature-bot.db` requires `sudo`, `chown` the copy to the
-service account afterwards. A root-owned copy leaves the instance unable to
-write it, which surfaces as the permission failure described below rather than
-as anything mentioning ownership.
+If reading `/var/db/temperature_bot/temperature-bot.db` requires `sudo`, run the
+snapshot as the target service account or `chown` the copy afterwards. A
+root-owned copy leaves the instance unable to write it, which surfaces as the
+permission failure described below rather than as anything mentioning
+ownership.
 
 `make fetch-dev-db` also produces this layout, but it is built for a developer
 laptop — it rsyncs `air.basistech.net:/var/db/` (the same machine, when run on
@@ -293,8 +291,8 @@ Edit the instance's unit in `etc/` so the change is versioned rather than only
 live, then install it:
 
 ```bash
-# Edit etc/deg1_basistech_net.service so exactly one DB_PATH line is active:
-#   Environment="DB_PATH=/home/deg/temperature-bot/var/db/temperature-bot.db"
+# Verify etc/deg1_basistech_net.service names the private DB_PATH:
+#   Environment="DB_PATH=/home/deg/var/db/temperature-bot.db"
 sudo cp -f etc/deg1_basistech_net.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl restart deg1_basistech_net.service
@@ -385,7 +383,7 @@ at production:
 ```bash
 make DEPLOY_HOSTNAME="$(hostname)" \
      DEPLOY_APP_DIR=/home/deg/temperature-bot \
-     DEPLOY_DB=/home/deg/temperature-bot/var/db/temperature-bot.db \
+     DEPLOY_DB=/home/deg/var/db/temperature-bot.db \
      DEPLOY_BACKUP_DIR=/home/deg/temperature-bot-backups \
      deploy
 ```
@@ -395,11 +393,11 @@ unconditionally pass, so check `DEPLOY_DB` twice before running it. It must name
 the database the instance's *installed* unit actually uses — confirm with
 `systemctl show -p Environment <unit>` rather than reading the copy in `etc/`.
 The path above is the private-copy case. Migrating a database the instance does
-not read accomplishes nothing, and an instance currently pointed at
-`/var/db/temperature-bot.db` would instead have `make deploy` migrate the
-production database, which is human-authorized and human-executed only. A
-dedicated per-instance target with fixed values would be safer, and is listed
-below as missing automation.
+not read accomplishes nothing, and an instance pointed at
+`/var/db/temperature_bot/temperature-bot.db` would instead have `make deploy`
+migrate the production database, which is human-authorized and human-executed
+only. A dedicated per-instance target with fixed values would be safer, and is
+listed below as missing automation.
 
 `make deploy-stage` is the only fully automated non-production path, and its
 account, paths, and service name are hardcoded to `air-stage`.
@@ -447,8 +445,6 @@ Known gaps, so they can be planned rather than rediscovered:
 - **Cron entries** exist only as Makefile comments.
 - **No per-instance deploy targets.** `make deploy` is gated to `slg1` with
   production paths; `make deploy-stage` is hardcoded to `air-stage`.
-- **Inconsistent service accounts and paths** across the checked-in units.
-  Issue #76 proposes a single deploy user.
-- **Backups use `cp`** on a live, continuously written SQLite database, rather
-  than `sqlite3 .backup`. `deploy-stage` does this correctly; `deploy-flyway`
-  does not.
+- **Installed-unit drift.** The checked-in units now separate production,
+  staging, and developer databases, but nothing validates that the installed
+  units match them. Issue #76 tracks the remaining service-account work.

--- a/doc/performance-monitoring.md
+++ b/doc/performance-monitoring.md
@@ -81,7 +81,7 @@ The probe is a separate short-lived process, intended to run once per minute:
 
 ```cron
 * * * * * cd /home/air/temperature-bot && \
-  DB_PATH=/var/db/temperature-bot.db \
+  DB_PATH=/var/db/temperature_bot/temperature-bot.db \
   TEMPERATURE_BOT_INSTANCE=production \
   PERFORMANCE_CLIENT_ID=network-probe \
   .venv/bin/python -m bin.performance_monitor --once \

--- a/doc/sql-migrations.md
+++ b/doc/sql-migrations.md
@@ -100,8 +100,11 @@ flyway \
 1. Pulls the latest code in `/home/air/temperature-bot`.
 2. Synchronizes production dependencies from `uv.lock`.
 3. Validates already-applied migrations against
-   `/var/db/temperature-bot.db`, allowing only migrations that are pending.
-4. Copies the DB to `/var/db/temperature-bot-backups/temperature-bot.<UTC timestamp>.db`.
+   `/var/db/temperature_bot/temperature-bot.db`, allowing only migrations that
+   are pending.
+4. Creates a consistent SQLite snapshot in
+   `/var/db/temperature-bot-backups/temperature-bot.<UTC timestamp>.db` and
+   validates it with `PRAGMA quick_check`.
 5. Applies pending migrations with `-baselineOnMigrate=true`.
 6. Runs `flyway validate` again.
 
@@ -124,12 +127,12 @@ the staging service, atomically replaces its database, and restarts the service.
 The staging Gunicorn service listens on `127.0.0.1:8101` and never migrates or
 writes through the production database.
 
-The current deploy target does not stop the every-minute writer and uses a
-filesystem copy rather than SQLite's consistent backup API. Until GitHub issues
-tracking those deploy safeguards are resolved, a rooms migration must be
-performed in a maintenance window: stop the cron runner, verify no runner is
-active, create a consistent `sqlite3 ... .backup` snapshot, run the migration
-and smoke checks, and only then restart the runner.
+The current deploy target does not stop the every-minute writer. Its preflight
+snapshot is consistent, but the migration itself still needs a maintenance
+window. Until GitHub issues tracking that deploy safeguard are resolved, a
+rooms migration must be performed in a maintenance window: stop the cron
+runner, verify no runner is active, create a consistent `sqlite3 ... .backup`
+snapshot, run the migration and smoke checks, and only then restart the runner.
 
 To roll back a room migration, stop all writers again, preserve the failed
 database for diagnosis, restore the complete pre-migration SQLite backup

--- a/doc/tech-debt.md
+++ b/doc/tech-debt.md
@@ -189,19 +189,19 @@ Current state:
 
 - The checked-in Gunicorn service units omit `--reload`, matching the manually
   corrected live production process.
-- `etc/air_basistech_net.service` still runs as `User=simsong` and `Group=simsong`
-  while using `/home/air/temperature-bot`.
-- `etc/slg1_basistech_net.service` uses `/home/simsong/temperature-bot`.
-- `etc/deg1_basistech_net.service` uses `/home/deg/temperature-bot`.
-- `make deploy` assumes `/home/air/temperature-bot` and `/var/db/temperature-bot.db`,
-  but server files still require manual placement.
+- Checked-in production and staging units run as `temperature_bot`; the `slg1`
+  and `deg1` developer units retain their personal accounts and private
+  databases.
+- `make deploy` assumes `/home/air/temperature-bot` and
+  `/var/db/temperature_bot/temperature-bot.db`, but server files still require
+  manual placement.
 - `doc/deg-progress-notes.md` still contains open questions about syncing nginx
   and systemd files.
 
 Recommended direction:
 
-- Choose one production service account, likely `air`, and make ownership,
-  systemd units, cron/runner setup, and deploy paths match it.
+- Reconcile the installed units and cron entries with the checked-in
+  `temperature_bot` ownership and production database path.
 - Add Makefile targets to install or validate nginx/systemd files non-
   interactively.
 - Document the restart and new-machine procedure in a real operations doc, then
@@ -213,8 +213,8 @@ Relevant issues: #180, #177, #76, #31, #44, #30.
 
 Current state:
 
-- `make deploy` backs up the production SQLite DB before migrations.
-- `make monthly-backup` copies `/var/db/temperature-bot.db`.
+- `make deploy` and `make monthly-backup` create consistent SQLite snapshots
+  with `VACUUM INTO` and validate them with `PRAGMA quick_check`.
 - There is no complete documented backup/restore procedure for the DB plus
   `temperature-bot-config.yaml` and other credentials.
 

--- a/etc/air-stage_basistech_net.service
+++ b/etc/air-stage_basistech_net.service
@@ -4,8 +4,8 @@ Description=Gunicorn instance to serve the Flask application
 After=network.target
 
 [Service]
-User=simsong
-Group=simsong
+User=temperature_bot
+Group=temperature_bot
 WorkingDirectory=/home/air-stage/temperature-bot
 Environment="PATH=/home/air-stage/temperature-bot/.venv/bin"
 Environment="DB_PATH=/home/air-stage/var/db/temperature-bot.db"

--- a/etc/air_basistech_net.service
+++ b/etc/air_basistech_net.service
@@ -4,11 +4,11 @@ Description=Gunicorn instance to serve the Flask application
 After=network.target
 
 [Service]
-User=simsong
-Group=simsong
+User=temperature_bot
+Group=temperature_bot
 WorkingDirectory=/home/air/temperature-bot
 Environment="PATH=/home/air/temperature-bot/.venv/bin"
-Environment="DB_PATH=/var/db/temperature-bot.db"
+Environment="DB_PATH=/var/db/temperature_bot/temperature-bot.db"
 Environment="TEMPERATURE_BOT_INSTANCE=production"
 Environment="PERFORMANCE_CLIENT_ID=web"
 ExecStart=/bin/bash -c 'gunicorn app.main:app --bind 127.0.0.1:8100 --workers $((2 * $(/usr/bin/nproc) + 1))'

--- a/etc/deg1_basistech_net.service
+++ b/etc/deg1_basistech_net.service
@@ -9,10 +9,7 @@ Group=deg
 WorkingDirectory=/home/deg/temperature-bot
 Environment="PATH=/home/deg/temperature-bot/.venv/bin"
 
-# Enable this line to use local copy of DB
-# Environment="DB_PATH=/home/deg/temperature-bot/var/db/temperature-bot.db"
-# Enable this line to run using live DB
-Environment="DB_PATH=/var/db/temperature-bot.db"
+Environment="DB_PATH=/home/deg/var/db/temperature-bot.db"
 
 Environment="LOG_LEVEL=DEBUG"
 ExecStart=/bin/bash -c 'LOG_LEVEL=DEBUG gunicorn app.main:app --log-level debug --bind 127.0.0.1:8004 --workers $((2 * $(/usr/bin/nproc) + 1)) --access-logfile /home/deg/access.log --error-logfile /home/deg/error.log'

--- a/etc/slg1_basistech_net.service
+++ b/etc/slg1_basistech_net.service
@@ -8,7 +8,7 @@ User=simsong
 Group=simsong
 WorkingDirectory=/home/simsong/temperature-bot
 Environment="PATH=/home/simsong/temperature-bot/.venv/bin"
-Environment="DB_PATH=/var/db/temperature-bot.db"
+Environment="DB_PATH=/home/simsong/temperature-bot/var/db/temperature-bot.db"
 Environment="LOG_LEVEL=DEBUG"
 ExecStart=/bin/bash -c 'LOG_LEVEL=DEBUG gunicorn app.main:app --log-level debug --bind 127.0.0.1:8003 --workers $((2 * $(/usr/bin/nproc) + 1)) --access-logfile /home/simsong/access.log --error-logfile /home/simsong/error.log'
 Restart=always

--- a/etc/temperature-bot-ae200-notifications.service
+++ b/etc/temperature-bot-ae200-notifications.service
@@ -6,11 +6,11 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=simsong
-Group=simsong
+User=temperature_bot
+Group=temperature_bot
 WorkingDirectory=/home/air/temperature-bot
 Environment="PATH=/home/air/temperature-bot/.venv/bin:/usr/bin:/bin"
-Environment="DB_PATH=/var/db/temperature-bot.db"
+Environment="DB_PATH=/var/db/temperature_bot/temperature-bot.db"
 Environment="TEMPERATURE_BOT_INSTANCE=production"
 EnvironmentFile=-/etc/temperature-bot-ae200-notifications.env
 ExecStart=/home/air/temperature-bot/.venv/bin/python -m bin.ae200_notifications

--- a/etc/temperature-bot-performance-monitor.service
+++ b/etc/temperature-bot-performance-monitor.service
@@ -6,11 +6,11 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-User=simsong
-Group=simsong
+User=temperature_bot
+Group=temperature_bot
 WorkingDirectory=/home/air/temperature-bot
 Environment="PATH=/home/air/temperature-bot/.venv/bin:/usr/bin:/bin"
-Environment="DB_PATH=/var/db/temperature-bot.db"
+Environment="DB_PATH=/var/db/temperature_bot/temperature-bot.db"
 Environment="TEMPERATURE_BOT_INSTANCE=production"
 Environment="PERFORMANCE_CLIENT_ID=network-probe"
 ExecStart=/home/air/temperature-bot/.venv/bin/python -m bin.performance_monitor --once


### PR DESCRIPTION
## Summary

- replace raw live-SQLite copies in `monthly-backup` and `deploy-flyway` with `VACUUM INTO` snapshots plus `PRAGMA quick_check`
- align the checked-in production, staging, `deg1`, and `slg1` systemd templates with their intended service identities and database paths
- update operations, migration, monitoring, and backup documentation to match the safe snapshot and database-isolation rules

## Validation

- `make check`
- `make TEMPERATURE_BOT_CONFIG=/Users/simsong/gits/basistech_temperature-bot/temperature-bot-config.yaml test` (534 passed, 1 live-device test skipped; all JavaScript tests passed)
- disposable-database `make monthly-backup` snapshot and integrity-check trial
- disposable-database `make deploy-flyway` snapshot, integrity-check, and Flyway validate/migrate/validate trial

Follow-up to #221 and its Copilot review. Advances #218 and #76; applying the checked-in units to the live host remains an operations step.
