### PR TITLE
Replace cron scheduling and build deployment packages

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -129,3 +129,44 @@ jobs:
           verbose: true
           files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  deployment-package:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      UV_VERSION: '0.11.26'
+      FLYWAY_VERSION: '12.8.1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Build and install deployment package in a disposable root
+        run: make deployment-package-check
+
+      - name: Verify systemd units
+        run: make systemd-verify
+
+      - name: Upload ephemeral deployment package
+        uses: actions/upload-artifact@v7
+        with:
+          name: temperature-bot-deployment-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          path: |
+            dist/temperature-bot-deployment-*.zip
+            dist/temperature-bot-deployment-*.zip.sha256
+          if-no-files-found: error
+          retention-days: 5
+          compression-level: 0

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .playwright
 __pycache__/
 activate
+build/
 config.yaml
 coverage.xml
 debug_page*

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,11 @@ export PLAYWRIGHT_BROWSERS_PATH := .playwright
 # Pin tool versions (helps avoid "invisible" cache invalidations)
 UV_VERSION     ?= 0.11.26
 RUFF_VERSION   ?= 0.15.15
+FLYWAY_VERSION ?= 12.8.1
+
+DEPLOYMENT_BUILD_DIR    := build/deployment-package
+DEPLOYMENT_REQUIREMENTS := $(DEPLOYMENT_BUILD_DIR)/runtime.txt
+SYSTEMD_SCHEDULED_DIR  := etc/systemd
 
 # Test selection override, e.g.
 #   make PYTEST_ARGS=tests/test_db.py::test_name pytest
@@ -263,6 +268,51 @@ build-check: build ## Install the wheel in a clean environment and import the ap
 	AE200_SIMULATOR=1 HUBITAT_SIMULATOR=1 AIRTHINGS_SIMULATOR=1 AQICN_SIMULATOR=1 \
 	"$$build_tmp/venv/bin/python" -c 'from wsgi import app; assert app.name == "app.main"'
 
