### PR TITLE
Fix artifact installation and UI refresh warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,8 @@ deployment-package-verify: deployment-package ## Verify the deployment ZIP inven
 	echo "Verified $$package"
 
 deployment-package-check: deployment-package ## Install the package into a disposable immutable root
-	@package="$$(ls -1t dist/temperature-bot-deployment-*.zip | head -1)"; \
+	@set -eu; \
+	package="$$(ls -1t dist/temperature-bot-deployment-*.zip | head -1)"; \
 	install_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$install_tmp"' EXIT; \
 	$(PYTHON) -m bin.install_deployment_package \
@@ -333,6 +334,14 @@ deployment-package-check: deployment-package ## Install the package into a dispo
 	    --activate >/dev/null; \
 	test -L "$$install_tmp/opt/temperature-bot/current"; \
 	test -x "$$install_tmp/opt/temperature-bot/current/venv/bin/python"; \
+	echo "Verifying installed runner imports outside the source checkout"; \
+	DB_PATH="$$install_tmp/temperature-bot.db" \
+	TEMPERATURE_BOT_CONFIG="$(abspath tests/temperature-bot-config-test.yaml)" \
+	AE200_SIMULATOR=1 HUBITAT_SIMULATOR=1 AIRTHINGS_SIMULATOR=1 AQICN_SIMULATOR=1 \
+	"$$install_tmp/opt/temperature-bot/current/venv/bin/python" -I -c \
+	    'import bin.runner; import lib.ctools.clogging'; \
+	echo "Executing the relocated Gunicorn console script"; \
+	"$$install_tmp/opt/temperature-bot/current/venv/bin/gunicorn" --version; \
 	test -f "$$install_tmp/etc/systemd/system/temperature-bot-minute.timer"; \
 	echo "Installed and activated $$package in a disposable root"
 

--- a/app/static/unit_speed.js
+++ b/app/static/unit_speed.js
@@ -57,6 +57,7 @@ const FCU_TEMP_SOURCE_MULTIPLIER_KEY = "multiplier";
 const FCU_TEMP_SOURCE_TITLE = "FCU Temperature Sources";
 const DEVICE_DISPLAY_NAME_KEY = "display_name";
 const DEVICE_TYPE_ICONS = { ERV: "♻️", FCU: "🌀", SENSOR: "📡" };
+const FAN_CONTROL_DEVICE_TYPES = new Set(["ERV", "FCU"]);
 
 // Refresh logic
 var start = Date.now();
