### PR TITLE
Vendor logging helper and remove ctools submodule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ temperature-bot/
 │   ├── conftest.py                     # Pytest fixtures
 │   ├── helpers/                        # Test helpers
 │   └── test_*.py
-└── lib/ctools                          # External submodule, excluded from linting
+└── app/clogging.py                     # Vendored runner logging/syslog helper
 ```
 
 ## Required Workflow

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -29,8 +29,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -139,8 +137,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/web-ui-screenshots.yml
+++ b/.github/workflows/web-ui-screenshots.yml
@@ -52,8 +52,6 @@ jobs:
       - name: Checkout
         if: steps.resolve_pr.outputs.number != '' && steps.resolve_pr.outputs.same_repo == 'true'
         uses: actions/checkout@v7
-        with:
-          submodules: true
 
       - name: Set up Python
         if: steps.resolve_pr.outputs.number != '' && steps.resolve_pr.outputs.same_repo == 'true'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/ctools"]
-	path = lib/ctools
-	url = git@github.com:simsong/ctools.git

--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ check: $(REQ) dependency-check ## Run all static analysis checks
 
 dependency-check: ## Verify the uv lockfile and reject legacy dependency tooling
 	uv lock --check
-	@! git grep -n -i 'poe''try' -- ':!.beads/**' ':!lib/ctools/**' ':!doc/RELEASE_NOTES.md'
+	@! git grep -n -i 'poe''try' -- ':!.beads/**' ':!doc/RELEASE_NOTES.md'
 
 build: dependency-check ## Build the source distribution and wheel
 	uv build --no-sources
@@ -339,7 +339,7 @@ deployment-package-check: deployment-package ## Install the package into a dispo
 	TEMPERATURE_BOT_CONFIG="$(abspath tests/temperature-bot-config-test.yaml)" \
 	AE200_SIMULATOR=1 HUBITAT_SIMULATOR=1 AIRTHINGS_SIMULATOR=1 AQICN_SIMULATOR=1 \
 	"$$install_tmp/opt/temperature-bot/current/venv/bin/python" -I -c \
-	    'import bin.runner; import lib.ctools.clogging'; \
+	    'import bin.runner; import app.clogging'; \
 	echo "Executing the relocated Gunicorn console script"; \
 	"$$install_tmp/opt/temperature-bot/current/venv/bin/gunicorn" --version; \
 	test -f "$$install_tmp/etc/systemd/system/temperature-bot-minute.timer"; \

--- a/app/clogging.py
+++ b/app/clogging.py
@@ -1,0 +1,146 @@
+"""Small logging helpers used by the scheduled runner.
+
+Derived from ``ctools/clogging.py`` at commit
+7f4a3c0c251104007b63383d215f54a7cff31160. The source is a work of the
+United States government and is also dedicated worldwide under CC0 1.0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import logging
+import logging.handlers
+import os
+import socket
+from dataclasses import dataclass
+from typing import Literal
+
+DEVLOG = "/dev/log"
+DEVLOG_MAC = "/var/run/syslog"
+YEAR = str(datetime.datetime.now().year)
+SYSLOG_FORMAT = "%(filename)s:%(lineno)d (%(funcName)s) %(message)s"
+LOG_FORMAT = "%(asctime)s " + SYSLOG_FORMAT
+MAX_LENGTH = 1000
+
+
+@dataclass
+class _LoggingState:
+    added_syslog: bool = False
+    configured_logging: bool = False
+
+
+_STATE = _LoggingState()
+
+
+def add_argument(
+    parser: argparse.ArgumentParser, *, loglevel_default: str = "INFO"
+) -> None:
+    """Add the runner's logging arguments to an argument parser."""
+    parser.add_argument(
+        "--loglevel",
+        help="Set logging level",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        default=loglevel_default,
+    )
+    try:
+        parser.add_argument("--logfilename", help="output filename for logfile")
+    except argparse.ArgumentError:
+        pass
+
+
+def syslog_default_address() -> str:
+    """Return the local Unix syslog socket."""
+    if os.path.exists(DEVLOG):
+        return DEVLOG
+    if os.path.exists(DEVLOG_MAC):
+        return DEVLOG_MAC
+    raise RuntimeError(f"Neither {DEVLOG} nor {DEVLOG_MAC} are present.")
+
+
+class MaxLengthFormatter(logging.Formatter):
+    """Truncate oversized messages without mutating the shared log record."""
+
+    def __init__(
+        self,
+        fmt: str | None = None,
+        datefmt: str | None = None,
+        style: Literal["%", "{", "$"] = "%",
+        max_length: int = 100,
+    ) -> None:
+        super().__init__(fmt, datefmt, style)
+        self.max_length = max_length
+
+    def format(self, record: logging.LogRecord) -> str:
+        message = record.getMessage()
+        if len(message) <= self.max_length:
+            return super().format(record)
+        original_message = record.msg
+        original_args = record.args
+        record.msg = message[: self.max_length] + "..."
+        record.args = ()
+        try:
+            return super().format(record)
+        finally:
+            record.msg = original_message
+            record.args = original_args
+
+
+def setup_syslog(
+    facility: int = logging.handlers.SysLogHandler.LOG_LOCAL1,
+    syslog_address: str | tuple[str, int] | None = None,
+    syslog_format: str = YEAR + " " + SYSLOG_FORMAT,
+    use_tcp: bool = False,
+    max_length: int = MAX_LENGTH,
+) -> None:
+    """Install one root syslog handler."""
+    if _STATE.added_syslog:
+        return
+
+    if use_tcp:
+        address = syslog_address or ("localhost", 514)
+        socktype = socket.SOCK_STREAM
+        syslog_format += "\n"
+        append_nul = False
+    else:
+        address = syslog_address or syslog_default_address()
+        socktype = socket.SOCK_DGRAM
+        append_nul = True
+
+    handler = logging.handlers.SysLogHandler(
+        address=address, facility=facility, socktype=socktype
+    )
+    handler.append_nul = append_nul
+    handler.setFormatter(MaxLengthFormatter(syslog_format, max_length=max_length))
+    logging.getLogger().addHandler(handler)
+    _STATE.added_syslog = True
+
+
+def setup(  # pylint: disable=too-many-arguments
+    level: str | int = "INFO",
+    *,
+    syslog: bool = False,
+    syslog_address: str | tuple[str, int] | None = None,
+    filename: str | None = None,
+    facility: int = logging.handlers.SysLogHandler.LOG_LOCAL1,
+    log_format: str = LOG_FORMAT,
+    syslog_format: str = SYSLOG_FORMAT,
+) -> None:
+    """Configure root logging once and optionally add syslog output."""
+    loglevel = level if isinstance(level, int) else logging.getLevelNamesMapping()[level]
+    root = logging.getLogger()
+    if not _STATE.configured_logging:
+        if root.hasHandlers():
+            current_level = root.getEffectiveLevel()
+            if current_level == logging.NOTSET or loglevel < current_level:
+                root.setLevel(loglevel)
+        else:
+            logging.basicConfig(filename=filename, format=log_format, level=loglevel)
+        _STATE.configured_logging = True
+
+    if syslog:
+        setup_syslog(
+            facility=facility,
+            syslog_address=syslog_address,
+            syslog_format=syslog_format,
+        )

--- a/bin/cli_test.py
+++ b/bin/cli_test.py
@@ -18,8 +18,7 @@ from app.ae200 import AE200Functions
 import app.ae200 as ae200
 import app.db as db
 
-import lib.ctools.clogging as clogging
-import lib.ctools.lock as clock
+from app import clogging
 
 def setup_parser():
     import argparse

--- a/bin/install_deployment_package.py
+++ b/bin/install_deployment_package.py
@@ -72,7 +72,7 @@ def _verify_environment(release: Path, manifest: DeploymentManifest) -> None:
             "import importlib.util; from app.version import __version__; "
             f"assert __version__ == {manifest.version!r}, __version__; "
             "assert importlib.util.find_spec('bin.runner') is not None; "
-            "assert importlib.util.find_spec('lib.ctools.clogging') is not None; "
+            "assert importlib.util.find_spec('app.clogging') is not None; "
             "assert importlib.util.find_spec('app.deployment_package') is not None"
         ),
     )

--- a/bin/runner.py
+++ b/bin/runner.py
@@ -42,7 +42,7 @@ from app.models import (
 from app import rules_engine
 
 
-import lib.ctools.clogging as clogging
+from app import clogging
 
 logger = logging.getLogger(__name__)
 AIRTHINGS_READING_BATCH = TypeAdapter(list[AirthingsDeviceReading])

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -7,6 +7,9 @@ change they completed.
 
 ## Unreleased
 
+- Vendored the small runner logging helper and removed the ctools submodule and
+  unused `lock.py` import, simplifying clean checkouts and deployment packages.
+
 ### Deployment and operations
 
 - Migrated dependency management and CI from Poetry to `uv`, with pinned setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires = ["hatchling>=1.27,<2"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["app", "bin", "lib"]
+packages = ["app", "bin"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "etc/schema.sql" = "etc/schema.sql"
@@ -67,9 +67,6 @@ dev = [
     "types-pyyaml==6.0.12.20260518",
     "types-requests==2.33.0.20260712",
 ]
-
-[tool.ruff]
-exclude = ["lib/"]
 
 [tool.ruff.lint]
 ignore = ["ANN201", "ANN401"]  # Ignore missing return type annotations and Any types
@@ -119,7 +116,7 @@ root = "."
 
 
 [tool.pytest.ini_options]
-norecursedirs = [".tmp", "lib/ctools"]
+norecursedirs = [".tmp"]
 env = [
     "PYTEST=1",
     "AE200_SIMULATOR=1",

--- a/tests/test_clogging.py
+++ b/tests/test_clogging.py
@@ -1,0 +1,94 @@
+"""Tests for the vendored logging helper."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app import clogging
+
+
+def _run_python(source: str, *args: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", source, *(str(arg) for arg in args)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_add_argument_preserves_logging_cli_contract() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--logfilename")
+    clogging.add_argument(parser, loglevel_default="WARNING")
+
+    defaults = parser.parse_args([])
+    explicit = parser.parse_args(["--loglevel", "DEBUG", "--logfilename", "run.log"])
+
+    assert defaults.loglevel == "WARNING"
+    assert defaults.logfilename is None
+    assert explicit.loglevel == "DEBUG"
+    assert explicit.logfilename == "run.log"
+
+
+def test_max_length_formatter_does_not_mutate_shared_record() -> None:
+    record = logging.LogRecord("runner", logging.INFO, __file__, 1, "abcdefghijk", (), None)
+
+    assert clogging.MaxLengthFormatter("%(message)s", max_length=8).format(record) == (
+        "abcdefgh..."
+    )
+    assert record.getMessage() == "abcdefghijk"
+
+
+def test_syslog_default_address_matches_host_or_fails_clearly() -> None:
+    existing = [
+        path for path in (clogging.DEVLOG, clogging.DEVLOG_MAC) if Path(path).exists()
+    ]
+
+    if existing:
+        assert clogging.syslog_default_address() == existing[0]
+    else:
+        with pytest.raises(RuntimeError, match="Neither .+ nor .+ are present"):
+            clogging.syslog_default_address()
+
+
+def test_setup_writes_requested_log_file(tmp_path: Path) -> None:
+    logfile = tmp_path / "runner.log"
+    result = _run_python(
+        "from app import clogging; import logging, sys; "
+        "clogging.setup('INFO', filename=sys.argv[1]); "
+        "logging.getLogger('runner').info('runner ready'); logging.shutdown()",
+        logfile,
+    )
+
+    assert result.stderr == ""
+    assert "runner ready" in logfile.read_text(encoding="utf-8")
+
+
+def test_setup_syslog_uses_real_unix_socket_once() -> None:
+    with tempfile.TemporaryDirectory(prefix="tb-syslog-", dir="/tmp") as directory:
+        socket_path = Path(directory) / "socket"
+        result = _run_python(
+            "from app import clogging; import json, logging, socket, sys; "
+            "server=socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM); "
+            "server.bind(sys.argv[1]); server.settimeout(2); "
+            "root=logging.getLogger(); before=len(root.handlers); "
+            "clogging.setup_syslog(syslog_address=sys.argv[1], "
+            "syslog_format='%(message)s', max_length=8); "
+            "clogging.setup_syslog(syslog_address=sys.argv[1]); "
+            "root.warning('abcdefghijk'); payload=server.recv(1024); "
+            "print(json.dumps({'handlers': len(root.handlers)-before, "
+            "'payload': payload.decode()}))",
+            socket_path,
+        )
+        observed = json.loads(result.stdout)
+
+    assert observed["handlers"] == 1
+    assert "abcdefgh..." in observed["payload"]


### PR DESCRIPTION
## Summary

- vendor the runner's small logging/syslog helper as `app.clogging`, with pinned-source and CC0 provenance
- remove the unused `lock.py` import and the entire ctools Git submodule
- package and verify the repository-owned helper in clean wheels and deployment artifacts
- remove obsolete submodule checkout/lint/test configuration
- add substantive real-file and Unix-datagram-socket logging tests

The systemd scheduled-writer lock at `/run/temperature-bot/writer.lock` is unchanged.

Fixes #240

## Verification

- `make check`
- `make pytest` — 552 passed
- `make test-js`
- `make build-check`
- `make deployment-package-check`
- wheel inventory contains `app/clogging.py` and no `lib/ctools`
- `git diff --check`