+$(DEPLOYMENT_REQUIREMENTS): uv.lock pyproject.toml | $(REQ)
+	mkdir -p $(DEPLOYMENT_BUILD_DIR)
+	uv export --quiet --locked --no-dev --no-editable --no-emit-project \
+	    --output-file $(DEPLOYMENT_REQUIREMENTS)
+
+deployment-package: build $(DEPLOYMENT_REQUIREMENTS) ## Build the deployment ZIP and SHA-256 sidecar
+	$(PYTHON) -m bin.build_deployment_package \
+	    --requirements $(DEPLOYMENT_REQUIREMENTS) \
+	    --output-dir dist \
+	    --flyway-version $(FLYWAY_VERSION)
+
+deployment-package-verify: deployment-package ## Verify the deployment ZIP inventory and hashes
+	@package="$$(ls -1t dist/temperature-bot-deployment-*.zip | head -1)"; \
+	$(PYTHON) -m bin.install_deployment_package \
+	    "$$package" --require-checksum --verify-only >/dev/null; \
+	echo "Verified $$package"
+
+deployment-package-check: deployment-package ## Install the package into a disposable immutable root
+	@package="$$(ls -1t dist/temperature-bot-deployment-*.zip | head -1)"; \
+	install_tmp="$$(mktemp -d)"; \
+	trap 'rm -rf "$$install_tmp"' EXIT; \
+	$(PYTHON) -m bin.install_deployment_package \
+	    "$$package" --require-checksum \
+	    --root "$$install_tmp/opt/temperature-bot" \
+	    --systemd-dir "$$install_tmp/etc/systemd/system" \
+	    --activate >/dev/null; \
+	test -L "$$install_tmp/opt/temperature-bot/current"; \
+	test -x "$$install_tmp/opt/temperature-bot/current/venv/bin/python"; \
+	test -f "$$install_tmp/etc/systemd/system/temperature-bot-minute.timer"; \
+	echo "Installed and activated $$package in a disposable root"
+
+systemd-verify: ## Validate packaged scheduled-job units on Linux
+	@command -v systemd-analyze >/dev/null || \
+	    { echo "systemd-analyze is required for systemd-verify"; exit 1; }
+	systemd-analyze verify \
+	    $(wildcard $(SYSTEMD_SCHEDULED_DIR)/*.service) \
+	    $(wildcard $(SYSTEMD_SCHEDULED_DIR)/*.timer)
+	@if command -v rg >/dev/null; then \
+		! rg -n 'User=(simsong|deg|root)|Group=(simsong|deg|root)|/home/' \
+		    $(SYSTEMD_SCHEDULED_DIR); \
+	else \
+		! grep -ERn 'User=(simsong|deg|root)|Group=(simsong|deg|root)|/home/' \
+		    $(SYSTEMD_SCHEDULED_DIR); \
+	fi
+
 format: $(REQ) ## Auto-fix Python style issues with ruff
 	uv run --locked ruff check --fix app | etc/ruff-reformat.bash
 
@@ -331,33 +381,29 @@ outdated: $(REQ) ## Report outdated Python and CDN dependencies
 	@echo "=== CDN libraries (in templates) ==="
 	bash etc/check-cdn-versions.bash
 
-.PHONY: lint check dependency-check build build-check format pylint ruff-check no-type-ignore pylint-check djlint eslint check-types pytest test-js test playwright-install web-screenshots outdated
+.PHONY: lint check dependency-check build build-check deployment-package deployment-package-verify deployment-package-check systemd-verify format pylint ruff-check no-type-ignore pylint-check djlint eslint check-types pytest test-js test playwright-install web-screenshots outdated
 
 ################################################################
-## Cron targets
-## Here mostly for testing. The actual cron entries are:
-##
-##  * * * * * cd /home/air/temperature-bot ; DB_PATH=/var/db/temperature_bot/temperature-bot.db TEMPERATURE_BOT_INSTANCE=production PERFORMANCE_CLIENT_ID=minute-runner .venv/bin/python -m bin.runner --loglevel INFO >> /home/air/temperature-bot.log 2>&1
-##
-##
-## @daily    cd /home/air/temperature-bot ; sleep 15 ; DB_PATH=/var/db/temperature_bot/temperature-bot.db .venv/bin/python -m bin.runner --loglevel INFO --daily  >> /home/air/temperature-bot-daily.log 2>&1
-## @hourly   cd /home/air/temperature-bot ; sleep 30 ; DB_PATH=/var/db/temperature_bot/temperature-bot.db .venv/bin/python -m bin.runner --loglevel INFO --aqi    >> /home/air/temperature-bot-hourly.log 2>&1
-##
-## Question - should we just have cron do a 'make daily' and 'make every-minute' ?
+## Scheduled runner targets
+## Production uses the checked-in systemd oneshot services and timers described
+## in doc/systemd-scheduled-jobs.md. These targets remain useful for manual runs.
 
 every-minute: $(REQ) ## Run the per-minute data collection runner
 	PERFORMANCE_CLIENT_ID=minute-runner $(PYTHON) -m bin.runner
+
+hourly: $(REQ) ## Run the hourly AQI collection runner
+	PERFORMANCE_CLIENT_ID=hourly-runner $(PYTHON) -m bin.runner --aqi
 
 performance-probe: $(REQ) ## Record one AE-200 DNS, ICMP, and TCP-reject probe
 	PERFORMANCE_CLIENT_ID=network-probe $(PYTHON) -m bin.performance_monitor --once
 
 daily: $(REQ) ## Run the daily data collection runner
-	$(PYTHON) -m bin.runner --daily
+	PERFORMANCE_CLIENT_ID=daily-runner $(PYTHON) -m bin.runner --daily
 
 monthly-backup: ## Back up the production database with a dated copy
 	sudo /bin/cp -f $(DEPLOY_DB) $(DEPLOY_BACKUP_DIR)/temperature-bot.$$(date -I).db
 
-.PHONY: every-minute performance-probe daily monthly-backup
+.PHONY: every-minute hourly performance-probe daily monthly-backup
 
 ################################################################
 ## Installation targets
@@ -389,6 +435,7 @@ clean: ## Remove generated files and the virtual environment
 	rm -rf .playwright
 	rm -rf htmlcov
 	rm -rf dist
+	rm -rf build
 	rm -rf var/web-ui-screenshots
 	rm -f coverage.xml
 	rm -f .coverage

--- a/README.md
+++ b/README.md
@@ -65,11 +65,20 @@ edge, but shared keys should be centralized instead of repeated inline.
 
 ## Operations
 
-The periodic runner is `bin/runner.py`; production cron/systemd entries run it
-against `/var/db/temperature-bot.db`. The `make deploy` target is intended for
-the production host only. It pulls code, installs dependencies, validates
+The periodic runner is `bin/runner.py`; canonical production scheduling is now
+defined by checked-in systemd oneshot services and timers that run it against
+`/var/db/temperature_bot/temperature-bot.db`. See
+`doc/systemd-scheduled-jobs.md` for installation, observation, and deployment
+quiescence. The units are not installed by this repository change. The `make
+deploy` target is intended for the production host only. It pulls code,
+installs dependencies, validates
 Flyway migrations, backs up the production SQLite DB, applies pending
 migrations, and validates again.
+
+`doc/DEPLOYMENT_PACKAGE.md` defines the ZIP artifact containing the wheel,
+locked runtime requirements, Flyway migrations, systemd units, installer, and
+manifest. Pull requests build and install this package in a disposable root;
+their Actions artifacts expire after five days and are not production releases.
 
 To stand up a new instance, or an additional observation instance on the shared
 server, follow `doc/operations-new-instance.md`.

--- a/app/deployment_package.py
+++ b/app/deployment_package.py
@@ -14,7 +14,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 MANIFEST_PATH = "manifest.json"
-PACKAGE_FORMAT_VERSION = 1
+PACKAGE_FORMAT_VERSION: Literal[1] = 1
 PackageRole = Literal[
     "wheel",
     "requirements",

--- a/app/deployment_package.py
+++ b/app/deployment_package.py
@@ -1,0 +1,297 @@
+"""Build, verify, and safely extract Temperature Bot deployment packages."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import tempfile
+import zipfile
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+MANIFEST_PATH = "manifest.json"
+PACKAGE_FORMAT_VERSION = 1
+PackageRole = Literal[
+    "wheel",
+    "requirements",
+    "migration",
+    "systemd",
+    "configuration",
+    "installer",
+    "documentation",
+    "metadata",
+]
+
+
+def validate_package_path(value: str) -> str:
+    """Return a normalized safe relative ZIP member path."""
+    path = PurePosixPath(value)
+    if (
+        not value
+        or "\\" in value
+        or path.is_absolute()
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or str(path) != value
+    ):
+        raise ValueError(f"unsafe deployment package path: {value!r}")
+    return value
+
+
+class PayloadSource(BaseModel):
+    """One source file and its intended path inside a deployment ZIP."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    source: Path
+    path: str
+    role: PackageRole
+    mode: int = Field(default=0o644, ge=0, le=0o777)
+
+    _safe_path = field_validator("path")(validate_package_path)
+
+    @field_validator("source")
+    @classmethod
+    def source_is_file(cls, value: Path) -> Path:
+        if not value.is_file():
+            raise ValueError(f"deployment payload is not a file: {value}")
+        return value
+
+
+class PackageFile(BaseModel):
+    """Integrity and installation metadata for one ZIP member."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    role: PackageRole
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    size: int = Field(ge=0)
+    mode: int = Field(ge=0, le=0o777)
+
+    _safe_path = field_validator("path")(validate_package_path)
+
+
+class PackageIdentity(BaseModel):
+    """Build identity recorded independently of mutable Git state."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    application: Literal["temperature-bot"] = "temperature-bot"
+    version: str = Field(min_length=1)
+    commit: str = Field(pattern=r"^[0-9a-f]{7,64}$")
+    built_at: datetime
+    dirty: bool = False
+    requires_python: str = Field(min_length=1)
+    flyway_version: str = Field(min_length=1)
+
+
+class DeploymentManifest(PackageIdentity):
+    """Canonical contract for one deployment package."""
+
+    format_version: Literal[1] = PACKAGE_FORMAT_VERSION
+    wheel: str
+    requirements: str
+    migrations: list[str]
+    systemd_units: list[str]
+    files: list[PackageFile]
+
+    _safe_wheel = field_validator("wheel")(validate_package_path)
+    _safe_requirements = field_validator("requirements")(validate_package_path)
+
+    @field_validator("migrations", "systemd_units")
+    @classmethod
+    def safe_path_list(cls, values: list[str]) -> list[str]:
+        return [validate_package_path(value) for value in values]
+
+    @model_validator(mode="after")
+    def validate_inventory(self) -> "DeploymentManifest":
+        paths = [item.path for item in self.files]
+        if len(paths) != len(set(paths)):
+            raise ValueError("deployment manifest contains duplicate paths")
+        wheel_paths = [item.path for item in self.files if item.role == "wheel"]
+        if wheel_paths != [self.wheel]:
+            raise ValueError("wheel does not identify a wheel payload")
+        requirement_paths = [item.path for item in self.files if item.role == "requirements"]
+        if requirement_paths != [self.requirements]:
+            raise ValueError("requirements does not identify a requirements payload")
+        migration_paths = sorted(item.path for item in self.files if item.role == "migration")
+        if self.migrations != migration_paths:
+            raise ValueError("migration list does not match payload inventory")
+        unit_paths = sorted(item.path for item in self.files if item.role == "systemd")
+        if self.systemd_units != unit_paths:
+            raise ValueError("systemd unit list does not match payload inventory")
+        unit_names = [PurePosixPath(path).name for path in self.systemd_units]
+        if len(unit_names) != len(set(unit_names)):
+            raise ValueError("systemd unit names are not unique")
+        if any(PurePosixPath(path).suffix not in {".service", ".timer"} for path in unit_paths):
+            raise ValueError("systemd payload is not a service or timer")
+        return self
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _zip_info(path: str, mode: int) -> zipfile.ZipInfo:
+    info = zipfile.ZipInfo(path)
+    info.create_system = 3
+    info.external_attr = (stat.S_IFREG | mode) << 16
+    return info
+
+
+def _single_role(payloads: list[PayloadSource], role: PackageRole) -> str:
+    paths = [payload.path for payload in payloads if payload.role == role]
+    if len(paths) != 1:
+        raise ValueError(f"deployment package requires exactly one {role} payload")
+    return paths[0]
+
+
+def build_package(
+    output: Path, identity: PackageIdentity, payloads: list[PayloadSource]
+) -> DeploymentManifest:
+    """Create an atomic ZIP and outer SHA-256 sidecar."""
+    paths = [payload.path for payload in payloads]
+    if len(paths) != len(set(paths)):
+        raise ValueError("deployment payload contains duplicate paths")
+
+    files = [
+        PackageFile(
+            path=payload.path,
+            role=payload.role,
+            sha256=sha256_file(payload.source),
+            size=payload.source.stat().st_size,
+            mode=payload.mode,
+        )
+        for payload in sorted(payloads, key=lambda item: item.path)
+    ]
+    manifest = DeploymentManifest(
+        **identity.model_dump(),
+        wheel=_single_role(payloads, "wheel"),
+        requirements=_single_role(payloads, "requirements"),
+        migrations=sorted(payload.path for payload in payloads if payload.role == "migration"),
+        systemd_units=sorted(payload.path for payload in payloads if payload.role == "systemd"),
+        files=files,
+    )
+    manifest_bytes = (manifest.model_dump_json(indent=2) + "\n").encode()
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=output.parent, suffix=".zip", delete=False) as temp:
+        temp_path = Path(temp.name)
+    try:
+        with zipfile.ZipFile(
+            temp_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+        ) as archive:
+            archive.writestr(_zip_info(MANIFEST_PATH, 0o644), manifest_bytes)
+            for payload in sorted(payloads, key=lambda item: item.path):
+                archive.writestr(
+                    _zip_info(payload.path, payload.mode), payload.source.read_bytes()
+                )
+        os.replace(temp_path, output)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+    checksum_path = output.with_suffix(output.suffix + ".sha256")
+    checksum_path.write_text(f"{sha256_file(output)}  {output.name}\n", encoding="utf-8")
+    return manifest
+
+
+def _read_manifest(archive: zipfile.ZipFile) -> DeploymentManifest:
+    try:
+        raw_manifest = archive.read(MANIFEST_PATH)
+    except KeyError as error:
+        raise ValueError("deployment package has no manifest.json") from error
+    try:
+        return DeploymentManifest.model_validate_json(raw_manifest)
+    except ValueError as error:
+        raise ValueError(f"invalid deployment manifest: {error}") from error
+
+
+def verify_package(package: Path) -> DeploymentManifest:
+    """Validate ZIP structure, CRCs, manifest, modes, sizes, and SHA-256 hashes."""
+    with zipfile.ZipFile(package) as archive:
+        infos = archive.infolist()
+        names = [info.filename for info in infos]
+        if len(names) != len(set(names)):
+            raise ValueError("deployment package contains duplicate ZIP members")
+        for info in infos:
+            validate_package_path(info.filename)
+            file_type = (info.external_attr >> 16) & 0o170000
+            if file_type not in {0, stat.S_IFREG}:
+                raise ValueError(f"deployment package member is not a regular file: {info.filename}")
+        corrupt = archive.testzip()
+        if corrupt is not None:
+            raise ValueError(f"deployment package CRC check failed: {corrupt}")
+
+        manifest = _read_manifest(archive)
+        expected = {MANIFEST_PATH, *(item.path for item in manifest.files)}
+        if set(names) != expected:
+            missing = sorted(expected - set(names))
+            extra = sorted(set(names) - expected)
+            raise ValueError(f"deployment package inventory mismatch; missing={missing}, extra={extra}")
+
+        by_name = {info.filename: info for info in infos}
+        for item in manifest.files:
+            data = archive.read(item.path)
+            if len(data) != item.size:
+                raise ValueError(f"deployment package size mismatch: {item.path}")
+            if sha256_bytes(data) != item.sha256:
+                raise ValueError(f"deployment package SHA-256 mismatch: {item.path}")
+            mode = (by_name[item.path].external_attr >> 16) & 0o777
+            if mode != item.mode:
+                raise ValueError(f"deployment package mode mismatch: {item.path}")
+        return manifest
+
+
+def verify_outer_checksum(package: Path, checksum_path: Path | None = None) -> None:
+    """Verify the builder's whole-ZIP SHA-256 sidecar."""
+    sidecar = checksum_path or package.with_suffix(package.suffix + ".sha256")
+    fields = sidecar.read_text(encoding="utf-8").strip().split()
+    if len(fields) != 2 or fields[1] != package.name:
+        raise ValueError(f"invalid deployment package checksum file: {sidecar}")
+    if fields[0] != sha256_file(package):
+        raise ValueError("deployment package outer SHA-256 mismatch")
+
+
+def extract_verified_package(package: Path, destination: Path) -> DeploymentManifest:
+    """Verify and extract without extractall(), symlinks, or path traversal."""
+    manifest = verify_package(package)
+    if destination.exists():
+        raise FileExistsError(destination)
+    destination.mkdir(parents=True)
+    with zipfile.ZipFile(package) as archive:
+        for item in manifest.files:
+            target = destination.joinpath(*PurePosixPath(item.path).parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(archive.read(item.path))
+            target.chmod(item.mode)
+        manifest_target = destination / MANIFEST_PATH
+        manifest_target.write_bytes(archive.read(MANIFEST_PATH))
+        manifest_target.chmod(0o644)
+    return manifest
+
+
+def verify_extracted_payload(destination: Path, manifest: DeploymentManifest) -> None:
+    """Verify immutable package files in an existing release directory."""
+    for item in manifest.files:
+        target = destination.joinpath(*PurePosixPath(item.path).parts)
+        if not target.is_file() or target.is_symlink():
+            raise ValueError(f"installed release payload is not a regular file: {item.path}")
+        file_stat = target.stat()
+        if file_stat.st_size != item.size:
+            raise ValueError(f"installed release size mismatch: {item.path}")
+        if sha256_file(target) != item.sha256:
+            raise ValueError(f"installed release SHA-256 mismatch: {item.path}")
+        if stat.S_IMODE(file_stat.st_mode) != item.mode:
+            raise ValueError(f"installed release mode mismatch: {item.path}")

--- a/bin/build_deployment_package.py
+++ b/bin/build_deployment_package.py
@@ -24,7 +24,7 @@ def _git(*args: str) -> str:
     return result.stdout.strip()
 
 
-def _payloads(requirements: Path, wheel: Path) -> list[PayloadSource]:
+def collect_payloads(requirements: Path, wheel: Path) -> list[PayloadSource]:
     payloads = [
         PayloadSource(source=wheel, path=f"wheel/{wheel.name}", role="wheel"),
         PayloadSource(
@@ -107,7 +107,7 @@ def main() -> None:
         flyway_version=args.flyway_version,
     )
     output = args.output_dir / f"temperature-bot-deployment-{version}-{commit[:12]}.zip"
-    build_package(output, identity, _payloads(args.requirements, wheels[0]))
+    build_package(output, identity, collect_payloads(args.requirements, wheels[0]))
     print(output)
 
 

--- a/bin/build_deployment_package.py
+++ b/bin/build_deployment_package.py
@@ -1,0 +1,115 @@
+"""Build the complete Temperature Bot deployment ZIP."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.deployment_package import PackageIdentity, PayloadSource, build_package
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _payloads(requirements: Path, wheel: Path) -> list[PayloadSource]:
+    payloads = [
+        PayloadSource(source=wheel, path=f"wheel/{wheel.name}", role="wheel"),
+        PayloadSource(
+            source=requirements,
+            path="requirements/runtime.txt",
+            role="requirements",
+        ),
+        PayloadSource(
+            source=REPO_ROOT / "bin/install_deployment_package.py",
+            path="installer/install_deployment_package.py",
+            role="installer",
+            mode=0o755,
+        ),
+        PayloadSource(
+            source=REPO_ROOT / "doc/DEPLOYMENT_PACKAGE.md",
+            path="documentation/DEPLOYMENT_PACKAGE.md",
+            role="documentation",
+        ),
+        PayloadSource(
+            source=REPO_ROOT / "VERSION", path="metadata/VERSION", role="metadata"
+        ),
+        PayloadSource(
+            source=REPO_ROOT / "pyproject.toml",
+            path="metadata/pyproject.toml",
+            role="metadata",
+        ),
+    ]
+    for migration in sorted((REPO_ROOT / "etc/flyway/sql").glob("*.sql")):
+        payloads.append(
+            PayloadSource(
+                source=migration,
+                path=f"migrations/{migration.name}",
+                role="migration",
+            )
+        )
+    for unit in sorted((REPO_ROOT / "etc/systemd").iterdir()):
+        if unit.is_file():
+            is_unit = unit.suffix in {".service", ".timer"}
+            payloads.append(
+                PayloadSource(
+                    source=unit,
+                    path=(
+                        f"systemd/{unit.name}"
+                        if is_unit
+                        else f"configuration/{unit.name}"
+                    ),
+                    role="systemd" if is_unit else "configuration",
+                )
+            )
+    return payloads
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--requirements", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, default=REPO_ROOT / "dist")
+    parser.add_argument("--flyway-version", required=True)
+    args = parser.parse_args()
+
+    project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
+        "project"
+    ]
+    version = (REPO_ROOT / "VERSION").read_text(encoding="utf-8").strip()
+    if project["version"] != version:
+        raise SystemExit(
+            f"VERSION ({version}) does not match pyproject.toml ({project['version']})"
+        )
+    wheels = sorted((REPO_ROOT / "dist").glob(f"temperature_bot-{version}-*.whl"))
+    if len(wheels) != 1:
+        raise SystemExit(f"expected one wheel for {version}, found {len(wheels)}")
+
+    commit = os.getenv("GITHUB_SHA") or _git("rev-parse", "HEAD")
+    dirty = bool(_git("status", "--porcelain"))
+    identity = PackageIdentity(
+        version=version,
+        commit=commit,
+        built_at=datetime.now(timezone.utc),
+        dirty=dirty,
+        requires_python=project["requires-python"],
+        flyway_version=args.flyway_version,
+    )
+    output = args.output_dir / f"temperature-bot-deployment-{version}-{commit[:12]}.zip"
+    build_package(output, identity, _payloads(args.requirements, wheels[0]))
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/install_deployment_package.py
+++ b/bin/install_deployment_package.py
@@ -1,0 +1,193 @@
+"""Verify and stage an immutable Temperature Bot deployment package."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+from app.deployment_package import (
+    DeploymentManifest,
+    extract_verified_package,
+    verify_extracted_payload,
+    verify_outer_checksum,
+    verify_package,
+)
+
+
+class InstallationResult(BaseModel):
+    """Machine-readable result of a verified package installation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: str
+    commit: str
+    release_directory: Path
+    activated: bool
+    systemd_units_installed: list[Path]
+
+
+def _run(*args: str) -> None:
+    subprocess.run(args, check=True)
+
+
+def _install_environment(release: Path, manifest: DeploymentManifest, uv: str, python: str) -> None:
+    environment = release / "venv"
+    interpreter = environment / "bin/python"
+    _run(uv, "venv", "--python", python, str(environment))
+    _run(
+        uv,
+        "pip",
+        "sync",
+        "--python",
+        str(interpreter),
+        "--require-hashes",
+        str(release / manifest.requirements),
+    )
+    _run(
+        uv,
+        "pip",
+        "install",
+        "--python",
+        str(interpreter),
+        "--no-deps",
+        str(release / manifest.wheel),
+    )
+    _run(
+        str(interpreter),
+        "-c",
+        (
+            "import importlib.util; from app.version import __version__; "
+            f"assert __version__ == {manifest.version!r}, __version__; "
+            "assert importlib.util.find_spec('bin.runner') is not None; "
+            "assert importlib.util.find_spec('app.deployment_package') is not None"
+        ),
+    )
+
+
+def _install_systemd_units(
+    release: Path, manifest: DeploymentManifest, systemd_dir: Path
+) -> list[Path]:
+    systemd_dir.mkdir(parents=True, exist_ok=True)
+    installed = []
+    for member in manifest.systemd_units:
+        source = release / member
+        target = systemd_dir / source.name
+        with tempfile.NamedTemporaryFile(dir=systemd_dir, delete=False) as temporary:
+            temp_path = Path(temporary.name)
+            temporary.write(source.read_bytes())
+        try:
+            temp_path.chmod(0o644)
+            os.replace(temp_path, target)
+        finally:
+            temp_path.unlink(missing_ok=True)
+        installed.append(target)
+    return installed
+
+
+def _activate(root: Path, release: Path) -> None:
+    current = root / "current"
+    if current.exists() and not current.is_symlink():
+        raise ValueError(f"refusing to replace non-symlink activation path: {current}")
+    temporary = root / f".current.{os.getpid()}"
+    temporary.unlink(missing_ok=True)
+    temporary.symlink_to(Path("releases") / release.name)
+    os.replace(temporary, current)
+
+
+def install_package(
+    package: Path,
+    root: Path,
+    *,
+    uv: str = "uv",
+    python: str = "3.12",
+    create_venv: bool = True,
+    activate: bool = False,
+    systemd_dir: Path | None = None,
+) -> InstallationResult:
+    """Stage a verified immutable release and optionally activate/install units."""
+    manifest = verify_package(package)
+    release_name = f"{manifest.version}-{manifest.commit[:12]}"
+    releases = root / "releases"
+    release = releases / release_name
+    root.mkdir(parents=True, exist_ok=True)
+    releases.mkdir(exist_ok=True)
+
+    if release.exists():
+        installed_manifest = DeploymentManifest.model_validate_json(
+            (release / "manifest.json").read_bytes()
+        )
+        if installed_manifest != manifest:
+            raise ValueError(f"installed release differs from package: {release}")
+        verify_extracted_payload(release, installed_manifest)
+    else:
+        staging = releases / f".{release_name}.staging.{os.getpid()}"
+        try:
+            extract_verified_package(package, staging)
+            if create_venv:
+                _install_environment(staging, manifest, uv, python)
+            os.replace(staging, release)
+        finally:
+            if staging.exists():
+                shutil.rmtree(staging)
+
+    installed_units = (
+        _install_systemd_units(release, manifest, systemd_dir)
+        if systemd_dir is not None
+        else []
+    )
+    if activate:
+        _activate(root, release)
+    return InstallationResult(
+        version=manifest.version,
+        commit=manifest.commit,
+        release_directory=release,
+        activated=activate,
+        systemd_units_installed=installed_units,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("package", type=Path)
+    parser.add_argument("--checksum", type=Path)
+    parser.add_argument("--require-checksum", action="store_true")
+    parser.add_argument("--verify-only", action="store_true")
+    parser.add_argument("--root", type=Path, default=Path("/opt/temperature-bot"))
+    parser.add_argument("--uv", default="uv")
+    parser.add_argument("--python", default="3.12")
+    parser.add_argument("--skip-venv", action="store_true")
+    parser.add_argument("--activate", action="store_true")
+    parser.add_argument("--systemd-dir", type=Path)
+    args = parser.parse_args()
+
+    sidecar = args.checksum or args.package.with_suffix(args.package.suffix + ".sha256")
+    if sidecar.exists():
+        verify_outer_checksum(args.package, sidecar)
+    elif args.require_checksum:
+        raise SystemExit(f"required checksum file is missing: {sidecar}")
+
+    manifest = verify_package(args.package)
+    if args.verify_only:
+        print(manifest.model_dump_json(indent=2))
+        return
+    result = install_package(
+        args.package,
+        args.root,
+        uv=args.uv,
+        python=args.python,
+        create_venv=not args.skip_venv,
+        activate=args.activate,
+        systemd_dir=args.systemd_dir,
+    )
+    print(json.dumps(result.model_dump(mode="json"), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/install_deployment_package.py
+++ b/bin/install_deployment_package.py
@@ -153,7 +153,7 @@ def install_package(
     )
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("package", type=Path)
     parser.add_argument("--checksum", type=Path)
@@ -165,7 +165,7 @@ def main() -> None:
     parser.add_argument("--skip-venv", action="store_true")
     parser.add_argument("--activate", action="store_true")
     parser.add_argument("--systemd-dir", type=Path)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     sidecar = args.checksum or args.package.with_suffix(args.package.suffix + ".sha256")
     if sidecar.exists():

--- a/doc/DEPLOYMENT_PACKAGE.md
+++ b/doc/DEPLOYMENT_PACKAGE.md
@@ -1,0 +1,182 @@
+# Deployment Package
+
+Temperature Bot deployment packages are immutable ZIP files that carry one
+tested application wheel together with the exact migrations and operating
+system integration files that belong to that revision. A host installs a
+package into a new versioned directory; it never updates the active virtual
+environment or a Git checkout in place.
+
+This document defines package format version 1. Issue #213 owns release
+publication, #214 owns immutable installation, #216 owns the complete
+database-safe activation transaction, and #225 owns the initial cron-to-systemd
+migration.
+
+## Why ZIP
+
+ZIP was selected over `.tar.gz` for this application bundle because its central
+directory makes listing members fast without decompressing the archive, and
+because standard Python can create, inspect, and validate it without another
+host dependency. Use `unzip -l PACKAGE.zip` or `python -m zipfile -l PACKAGE.zip`
+to inspect a package.
+
+ZIP CRCs detect accidental corruption but are not a cryptographic integrity or
+authenticity mechanism. The builder therefore adds:
+
+- a `manifest.json` containing the SHA-256, size, mode, and role of every
+  payload file;
+- a `PACKAGE.zip.sha256` sidecar covering the exact ZIP bytes;
+- release provenance/attestation as a publication requirement in #213.
+
+The verifier rejects duplicate names, absolute paths, `..` traversal, backslash
+paths, unlisted files, missing files, symlinks, mode mismatches, CRC failures,
+and SHA-256 mismatches. The installer writes each verified file itself and does
+not call `ZipFile.extractall()`.
+
+## Package name and layout
+
+An ephemeral pull-request build is named from the application version and
+source commit:
+
+```text
+temperature-bot-deployment-0.11.0-0123456789ab.zip
+temperature-bot-deployment-0.11.0-0123456789ab.zip.sha256
+```
+
+The ZIP has this layout:
+
+```text
+manifest.json
+wheel/temperature_bot-<version>-py3-none-any.whl
+requirements/runtime.txt
+migrations/V*.sql
+migrations/R*.sql
+configuration/temperature-bot.env.example
+systemd/temperature-bot-minute.service
+systemd/temperature-bot-minute.timer
+systemd/temperature-bot-hourly.service
+systemd/temperature-bot-hourly.timer
+systemd/temperature-bot-daily.service
+systemd/temperature-bot-daily.timer
+installer/install_deployment_package.py
+documentation/DEPLOYMENT_PACKAGE.md
+metadata/VERSION
+metadata/pyproject.toml
+```
+
+`runtime.txt` is exported from the committed `uv.lock`, without development
+dependencies or the local project, and retains distribution hashes. The
+application wheel is installed separately with `--no-deps`. This makes the
+locked third-party environment and application artifact independently visible.
+
+The migration directory is the complete Flyway history from the same commit,
+not only migrations newer than the currently deployed schema. The manifest
+records the required Flyway version, Python constraint, exact Git commit, build
+time, and whether the source tree was dirty. A future immutable release job
+must refuse dirty input; local and ephemeral PR packages retain the flag for
+diagnosis.
+
+The example environment file is configuration documentation and is never
+copied to the systemd unit directory. Systemd `.service` and `.timer` files are
+payload, not trusted instructions merely because they are in a ZIP. The
+deployment transaction verifies the package before copying units, runs
+`systemd-analyze verify`, preserves the previously installed units, and
+restores them on pre-commit rollback.
+
+## Build and inspect
+
+All project commands go through the Makefile:
+
+```bash
+make deployment-package
+make deployment-package-verify
+make deployment-package-check
+```
+
+`deployment-package` builds the wheel, exports locked runtime requirements,
+and writes the ZIP and sidecar under `dist/`. `deployment-package-verify`
+checks the whole-ZIP sidecar and every manifest entry. The stronger
+`deployment-package-check` installs the package into a disposable versioned
+root, creates a fresh virtual environment, installs the locked dependencies
+and wheel, imports the installed application version, and exercises atomic
+activation. It does not touch `/opt`, `/etc`, systemd, or a real database.
+
+## Installer contract
+
+The current installer is the safe package-verification and immutable-staging
+primitive for the future upgrade transaction:
+
+```bash
+uv run --locked python -m bin.install_deployment_package \
+  dist/temperature-bot-deployment-<version>-<commit>.zip \
+  --require-checksum \
+  --root /opt/temperature-bot
+```
+
+By default it verifies and stages
+`/opt/temperature-bot/releases/<version>-<commit>/` but does not change
+`current`, copy systemd units, migrate a database, or restart anything.
+`--activate` and `--systemd-dir` are explicit primitives used by tests and by
+the future transaction after its safety gates pass; they are not a complete
+production upgrade command.
+
+An existing trusted release environment runs the installer. First-host
+bootstrap remains an operations procedure under #44. A package may carry a
+new installer for the next transaction, but the currently trusted verifier
+must validate that package before candidate code is executed.
+
+## Upgrade transaction design
+
+The production upgrade command will compose the installer with a durable state
+machine. It must record every transition and be safely restartable.
+
+1. **Discover** — select an approved channel/version, enforce hold/pin/failed
+   release policy, and download the ZIP plus provenance with bounded size and
+   time limits.
+2. **Verify** — validate release provenance, outer SHA-256, safe ZIP structure,
+   manifest inventory, every payload SHA-256, version/tag agreement, Python,
+   Flyway, disk space, configuration, and target instance identity.
+3. **Stage** — install into a new immutable release directory and virtual
+   environment. Run package-resource and read-only application preflight checks
+   without changing the active release.
+4. **Lock** — acquire the host deployment lock. Record the active release,
+   installed unit bytes, unit enabled/active states, database identity/schema,
+   and intended rollback paths.
+5. **Quiesce** — stop writer timers first so no new jobs start. Then wait for or
+   stop their oneshot services and stop Gunicorn/other database writers. Verify
+   with systemd state and open-file/process checks that no writer remains.
+6. **Snapshot** — create a consistent SQLite snapshot with the backup API or
+   `VACUUM INTO`; never raw-copy a live WAL database. Run `PRAGMA quick_check`
+   and record size, SHA-256, Flyway schema, release, and timestamp.
+7. **Migrate** — use the candidate package's complete migration directory and
+   manifest-pinned Flyway version. Validate, migrate, validate again, and record
+   before/after schema versions.
+8. **Prepare activation** — back up installed systemd units, copy candidate
+   units atomically, run `systemd-analyze verify`, execute `daemon-reload`, and
+   atomically point `current` at the candidate.
+9. **Prove health** — start only the web candidate, then run bounded loopback
+   and public health/root/API checks. Scheduled writers remain stopped.
+10. **Commit** — after health succeeds, start the writer timers and verify their
+    schedules. Exposure plus writer resumption is the commit point.
+11. **Report** — persist structured results and email the configured
+    maintainers with release, commit, backup, migration, unit, smoke, duration,
+    and disposition evidence.
+
+Before the commit point, any failure restores the previous database snapshot,
+release symlink, systemd units, daemon state, and prior service/timer states.
+After the commit point, automatic database restoration is forbidden because it
+could discard new writes. The transaction enters maintenance/failed state,
+preserves all evidence, notifies maintainers, and requires an explicit forward
+fix or operator-approved restore.
+
+Power loss and process termination are ordinary state-machine resumptions, not
+special cases. Durable checkpoints distinguish downloaded, verified, staged,
+quiesced, snapshotted, migrated, activated, committed, rolled back, and failed
+states. Fault-injection tests under #216 must exercise every boundary.
+
+## Pull-request artifacts
+
+Every pull request builds and checks one deployment ZIP on Ubuntu, then uploads
+the ZIP and its `.sha256` sidecar as a GitHub Actions artifact. These packages
+are test evidence, not releases and not authorized for production deployment.
+They expire after five days. Stable release assets will instead be published
+and retained through the immutable GitHub Release workflow tracked by #213.

--- a/doc/systemd-scheduled-jobs.md
+++ b/doc/systemd-scheduled-jobs.md
@@ -1,0 +1,82 @@
+# Scheduled Jobs with systemd
+
+Temperature Bot's minute, hourly, and daily production jobs are defined as
+separate systemd oneshot services and timers under `etc/systemd/`. They run as
+the non-login `temperature_bot` account, share an OS lock, and log to journald.
+
+| Timer | Schedule | Command |
+|---|---|---|
+| `temperature-bot-minute.timer` | every wall-clock minute | `bin.runner` |
+| `temperature-bot-hourly.timer` | 30 seconds after each hour | `bin.runner --aqi` |
+| `temperature-bot-daily.timer` | 15 seconds after midnight | `bin.runner --daily` |
+
+The offsets retain the historical cron timing. `Persistent=true` runs one
+catch-up invocation after downtime; it does not replay every missed interval.
+The three services use `/run/temperature-bot/writer.lock` so differently named
+jobs cannot write concurrently. systemd also prevents a second instance of one
+oneshot service while it is active.
+
+## Install
+
+The deployment package owns the canonical unit bytes. Before the complete
+upgrade transaction exists, installation remains an explicit human operation:
+
+```bash
+sudo install -d -m 0750 -o root -g temperature_bot /etc/temperature-bot
+sudo install -m 0640 -o root -g temperature_bot \
+  etc/systemd/temperature-bot.env.example /etc/temperature-bot/runtime.env
+sudo install -m 0644 etc/systemd/*.service etc/systemd/*.timer \
+  /etc/systemd/system/
+sudo systemd-analyze verify \
+  /etc/systemd/system/temperature-bot-{minute,hourly,daily}.{service,timer}
+sudo systemctl daemon-reload
+sudo systemctl enable --now \
+  temperature-bot-minute.timer \
+  temperature-bot-hourly.timer \
+  temperature-bot-daily.timer
+```
+
+Review `/etc/temperature-bot/runtime.env` before enabling anything. The
+production database is `/var/db/temperature_bot/temperature-bot.db`; old
+documentation and commented crontabs may name the retired hyphenated directory.
+Do not enable the timers until the production web service and database
+ownership issues in #76 and #218 have been resolved and verified.
+
+Once a timer has completed successfully, remove the corresponding cron entry.
+Never leave both schedulers enabled.
+
+## Observe and operate
+
+```bash
+systemctl list-timers 'temperature-bot-*'
+systemctl status temperature-bot-minute.timer temperature-bot-minute.service
+journalctl -u temperature-bot-minute.service -e
+sudo systemctl start temperature-bot-minute.service
+sudo systemctl disable --now temperature-bot-minute.timer
+```
+
+Starting the service directly performs one immediate run without changing the
+timer schedule.
+
+## Deployment quiescence
+
+Stopping a timer prevents future starts but does not stop an invocation that is
+already running. Deployment therefore uses this order for every writer:
+
+1. Record whether each timer is enabled and active.
+2. Stop the minute, hourly, and daily timers.
+3. Wait a bounded time for their services to become inactive; gracefully stop
+   a remaining service and fail closed if it cannot stop.
+4. Verify all scheduled services and other database writers are inactive.
+5. Take and validate the SQLite rollback snapshot, migrate, activate, and run
+   health checks.
+6. Restore only the timers that were previously enabled/active, and only after
+   success or completed rollback.
+
+This is why the systemd migration is a deployment prerequisite: it provides an
+explicit and auditable way to prevent the next every-minute poll while the
+database is being backed up, migrated, or restored.
+
+This PR versions and tests the units but does not install them or alter the live
+host. Production rollout requires explicit authorization and live verification
+of the effective units, processes, database, timers, and old crontabs.

--- a/etc/systemd/temperature-bot-daily.service
+++ b/etc/systemd/temperature-bot-daily.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Run Temperature Bot daily database maintenance
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=temperature_bot
+Group=temperature_bot
+WorkingDirectory=/opt/temperature-bot/current
+EnvironmentFile=/etc/temperature-bot/runtime.env
+Environment=PERFORMANCE_CLIENT_ID=daily-runner
+RuntimeDirectory=temperature-bot
+RuntimeDirectoryMode=0750
+RuntimeDirectoryPreserve=yes
+UMask=0027
+ExecStart=/usr/bin/flock --exclusive --wait 50 /run/temperature-bot/writer.lock /opt/temperature-bot/current/venv/bin/python -m bin.runner --loglevel ${LOG_LEVEL} --daily
+TimeoutStartSec=30min
+TimeoutStopSec=30s
+NoNewPrivileges=yes

--- a/etc/systemd/temperature-bot-daily.timer
+++ b/etc/systemd/temperature-bot-daily.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the Temperature Bot daily maintenance job
+
+[Timer]
+OnCalendar=*-*-* 00:00:15
+AccuracySec=1s
+Persistent=true
+Unit=temperature-bot-daily.service
+
+[Install]
+WantedBy=timers.target

--- a/etc/systemd/temperature-bot-hourly.service
+++ b/etc/systemd/temperature-bot-hourly.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Fetch hourly Temperature Bot air-quality data
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=temperature_bot
+Group=temperature_bot
+WorkingDirectory=/opt/temperature-bot/current
+EnvironmentFile=/etc/temperature-bot/runtime.env
+Environment=PERFORMANCE_CLIENT_ID=hourly-runner
+RuntimeDirectory=temperature-bot
+RuntimeDirectoryMode=0750
+RuntimeDirectoryPreserve=yes
+UMask=0027
+ExecStart=/usr/bin/flock --exclusive --wait 50 /run/temperature-bot/writer.lock /opt/temperature-bot/current/venv/bin/python -m bin.runner --loglevel ${LOG_LEVEL} --aqi
+TimeoutStartSec=5min
+TimeoutStopSec=30s
+NoNewPrivileges=yes

--- a/etc/systemd/temperature-bot-hourly.timer
+++ b/etc/systemd/temperature-bot-hourly.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the Temperature Bot hourly data job
+
+[Timer]
+OnCalendar=*-*-* *:00:30
+AccuracySec=1s
+Persistent=true
+Unit=temperature-bot-hourly.service
+
+[Install]
+WantedBy=timers.target

--- a/etc/systemd/temperature-bot-minute.service
+++ b/etc/systemd/temperature-bot-minute.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Collect Temperature Bot device data and run rules
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=temperature_bot
+Group=temperature_bot
+WorkingDirectory=/opt/temperature-bot/current
+EnvironmentFile=/etc/temperature-bot/runtime.env
+Environment=PERFORMANCE_CLIENT_ID=minute-runner
+RuntimeDirectory=temperature-bot
+RuntimeDirectoryMode=0750
+RuntimeDirectoryPreserve=yes
+UMask=0027
+ExecStart=/usr/bin/flock --exclusive --wait 50 /run/temperature-bot/writer.lock /opt/temperature-bot/current/venv/bin/python -m bin.runner --loglevel ${LOG_LEVEL}
+TimeoutStartSec=5min
+TimeoutStopSec=30s
+NoNewPrivileges=yes

--- a/etc/systemd/temperature-bot-minute.timer
+++ b/etc/systemd/temperature-bot-minute.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the Temperature Bot collector every minute
+
+[Timer]
+OnCalendar=*-*-* *:*:00
+AccuracySec=1s
+Persistent=true
+Unit=temperature-bot-minute.service
+
+[Install]
+WantedBy=timers.target

--- a/etc/systemd/temperature-bot.env.example
+++ b/etc/systemd/temperature-bot.env.example
@@ -1,0 +1,5 @@
+# Install as /etc/temperature-bot/runtime.env with mode 0640.
+DB_PATH=/var/db/temperature_bot/temperature-bot.db
+TEMPERATURE_BOT_CONFIG=/etc/temperature-bot/config.yaml
+TEMPERATURE_BOT_INSTANCE=production
+LOG_LEVEL=INFO

--- a/tests/test_deployment_package.py
+++ b/tests/test_deployment_package.py
@@ -1,0 +1,160 @@
+"""Substantive deployment ZIP integrity and installation tests."""
+
+from __future__ import annotations
+
+import stat
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.deployment_package import (
+    MANIFEST_PATH,
+    PackageIdentity,
+    PayloadSource,
+    build_package,
+    extract_verified_package,
+    verify_outer_checksum,
+    verify_package,
+)
+from bin.install_deployment_package import install_package
+
+
+def _source(root: Path, relative: str, data: bytes) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return path
+
+
+def _package(tmp_path: Path) -> Path:
+    source = tmp_path / "source"
+    payloads = [
+        PayloadSource(
+            source=_source(source, "app.whl", b"wheel"),
+            path="wheel/temperature_bot-1.2.3-py3-none-any.whl",
+            role="wheel",
+        ),
+        PayloadSource(
+            source=_source(source, "runtime.txt", b"pydantic==2.0\n"),
+            path="requirements/runtime.txt",
+            role="requirements",
+        ),
+        PayloadSource(
+            source=_source(source, "V1.sql", b"SELECT 1;\n"),
+            path="migrations/V1.sql",
+            role="migration",
+        ),
+        PayloadSource(
+            source=_source(source, "minute.service", b"[Service]\nType=oneshot\n"),
+            path="systemd/minute.service",
+            role="systemd",
+        ),
+        PayloadSource(
+            source=_source(source, "runtime.env.example", b"LOG_LEVEL=INFO\n"),
+            path="configuration/runtime.env.example",
+            role="configuration",
+        ),
+        PayloadSource(
+            source=_source(source, "install.py", b"#!/usr/bin/env python3\n"),
+            path="installer/install.py",
+            role="installer",
+            mode=0o755,
+        ),
+    ]
+    package = tmp_path / "temperature-bot.zip"
+    build_package(
+        package,
+        PackageIdentity(
+            version="1.2.3",
+            commit="a" * 40,
+            built_at=datetime(2026, 8, 26, tzinfo=timezone.utc),
+            requires_python=">=3.12",
+            flyway_version="12.8.1",
+        ),
+        payloads,
+    )
+    return package
+
+
+def test_build_verify_and_safe_extract_round_trip(tmp_path):
+    package = _package(tmp_path)
+    verify_outer_checksum(package)
+    manifest = verify_package(package)
+
+    assert manifest.version == "1.2.3"
+    assert manifest.migrations == ["migrations/V1.sql"]
+    assert manifest.systemd_units == ["systemd/minute.service"]
+
+    destination = tmp_path / "extracted"
+    extract_verified_package(package, destination)
+    assert (destination / "migrations/V1.sql").read_text() == "SELECT 1;\n"
+    assert stat.S_IMODE((destination / "installer/install.py").stat().st_mode) == 0o755
+
+
+def test_installer_stages_atomically_and_activates_relative_symlink(tmp_path):
+    package = _package(tmp_path)
+    root = tmp_path / "opt/temperature-bot"
+    systemd_dir = tmp_path / "etc/systemd/system"
+
+    result = install_package(
+        package,
+        root,
+        create_venv=False,
+        activate=True,
+        systemd_dir=systemd_dir,
+    )
+
+    assert result.release_directory == root / "releases/1.2.3-aaaaaaaaaaaa"
+    assert (root / "current").readlink() == Path("releases/1.2.3-aaaaaaaaaaaa")
+    assert (systemd_dir / "minute.service").read_text() == "[Service]\nType=oneshot\n"
+    assert not (systemd_dir / "runtime.env.example").exists()
+    assert not list((root / "releases").glob("*.staging.*"))
+
+
+def test_installer_revalidates_existing_immutable_payload(tmp_path):
+    package = _package(tmp_path)
+    root = tmp_path / "opt/temperature-bot"
+    result = install_package(package, root, create_venv=False)
+    (result.release_directory / "migrations/V1.sql").write_text("SELECT 2;\n")
+
+    with pytest.raises(ValueError, match="installed release SHA-256 mismatch"):
+        install_package(package, root, create_venv=False)
+
+
+def test_verifier_rejects_payload_changed_after_manifest(tmp_path):
+    package = _package(tmp_path)
+    tampered = tmp_path / "tampered.zip"
+    with zipfile.ZipFile(package) as source, zipfile.ZipFile(tampered, "w") as target:
+        for info in source.infolist():
+            data = source.read(info.filename)
+            if info.filename.endswith("V1.sql"):
+                data = b"SELECT 2;\n"
+            target.writestr(info, data)
+
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        verify_package(tampered)
+
+
+def test_verifier_rejects_unlisted_member(tmp_path):
+    package = _package(tmp_path)
+    with zipfile.ZipFile(package, "a") as archive:
+        archive.writestr("unexpected.txt", "not in manifest")
+
+    with pytest.raises(ValueError, match="inventory mismatch"):
+        verify_package(package)
+
+
+@pytest.mark.parametrize("path", ["/absolute", "../escape", "a/../escape", r"a\b"])
+def test_payload_rejects_unsafe_member_paths(tmp_path, path):
+    source = _source(tmp_path, "payload", b"data")
+    with pytest.raises(ValidationError, match="unsafe deployment package path"):
+        PayloadSource(source=source, path=path, role="metadata")
+
+
+def test_manifest_is_first_for_fast_inspection(tmp_path):
+    package = _package(tmp_path)
+    with zipfile.ZipFile(package) as archive:
+        assert archive.namelist()[0] == MANIFEST_PATH

--- a/tests/test_deployment_package.py
+++ b/tests/test_deployment_package.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import stat
 import zipfile
 from datetime import datetime, timezone
@@ -12,6 +13,7 @@ from pydantic import ValidationError
 
 from app.deployment_package import (
     MANIFEST_PATH,
+    DeploymentManifest,
     PackageIdentity,
     PayloadSource,
     build_package,
@@ -19,7 +21,8 @@ from app.deployment_package import (
     verify_outer_checksum,
     verify_package,
 )
-from bin.install_deployment_package import install_package
+from bin.build_deployment_package import collect_payloads
+from bin.install_deployment_package import install_package, main as installer_main
 
 
 def _source(root: Path, relative: str, data: bytes) -> Path:
@@ -94,6 +97,31 @@ def test_build_verify_and_safe_extract_round_trip(tmp_path):
     assert stat.S_IMODE((destination / "installer/install.py").stat().st_mode) == 0o755
 
 
+def test_builder_collects_complete_migrations_units_and_configuration(tmp_path):
+    wheel = _source(tmp_path, "temperature_bot-1.2.3-py3-none-any.whl", b"wheel")
+    requirements = _source(tmp_path, "runtime.txt", b"pydantic==2.0\n")
+    payloads = collect_payloads(requirements, wheel)
+    paths = {payload.path for payload in payloads}
+
+    assert "configuration/temperature-bot.env.example" in paths
+    assert "documentation/DEPLOYMENT_PACKAGE.md" in paths
+    assert "installer/install_deployment_package.py" in paths
+    assert len([payload for payload in payloads if payload.role == "migration"]) == 19
+    units = [payload for payload in payloads if payload.role == "systemd"]
+    assert len(units) == 6
+    assert all(Path(payload.path).suffix in {".service", ".timer"} for payload in units)
+
+
+def test_installer_verify_only_cli_emits_valid_manifest(tmp_path, capsys):
+    package = _package(tmp_path)
+
+    installer_main([str(package), "--require-checksum", "--verify-only"])
+
+    manifest = DeploymentManifest.model_validate(json.loads(capsys.readouterr().out))
+    assert manifest.version == "1.2.3"
+    assert manifest.systemd_units == ["systemd/minute.service"]
+
+
 def test_installer_stages_atomically_and_activates_relative_symlink(tmp_path):
     package = _package(tmp_path)
     root = tmp_path / "opt/temperature-bot"
@@ -143,6 +171,8 @@ def test_verifier_rejects_unlisted_member(tmp_path):
     with zipfile.ZipFile(package, "a") as archive:
         archive.writestr("unexpected.txt", "not in manifest")
 
+    with pytest.raises(ValueError, match="outer SHA-256 mismatch"):
+        verify_outer_checksum(package)
     with pytest.raises(ValueError, match="inventory mismatch"):
         verify_package(package)
 


### PR DESCRIPTION
## Summary

- replace the checked-in cron examples with minute, hourly, and daily systemd oneshot services and timers, sharing a writer lock and an explicit deployment-quiescence procedure
- define a versioned deployment ZIP containing the wheel, hash-locked runtime requirements, complete Flyway history, systemd units, configuration example, installer, documentation, and a SHA-256 manifest/sidecar
- add safe ZIP verification, immutable release staging, disposable install checks, and explicit unit-copy/activation primitives
- build and validate a deployment ZIP for every pull request and retain the ZIP plus checksum artifact for five days
- document the future database-safe upgrade state machine, rollback boundary, and notification evidence

The repository change does not install units, edit crontabs, migrate the production database, or alter the live host. Production rollout remains an explicit follow-up under #225 after the service-account/database gates are satisfied.

## Validation

- `make check`
- `make deployment-package-check`
- `make PYTEST_ARGS=tests/test_deployment_package.py pytest` (12 passed)
- `make test` (545 Python tests passed; complete JavaScript suite passed)
- `make systemd-verify` inside Linux (Amazon Linux 2023, systemd-analyze)
- `git diff --check`
- verified the generated ZIP inventory, manifest-first layout, sidecar, clean disposable venv install, relative activation symlink, and six installed systemd unit files

Part of #225. Advances #31, #213, #214, and #216.
