### PR TITLE
Reload room dashboards every hour

### DIFF
--- a/app/templates/room_dashboard.html
+++ b/app/templates/room_dashboard.html
@@ -2,6 +2,10 @@
 {% set hide_nav = True %}
 {% block title %}{{ location }}{% endblock %}
 {% block head %}
+{# These panels are long-lived kiosk pages. A full hourly reload picks up
+   deployments and server-rendered configuration that the 10-second status
+   polling cannot update. #}
+<meta http-equiv="refresh" content="3600">
 <link rel="stylesheet" href="/static/slider.css">
 <style>
 /* CSS Variables for maintainability */

--- a/doc/agent-index.md
+++ b/doc/agent-index.md
@@ -67,6 +67,8 @@ room control tiles, and room dashboard frontend work.
 - `app/templates/room_dashboard.html`
   - Shared room dashboard Jinja template. Loops the configured control list and
     pre-renders HVAC cards, sensors, live clock, and script includes.
+  - All room button panels perform a full page reload every hour so long-lived
+    kiosk displays pick up deployments and server-rendered configuration.
 - `app/static/room_dashboard.js`
   - Room dashboard behavior: speed buttons, set temperature controls, configured
     room controls, polling, and scale-to-fit.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -533,6 +533,7 @@ def test_kitchen_route(flask_test_client):  # noqa: F811
     response = flask_test_client.get("/kitchen")
     assert response.status_code == 200
     assert b"Kitchen" in response.data or b"room_dashboard" in response.data
+    assert b'<meta http-equiv="refresh" content="3600">' in response.data
     assert b"/static/hickory_life.js" not in response.data
 
 
@@ -542,6 +543,7 @@ def test_hickory_route(flask_test_client):  # noqa: F811
     assert response.status_code == 200
     assert b'data-room-control-key="hickory"' in response.data
     assert b"Hickory" in response.data or b"room_dashboard" in response.data
+    assert b'<meta http-equiv="refresh" content="3600">' in response.data
     assert b"/static/hickory_life.js" in response.data
 
 


### PR DESCRIPTION
## Summary

- reload the shared room button panel every hour with a browser-native refresh
- apply the behavior to Hickory, Kitchen, Broadway, and canonical room dashboards
- test the Hickory and non-Hickory render contracts and document the kiosk behavior

## Validation

- `make check`
- `make test-js`
- `make pytest` (549 passed)
- `git diff --check`