### PR TITLE
Collapse screenshot galleries in PR comments

### DIFF
--- a/.github/workflows/web-ui-screenshots.yml
+++ b/.github/workflows/web-ui-screenshots.yml
@@ -191,8 +191,10 @@ jobs:
               marker,
               '## Web UI Screenshots',
               '',
-              `Generated ${manifest.pages.length} screenshots for this PR.`,
               `[Workflow run](${process.env.RUN_URL})`,
+              '',
+              '<details>',
+              `<summary>Show ${manifest.pages.length} generated screenshots</summary>`,
               '',
             ];
 
@@ -210,6 +212,7 @@ jobs:
                 ''
               );
             }
+            lines.push('</details>', '');
 
             const body = lines.join('\n');
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -27,6 +27,11 @@ change they completed.
 - Removed the redundant `bin/runner.py` source-inode lock after retiring cron;
   scheduled jobs remain mutually exclusive through the systemd writer lock.
 
+### Development workflow
+
+- Collapsed automated web UI screenshot galleries in pull-request comments so
+  reviewers can expand them only when needed.
+
 ## 0.11.0 - 2026-08-20
 
 ### Room dashboards and hardware


### PR DESCRIPTION
## Summary

- keep the Web UI Screenshots heading and workflow-run link visible
- wrap screenshot headings, routes, thumbnails, and full-image links in a collapsed GitHub `<details>` block
- show the generated screenshot count in the disclosure summary

## Verification

- workflow YAML parsed successfully
- `git diff --check`
- `make check`
- this PR's screenshot workflow will exercise the comment update end to end

Fixes #236.