@@ -115,6 +116,9 @@ function clearPendingFanChange(pendingChanges, deviceId, change) {
  * @returns {string|null} The id of the radio to select, or null if undetermined.
  */
 function fanRadioIdForDevice(dev, pendingRadioId = null) {
+  if (!FAN_CONTROL_DEVICE_TYPES.has(dev.device_type)) {
+    return null;
+  }
   if (pendingRadioId) {
     return pendingRadioId;
   }

--- a/bin/install_deployment_package.py
+++ b/bin/install_deployment_package.py
@@ -40,7 +40,7 @@ def _run(*args: str) -> None:
 def _install_environment(release: Path, manifest: DeploymentManifest, uv: str, python: str) -> None:
     environment = release / "venv"
     interpreter = environment / "bin/python"
-    _run(uv, "venv", "--python", python, str(environment))
+    _run(uv, "venv", "--relocatable", "--python", python, str(environment))
     _run(
         uv,
         "pip",
@@ -59,16 +59,24 @@ def _install_environment(release: Path, manifest: DeploymentManifest, uv: str, p
         "--no-deps",
         str(release / manifest.wheel),
     )
+
+
+def _verify_environment(release: Path, manifest: DeploymentManifest) -> None:
+    environment = release / "venv"
+    interpreter = environment / "bin/python"
     _run(
         str(interpreter),
+        "-I",
         "-c",
         (
             "import importlib.util; from app.version import __version__; "
             f"assert __version__ == {manifest.version!r}, __version__; "
             "assert importlib.util.find_spec('bin.runner') is not None; "
+            "assert importlib.util.find_spec('lib.ctools.clogging') is not None; "
             "assert importlib.util.find_spec('app.deployment_package') is not None"
         ),
     )
+    _run(str(environment / "bin/gunicorn"), "--version")
 
 
 def _install_systemd_units(
@@ -136,6 +144,9 @@ def install_package(
         finally:
             if staging.exists():
                 shutil.rmtree(staging)
+
+    if create_venv:
+        _verify_environment(release, manifest)
 
     installed_units = (
         _install_systemd_units(release, manifest, systemd_dir)

--- a/doc/DEPLOYMENT_PACKAGE.md
+++ b/doc/DEPLOYMENT_PACKAGE.md
@@ -97,8 +97,12 @@ and writes the ZIP and sidecar under `dist/`. `deployment-package-verify`
 checks the whole-ZIP sidecar and every manifest entry. The stronger
 `deployment-package-check` installs the package into a disposable versioned
 root, creates a fresh virtual environment, installs the locked dependencies
-and wheel, imports the installed application version, and exercises atomic
-activation. It does not touch `/opt`, `/etc`, systemd, or a real database.
+and wheel, imports the installed web application and runner outside the source
+checkout, executes an installed console script after atomic activation, and
+checks the systemd inventory. The virtual environment is created as relocatable
+so its entry points remain valid when the staging directory is renamed to the
+immutable release directory. This requires `uv` 0.10.8 or newer. The check does
+not touch `/opt`, `/etc`, systemd, or a real database.
 
 ## Installer contract
 

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -26,6 +26,15 @@ change they completed.
   concurrent controller clients.
 - Removed the redundant `bin/runner.py` source-inode lock after retiring cron;
   scheduled jobs remain mutually exclusive through the systemd writer lock.
+- Corrected deployment packages to include the runner's `lib.ctools` dependency
+  and made staged virtual environments relocatable. Package checks now execute
+  the final-path Gunicorn script and import the installed runner in isolation.
+
+### Web interface
+
+- Stopped the status refresh from looking for fan-speed radio buttons on sensor
+  and untyped device rows, eliminating misleading console warnings while
+  preserving ERV and FCU control updates.
 
 ### Development workflow
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires = ["hatchling>=1.27,<2"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["app", "bin"]
+packages = ["app", "bin", "lib"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "etc/schema.sql" = "etc/schema.sql"

--- a/tests/test_unit_speed.js
+++ b/tests/test_unit_speed.js
@@ -225,23 +225,23 @@ function testPendingFanChangeOwnership() {
 // -- The bug: off unit holding Auto must show Off, not Auto --
 check(
   "off + held Auto (-1) -> Off",
-  fanRadioIdForDevice({ device_id: 5, drive: 0, fan_speed: -1 }),
+  fanRadioIdForDevice({ device_id: 5, device_type: "FCU", drive: 0, fan_speed: -1 }),
   "radio-5-0",
 );
 check(
   "off + held numbered speed -> Off",
-  fanRadioIdForDevice({ device_id: 5, drive: 0, fan_speed: 2 }),
+  fanRadioIdForDevice({ device_id: 5, device_type: "ERV", drive: 0, fan_speed: 2 }),
   "radio-5-0",
 );
 check(
   "drive string 'Off' + held Auto -> Off",
-  fanRadioIdForDevice({ device_id: 7, drive: "Off", fan_speed: -1 }),
+  fanRadioIdForDevice({ device_id: 7, device_type: "FCU", drive: "Off", fan_speed: -1 }),
   "radio-7-0",
 );
 check(
   "pending Off selection is not overwritten by stale High status",
   fanRadioIdForDevice(
-    { device_id: 7, drive: 1, fan_speed: 4 },
+    { device_id: 7, device_type: "FCU", drive: 1, fan_speed: 4 },
     "radio-7-0",
   ),
   "radio-7-0",
@@ -501,25 +501,35 @@ async function testEnableRulesForDevicePost() {
 // -- On states still resolve correctly --
 check(
   "on + Auto (-1) -> Auto",
-  fanRadioIdForDevice({ device_id: 5, drive: 1, fan_speed: -1 }),
+  fanRadioIdForDevice({ device_id: 5, device_type: "FCU", drive: 1, fan_speed: -1 }),
   "radio-5-auto",
 );
 check(
   "on + numbered speed -> that speed",
-  fanRadioIdForDevice({ device_id: 5, drive: 1, fan_speed: 3 }),
+  fanRadioIdForDevice({ device_id: 5, device_type: "ERV", drive: 1, fan_speed: 3 }),
   "radio-5-3",
 );
 check(
   "on + speed via legacy 'speed' field -> that speed",
-  fanRadioIdForDevice({ device_id: 9, drive: 1, speed: 4 }),
+  fanRadioIdForDevice({ device_id: 9, device_type: "FCU", drive: 1, speed: 4 }),
   "radio-9-4",
 );
 
 // -- Missing / falsy drive is treated as off --
 check(
   "no drive field -> Off",
-  fanRadioIdForDevice({ device_id: 5 }),
+  fanRadioIdForDevice({ device_id: 5, device_type: "FCU" }),
   "radio-5-0",
+);
+check(
+  "sensor rows do not resolve HVAC radio ids",
+  fanRadioIdForDevice({ device_id: 7720080, device_type: "SENSOR" }),
+  null,
+);
+check(
+  "untyped rows do not resolve HVAC radio ids",
+  fanRadioIdForDevice({ device_id: 1348015, device_type: null }),
+  null,
 );
 
 // -- AE-200 mode display --


### PR DESCRIPTION
## Summary

- build relocatable virtual environments so console-script shebangs survive staging-directory activation
- package the runner's `lib.ctools` dependency and verify the installed runner outside the source checkout
- make `deployment-package-check` fail fast and execute the final-path Gunicorn entry point
- restrict fan-radio refresh logic to ERV and FCU devices, eliminating false sensor-row console warnings
- document the corrected artifact contract and release notes

## Production evidence

Manual deployment of the prior artifact exposed both packaging failures. After final-path venv reconstruction and supplying `lib`, Gunicorn and the systemd minute runner succeeded. The deployed ERV Kitchen Off control then completed without an alert and logged `set_fcu_state(12,{'Drive': 'OFF'})`; it was restored to High.

## Verification

- `make deployment-package-check`
- `make check`
- `make test-js` (188 unit_speed tests)
- full simulator-backed `make pytest` (547 passed)
- wheel inventory contains `lib/ctools/clogging.py` and `lib/ctools/lock.py`
