### PR TITLE
Remove redundant runner inode lock

### DIFF
--- a/bin/runner.py
+++ b/bin/runner.py
@@ -1,5 +1,5 @@
 """
-Runs every minute by cron.
+Runs every minute through the production systemd timer.
  - gets temperature and writes to database
  - runs rules engine
 """
@@ -42,7 +42,6 @@ from app.models import (
 from app import rules_engine
 
 
-import lib.ctools.lock as clock
 import lib.ctools.clogging as clogging
 
 logger = logging.getLogger(__name__)
@@ -483,7 +482,6 @@ def main():
             print(res)
     else:
         # Run everything
-        clock.lock_script(abspath(__file__))
         update_from_ae200(conn)
         update_from_hubitat(conn)
         update_from_airthings(conn)

--- a/doc/Hubitat_Info.md
+++ b/doc/Hubitat_Info.md
@@ -44,8 +44,8 @@ No manual SQLite insert is required for normal temperature logging. A new
 exposed temperature sensor is created in the local `devices` table on first
 successful collection. Temperature Bot re-enumerates the Maker API
 `/devices/all` endpoint on every Hubitat scan, so a newly authorized live device
-should be picked up on the next scan. Production cron normally runs that scan
-once per minute.
+should be picked up on the next scan. The production minute timer normally runs
+that scan once per minute.
 
 Room dashboards select sensors canonically: `_canonical_room_sensors()` reads
 `devices.room_id`, so a newly logged Hubitat sensor appears on a room dashboard
@@ -94,7 +94,8 @@ dashboards may have separate tokens.
 
 ## Discovery And Collection
 
-`bin/runner.py` runs every minute in production cron. The default run path calls:
+`bin/runner.py` runs every minute through `temperature-bot-minute.timer`. The
+default run path calls:
 
 1. `update_from_ae200(conn)`
 2. `update_from_hubitat(conn)`

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -24,6 +24,8 @@ change they completed.
 - Removed unnecessary in-process and host-wide AE-200 command locks. Each
   request already uses an independent WebSocket, and Mitsubishi documents
   concurrent controller clients.
+- Removed the redundant `bin/runner.py` source-inode lock after retiring cron;
+  scheduled jobs remain mutually exclusive through the systemd writer lock.
 
 ## 0.11.0 - 2026-08-20
 

--- a/doc/hardware-landscape.md
+++ b/doc/hardware-landscape.md
@@ -34,9 +34,9 @@ independent systems that were installed for their own reasons:
                                                                   Flask web UI
 ```
 
-`bin/runner.py` runs from cron every minute, polls each system, and writes rows
-into one SQLite database. The web UI reads that database. Nothing streams; every
-number you see on a page was pulled by a poll.
+`bin/runner.py` runs from the production systemd timer every minute, polls each
+system, and writes rows into one SQLite database. The web UI reads that
+database. Nothing streams; every number you see on a page was pulled by a poll.
 
 ## Hubitat
 
@@ -279,7 +279,7 @@ switch command is not automatically safe just because the simulator is on.
 | A device appears on a Hubitat dashboard but not in our UI | Usually just not ticked in Maker API app 520. Check `/hub2/devicesList` before concluding it is absent from the hub — most Broadway devices were already meshed onto `.51` and merely unexposed. |
 | A device id from a Hubitat URL does not work in our config | Ids are per-hub. Hub Mesh gives the same device a different id on each hub, and the foreign id may name an unrelated device here. |
 | A control tile is inert and the log shows validation failures | Maker API sends `attributes` as a mapping from `/devices/all` but as a list from `/devices/<id>`. See `doc/Hubitat_Info.md`. |
-| A room dashboard tile says "No data for 2h" | Its last reading is older than the ten-minute freshness cutoff. Says nothing about the device itself — the runner, cron, or the hub may be what stopped. |
+| A room dashboard tile says "No data for 2h" | Its last reading is older than the ten-minute freshness cutoff. Says nothing about the device itself — the runner, timer, or the hub may be what stopped. |
 | A control tile says "Unavailable" | Different condition: the live Maker API read for that device just failed, so it is not exposed on hub `.51` or the hub is unreachable. |
 | A sensor logs data but appears on no room page | It has no `room_id`. Assign it in the Air Quality matrix. |
 | AE-200 values are stale or commands are slow | Compare WebSocket connection/response timing with the independent network probes; see `doc/performance-monitoring.md`. |

--- a/doc/operations-new-instance.md
+++ b/doc/operations-new-instance.md
@@ -228,15 +228,14 @@ issues real fan-speed and drive commands to the AE-200. **Only one instance may
 run it.** A second collector will fight production for control of the hardware.
 
 A developer instance — `slg1` or `deg1` — should run the web service only, with
-no runner cron entries. Rules changes are shadow-only on both and must not send
+no runner timers. Rules changes are shadow-only on both and must not send
 commands until a human approves the cutover (`doc/tech-debt.md`).
 
-If this instance genuinely is the collector, the production cron entries are
-recorded as comments in the Makefile (`Cron targets` section) and cover the
-per-minute runner, the hourly AQI fetch, and the daily compaction. The AE-200
-network probe is packaged as
-`etc/temperature-bot-performance-monitor.{service,timer}`; see
-`doc/performance-monitoring.md`. Use the timer or the cron entry, never both.
+If this instance genuinely is the collector, install and enable the versioned
+minute, hourly, and daily services and timers under `etc/systemd/`; see
+`doc/systemd-scheduled-jobs.md`. The AE-200 network probe is packaged separately
+as `etc/temperature-bot-performance-monitor.{service,timer}`; see
+`doc/performance-monitoring.md`.
 
 ### 10. Verify
 
@@ -415,8 +414,8 @@ sudo systemctl restart <instance>_basistech_net.service
 Flyway Community has no `undo`. The only rollback is the file backup taken
 before the migration.
 
-1. Stop every writer: the instance service, and the runner cron entries if this
-   instance collects.
+1. Stop every writer: the instance service and all runner timers and active
+   runner services if this instance collects.
 2. Preserve the failed database for diagnosis; do not overwrite it.
 3. Restore the complete pre-migration backup from `<DEPLOY_BACKUP_DIR>`,
    including its Flyway history.

--- a/doc/performance-monitoring.md
+++ b/doc/performance-monitoring.md
@@ -78,25 +78,15 @@ The default closed port is TCP/1 and is configurable with
 `AE200_REJECT_PORT`. Network firewalls may silently drop that port instead of
 rejecting it, so deployment must confirm the expected `refused` outcome.
 
-The probe is a separate short-lived process, intended to run once per minute:
-
-```cron
-* * * * * cd /home/air/temperature-bot && \
-  DB_PATH=/var/db/temperature_bot/temperature-bot.db \
-  TEMPERATURE_BOT_INSTANCE=production \
-  PERFORMANCE_CLIENT_ID=network-probe \
-  .venv/bin/python -m bin.performance_monitor --once \
-  >> /home/air/temperature-bot-performance.log 2>&1
-```
-
-Offsetting it by about 30 seconds is useful when comparing the probe with the
-minute collector. The process is independent of the HVAC Rules master switch.
-The checked-in `etc/temperature-bot-performance-monitor.service` and `.timer`
-run the production probe at 30 seconds past each minute. Install them in
-`/etc/systemd/system`, run `systemctl daemon-reload`, and enable the timer with
-`systemctl enable --now temperature-bot-performance-monitor.timer`. Use either
-the timer or the example cron entry, not both. A staging installation needs a
-copy or override with the staging working directory, database, and instance id.
+The probe is a separate short-lived process, independent of the HVAC Rules
+master switch. The checked-in
+`etc/temperature-bot-performance-monitor.service` and `.timer` run it at 30
+seconds past each minute so its measurements can be compared with the minute
+collector. Install them in `/etc/systemd/system`, run `systemctl daemon-reload`,
+and enable the timer with
+`systemctl enable --now temperature-bot-performance-monitor.timer`. A staging
+installation needs a copy or override with the staging working directory,
+database, and instance id.
 
 ## Storage
 

--- a/doc/sql-migrations.md
+++ b/doc/sql-migrations.md
@@ -130,9 +130,10 @@ writes through the production database.
 The current deploy target does not stop the every-minute writer. Its preflight
 snapshot is consistent, but the migration itself still needs a maintenance
 window. Until GitHub issues tracking that deploy safeguard are resolved, a
-rooms migration must be performed in a maintenance window: stop the cron
-runner, verify no runner is active, create a consistent `sqlite3 ... .backup`
-snapshot, run the migration and smoke checks, and only then restart the runner.
+rooms migration must be performed in a maintenance window: stop the runner
+timers and any active runner services, verify no runner is active, create a
+consistent `sqlite3 ... .backup` snapshot, run the migration and smoke checks,
+and only then restart the runner timers.
 
 To roll back a room migration, stop all writers again, preserve the failed
 database for diagnosis, restore the complete pre-migration SQLite backup

--- a/tests/test_bin_tools.py
+++ b/tests/test_bin_tools.py
@@ -68,27 +68,6 @@ def test_runner_module_help_has_no_runpy_warning():
     assert "RuntimeWarning" not in result.stderr
 
 
-def test_runner_default_lock_uses_runner_file(monkeypatch, temp_db):
-    """Default runner execution must not lock '-m' under `python -m bin.runner`."""
-    captured = {}
-
-    def capture_lock(lockfile=None):
-        captured["lockfile"] = lockfile
-        return 1
-
-    monkeypatch.setenv(TEST_DB_NAME, temp_db)
-    monkeypatch.setattr(sys, "argv", ["-m"])
-    monkeypatch.setattr(runner.clock, "lock_script", capture_lock)
-    monkeypatch.setattr(runner, "update_from_ae200", lambda conn: None)
-    monkeypatch.setattr(runner, "update_from_hubitat", lambda conn: None)
-    monkeypatch.setattr(runner, "update_from_airthings", lambda conn: None)
-    monkeypatch.setattr(runner.db, "get_rules_master_enabled", lambda conn: False)
-
-    runner.main()
-
-    assert captured["lockfile"] == str(Path(runner.__file__).resolve())
-
-
 @pytest.mark.parametrize("failure", ["timeout", "malformed"])
 def test_runner_alerts_continue_when_airthings_poll_fails(
     failure, monkeypatch, temp_db, caplog
@@ -126,7 +105,6 @@ def test_runner_alerts_continue_when_airthings_poll_fails(
 
     monkeypatch.setenv(TEST_DB_NAME, temp_db)
     monkeypatch.setattr(sys, "argv", ["runner"])
-    monkeypatch.setattr(runner.clock, "lock_script", lambda _path: 1)
     monkeypatch.setattr(runner, "update_from_ae200", lambda _conn: None)
     monkeypatch.setattr(runner, "update_from_hubitat", lambda _conn: None)
     monkeypatch.setattr(runner.db, "get_rules_master_enabled", lambda _conn: False)


### PR DESCRIPTION
## Summary

- remove the `bin/runner.py` source-inode lock and its obsolete lock-specific test
- retain the shared `/run/temperature-bot/writer.lock` in all three systemd runner services
- update current operations documentation from the retired cron scheduler to systemd timers

## Rationale

Production cron has been disabled. The minute, hourly, and daily systemd services already serialize database writers through one stable runtime lock path. The additional application lock was tied to the inode of `bin/runner.py`, so separate immutable releases could acquire different locks; it was redundant with systemd and did not reliably express the cross-release writer invariant. Removing it also prevents production source-inode locking from interfering with intentional local developer runs.

The systemd service lock remains the scheduler-level protection. Operators should start production work through the services rather than launching a competing ad hoc writer.

## Verification

- `make PYTEST_ARGS=tests/test_bin_tools.py pytest` (18 passed)
- `make check`
- `make test` (547 Python tests plus all JavaScript suites passed)
- audited `temperature-bot-{minute,hourly,daily}.service`: all retain `/usr/bin/flock ... /run/temperature-bot/writer.lock`

Refs #225.